### PR TITLE
feat: implement real OPG/USD price feed for payment calculations

### DIFF
--- a/tee_gateway/util.py
+++ b/tee_gateway/util.py
@@ -1,13 +1,32 @@
 import datetime
+import os
 
 from tee_gateway import typing_utils
 import logging
+import requests
 import threading
 import time
 from decimal import Decimal, InvalidOperation, ROUND_CEILING
 from typing import Any
 
 logger = logging.getLogger("llm_server.dynamic_pricing")
+
+# ---------------------------------------------------------------------------
+# OPG Price Feed Configuration
+# ---------------------------------------------------------------------------
+# CoinGecko API endpoint for Base network tokens
+COINGECKO_BASE_API = "https://api.coingecko.com/api/v3/simple/token_price/base"
+# OPG token contract address on Base (from definitions.py)
+OPG_CONTRACT_ADDRESS = "0x240b09731D96979f50B2C649C9CE10FcF9C7987F"
+
+# Environment variables for price feed configuration
+# Set OPG_PRICE_FEED_URL to use a custom price feed endpoint (e.g., DEX oracle)
+# Set OPG_STATIC_PRICE_USD to use a fixed price (e.g., "0.10" for $0.10)
+OPG_PRICE_FEED_URL = os.getenv("OPG_PRICE_FEED_URL")
+OPG_STATIC_PRICE_USD = os.getenv("OPG_STATIC_PRICE_USD")
+
+# Timeout for external API calls (seconds)
+PRICE_FEED_TIMEOUT = 5
 
 
 def _deserialize(data, klass):
@@ -170,19 +189,117 @@ _token_price_cache: dict[str, Any] = {
 _token_price_lock = threading.Lock()
 
 
-def _fetch_token_a_price_usd_mock() -> Decimal:
-    """Return the USD price of the payment token used for cost calculation.
+def _fetch_price_from_coingecko() -> Decimal | None:
+    """Fetch OPG token price from CoinGecko API.
 
-    Currently returns a fixed 1:1 ratio, which is correct for USDC-denominated
-    payments (1 USDC ≈ $1 USD). For OPG-denominated payments, replace this
-    with a live price feed (e.g. a DEX oracle or CoinGecko API call) that
-    returns the current OPG/USD exchange rate so that token amounts are
-    calculated correctly against the model's USD pricing.
+    Returns the USD price of OPG on Base network, or None if unavailable.
     """
+    try:
+        url = f"{COINGECKO_BASE_API}?contract_addresses={OPG_CONTRACT_ADDRESS}&vs_currencies=usd"
+        response = requests.get(url, timeout=PRICE_FEED_TIMEOUT)
+        response.raise_for_status()
+        data = response.json()
+
+        # CoinGecko returns: {"0x...": {"usd": 0.123}}
+        price_data = data.get(OPG_CONTRACT_ADDRESS.lower(), {})
+        usd_price = price_data.get("usd")
+
+        if usd_price is not None:
+            price = Decimal(str(usd_price))
+            if price > 0:
+                logger.info("OPG price from CoinGecko: $%s", price)
+                return price
+
+        logger.warning("CoinGecko returned no price data for OPG")
+        return None
+
+    except requests.exceptions.RequestException as e:
+        logger.warning("CoinGecko API request failed: %s", e)
+        return None
+    except (KeyError, ValueError, InvalidOperation) as e:
+        logger.warning("Failed to parse CoinGecko response: %s", e)
+        return None
+
+
+def _fetch_price_from_custom_feed() -> Decimal | None:
+    """Fetch OPG price from a custom price feed URL.
+
+    The custom endpoint should return JSON with a 'price' field (USD value).
+    Example response: {"price": 0.123} or {"price": "0.123"}
+    """
+    if not OPG_PRICE_FEED_URL:
+        return None
+
+    try:
+        response = requests.get(OPG_PRICE_FEED_URL, timeout=PRICE_FEED_TIMEOUT)
+        response.raise_for_status()
+        data = response.json()
+
+        # Support both {"price": X} and {"usd": X} formats
+        raw_price = data.get("price") or data.get("usd") or data.get("value")
+        if raw_price is not None:
+            price = Decimal(str(raw_price))
+            if price > 0:
+                logger.info("OPG price from custom feed: $%s", price)
+                return price
+
+        logger.warning("Custom price feed returned no valid price")
+        return None
+
+    except requests.exceptions.RequestException as e:
+        logger.warning("Custom price feed request failed: %s", e)
+        return None
+    except (KeyError, ValueError, InvalidOperation) as e:
+        logger.warning("Failed to parse custom price feed response: %s", e)
+        return None
+
+
+def _fetch_opg_price_usd() -> Decimal:
+    """Fetch the USD price of OPG token for payment calculations.
+
+    Tries multiple price sources in order:
+    1. Custom price feed URL (if OPG_PRICE_FEED_URL is set)
+    2. CoinGecko API (for mainnet tokens)
+    3. Static price from environment (if OPG_STATIC_PRICE_USD is set)
+    4. Fallback to 1:1 ratio with warning (suitable for USDC or testing)
+
+    Returns:
+        Decimal: The OPG/USD exchange rate (always positive).
+    """
+    # 1. Try custom price feed first (highest priority for operators)
+    price = _fetch_price_from_custom_feed()
+    if price is not None:
+        return price
+
+    # 2. Try CoinGecko API
+    price = _fetch_price_from_coingecko()
+    if price is not None:
+        return price
+
+    # 3. Use static price from environment if configured
+    if OPG_STATIC_PRICE_USD:
+        try:
+            static_price = Decimal(OPG_STATIC_PRICE_USD)
+            if static_price > 0:
+                logger.info("Using static OPG price from env: $%s", static_price)
+                return static_price
+        except (ValueError, InvalidOperation):
+            logger.error("Invalid OPG_STATIC_PRICE_USD value: %s", OPG_STATIC_PRICE_USD)
+
+    # 4. Fallback to 1:1 — appropriate for USDC payments or testing
+    logger.warning(
+        "No OPG price available from any source. Using 1:1 fallback ratio. "
+        "Set OPG_STATIC_PRICE_USD or OPG_PRICE_FEED_URL for accurate pricing."
+    )
     return Decimal("1")
 
 
 def get_token_a_price_usd() -> Decimal:
+    """Get the cached USD price of the payment token.
+
+    Returns the cached price if still valid (within TTL), otherwise fetches
+    a fresh price from available sources. Thread-safe.
+    """
     now = time.time()
     with _token_price_lock:
         cached_value = _token_price_cache.get("value")
@@ -193,7 +310,7 @@ def get_token_a_price_usd() -> Decimal:
         ):
             return cached_value
 
-        value = _fetch_token_a_price_usd_mock()
+        value = _fetch_opg_price_usd()
         _token_price_cache["value"] = value
         _token_price_cache["updated_at"] = now
         return value

--- a/tests/test_price_feed.py
+++ b/tests/test_price_feed.py
@@ -1,0 +1,229 @@
+#!/usr/bin/env python3
+"""
+Unit tests for OPG token price feed functionality.
+Tests CoinGecko integration, custom price feeds, and fallback behavior.
+"""
+
+import pytest
+from decimal import Decimal
+from unittest.mock import patch, MagicMock
+import requests
+
+# Import functions under test
+from tee_gateway.util import (
+    _fetch_price_from_coingecko,
+    _fetch_price_from_custom_feed,
+    _fetch_opg_price_usd,
+    get_token_a_price_usd,
+    _token_price_cache,
+    TOKEN_A_PRICE_CACHE_TTL_SECONDS,
+)
+
+
+class TestCoinGeckoPriceFeed:
+    """Tests for CoinGecko API integration."""
+
+    def test_successful_price_fetch(self):
+        """Test successful price retrieval from CoinGecko."""
+        mock_response = MagicMock()
+        mock_response.json.return_value = {
+            "0x240b09731d96979f50b2c649c9ce10fcf9c7987f": {"usd": 0.15}
+        }
+        mock_response.raise_for_status = MagicMock()
+
+        with patch("tee_gateway.util.requests.get", return_value=mock_response):
+            price = _fetch_price_from_coingecko()
+            assert price == Decimal("0.15")
+
+    def test_no_price_data_returns_none(self):
+        """Test returns None when CoinGecko has no data for the token."""
+        mock_response = MagicMock()
+        mock_response.json.return_value = {}
+        mock_response.raise_for_status = MagicMock()
+
+        with patch("tee_gateway.util.requests.get", return_value=mock_response):
+            price = _fetch_price_from_coingecko()
+            assert price is None
+
+    def test_api_error_returns_none(self):
+        """Test returns None on API request failure."""
+        with patch(
+            "tee_gateway.util.requests.get",
+            side_effect=requests.exceptions.Timeout("Connection timeout"),
+        ):
+            price = _fetch_price_from_coingecko()
+            assert price is None
+
+    def test_invalid_json_returns_none(self):
+        """Test returns None on invalid JSON response."""
+        mock_response = MagicMock()
+        mock_response.json.side_effect = ValueError("Invalid JSON")
+        mock_response.raise_for_status = MagicMock()
+
+        with patch("tee_gateway.util.requests.get", return_value=mock_response):
+            price = _fetch_price_from_coingecko()
+            assert price is None
+
+    def test_zero_price_returns_none(self):
+        """Test returns None when price is zero (invalid)."""
+        mock_response = MagicMock()
+        mock_response.json.return_value = {
+            "0x240b09731d96979f50b2c649c9ce10fcf9c7987f": {"usd": 0}
+        }
+        mock_response.raise_for_status = MagicMock()
+
+        with patch("tee_gateway.util.requests.get", return_value=mock_response):
+            price = _fetch_price_from_coingecko()
+            assert price is None
+
+
+class TestCustomPriceFeed:
+    """Tests for custom price feed endpoint integration."""
+
+    def test_no_url_configured_returns_none(self):
+        """Test returns None when no custom URL is configured."""
+        with patch("tee_gateway.util.OPG_PRICE_FEED_URL", None):
+            price = _fetch_price_from_custom_feed()
+            assert price is None
+
+    def test_successful_price_fetch(self):
+        """Test successful price retrieval from custom endpoint."""
+        mock_response = MagicMock()
+        mock_response.json.return_value = {"price": 0.25}
+        mock_response.raise_for_status = MagicMock()
+
+        with (
+            patch("tee_gateway.util.OPG_PRICE_FEED_URL", "https://example.com/price"),
+            patch("tee_gateway.util.requests.get", return_value=mock_response),
+        ):
+            price = _fetch_price_from_custom_feed()
+            assert price == Decimal("0.25")
+
+    def test_supports_usd_key(self):
+        """Test supports 'usd' key in response."""
+        mock_response = MagicMock()
+        mock_response.json.return_value = {"usd": 0.30}
+        mock_response.raise_for_status = MagicMock()
+
+        with (
+            patch("tee_gateway.util.OPG_PRICE_FEED_URL", "https://example.com/price"),
+            patch("tee_gateway.util.requests.get", return_value=mock_response),
+        ):
+            price = _fetch_price_from_custom_feed()
+            assert price == Decimal("0.30")
+
+    def test_supports_value_key(self):
+        """Test supports 'value' key in response."""
+        mock_response = MagicMock()
+        mock_response.json.return_value = {"value": "0.35"}
+        mock_response.raise_for_status = MagicMock()
+
+        with (
+            patch("tee_gateway.util.OPG_PRICE_FEED_URL", "https://example.com/price"),
+            patch("tee_gateway.util.requests.get", return_value=mock_response),
+        ):
+            price = _fetch_price_from_custom_feed()
+            assert price == Decimal("0.35")
+
+    def test_api_error_returns_none(self):
+        """Test returns None on API request failure."""
+        with (
+            patch("tee_gateway.util.OPG_PRICE_FEED_URL", "https://example.com/price"),
+            patch(
+                "tee_gateway.util.requests.get",
+                side_effect=requests.exceptions.ConnectionError("Network error"),
+            ),
+        ):
+            price = _fetch_price_from_custom_feed()
+            assert price is None
+
+
+class TestOPGPriceFeed:
+    """Tests for the main _fetch_opg_price_usd function."""
+
+    def test_custom_feed_takes_priority(self):
+        """Test custom price feed is tried first."""
+        with (
+            patch(
+                "tee_gateway.util._fetch_price_from_custom_feed",
+                return_value=Decimal("0.20"),
+            ),
+            patch(
+                "tee_gateway.util._fetch_price_from_coingecko",
+                return_value=Decimal("0.15"),
+            ),
+        ):
+            price = _fetch_opg_price_usd()
+            assert price == Decimal("0.20")
+
+    def test_coingecko_used_when_custom_fails(self):
+        """Test CoinGecko is used when custom feed returns None."""
+        with (
+            patch("tee_gateway.util._fetch_price_from_custom_feed", return_value=None),
+            patch(
+                "tee_gateway.util._fetch_price_from_coingecko",
+                return_value=Decimal("0.15"),
+            ),
+        ):
+            price = _fetch_opg_price_usd()
+            assert price == Decimal("0.15")
+
+    def test_static_price_used_when_apis_fail(self):
+        """Test static price from env is used when APIs fail."""
+        with (
+            patch("tee_gateway.util._fetch_price_from_custom_feed", return_value=None),
+            patch("tee_gateway.util._fetch_price_from_coingecko", return_value=None),
+            patch("tee_gateway.util.OPG_STATIC_PRICE_USD", "0.10"),
+        ):
+            price = _fetch_opg_price_usd()
+            assert price == Decimal("0.10")
+
+    def test_fallback_to_one_when_all_fail(self):
+        """Test falls back to 1:1 when all sources fail."""
+        with (
+            patch("tee_gateway.util._fetch_price_from_custom_feed", return_value=None),
+            patch("tee_gateway.util._fetch_price_from_coingecko", return_value=None),
+            patch("tee_gateway.util.OPG_STATIC_PRICE_USD", None),
+        ):
+            price = _fetch_opg_price_usd()
+            assert price == Decimal("1")
+
+    def test_invalid_static_price_falls_back(self):
+        """Test invalid static price falls back to 1:1."""
+        with (
+            patch("tee_gateway.util._fetch_price_from_custom_feed", return_value=None),
+            patch("tee_gateway.util._fetch_price_from_coingecko", return_value=None),
+            patch("tee_gateway.util.OPG_STATIC_PRICE_USD", "not-a-number"),
+        ):
+            price = _fetch_opg_price_usd()
+            assert price == Decimal("1")
+
+
+class TestPriceCaching:
+    """Tests for price caching behavior."""
+
+    def test_cache_returns_cached_value(self):
+        """Test cached value is returned within TTL."""
+        # Reset cache
+        _token_price_cache["value"] = Decimal("0.50")
+        _token_price_cache["updated_at"] = 9999999999.0  # Far future
+
+        with patch("tee_gateway.util.time.time", return_value=9999999999.0):
+            price = get_token_a_price_usd()
+            assert price == Decimal("0.50")
+
+    def test_cache_refresh_when_expired(self):
+        """Test cache is refreshed when TTL expired."""
+        # Set expired cache
+        _token_price_cache["value"] = Decimal("0.50")
+        _token_price_cache["updated_at"] = 0.0
+
+        with (
+            patch("tee_gateway.util.time.time", return_value=1000.0),
+            patch(
+                "tee_gateway.util._fetch_opg_price_usd", return_value=Decimal("0.75")
+            ),
+        ):
+            price = get_token_a_price_usd()
+            assert price == Decimal("0.75")
+            assert _token_price_cache["value"] == Decimal("0.75")


### PR DESCRIPTION
## Summary

Replaces the hardcoded 1:1 mock price in `_fetch_token_a_price_usd_mock()` with a real price feed implementation that fetches live OPG/USD exchange rates for accurate payment calculations.

## Changes

### New Price Feed Sources (in priority order)

1. **Custom price feed URL** - Set `OPG_PRICE_FEED_URL` env var for DEX oracles or custom endpoints
2. **CoinGecko API** - Fetches OPG token price on Base network via contract address
3. **Static fallback** - Set `OPG_STATIC_PRICE_USD` for a fixed price (useful for testnet)
4. **1:1 fallback** - Last resort with warning log (appropriate for USDC or testing)

### Configuration

| Environment Variable | Description |
|---------------------|-------------|
| `OPG_PRICE_FEED_URL` | Custom price feed endpoint URL |
| `OPG_STATIC_PRICE_USD` | Static USD price (e.g., `0.10` for $0.10) |

### Features

- Thread-safe price caching with 60-second TTL (unchanged)
- 5-second timeout for external API calls
- Comprehensive error handling and logging
- Full backward compatibility

## Testing

Added 17 new unit tests covering:
- CoinGecko API integration (success, errors, edge cases)
- Custom price feed integration
- Priority ordering of price sources
- Static fallback behavior
- Price caching behavior

All tests pass:
```
============================= 17 passed in 0.14s ==============================
```

## Closes

Closes #28
