### PR TITLE
Set UV package manager to exclude packages newer than March 2026

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,3 +54,4 @@ exclude = [".claude/worktrees"]
 [tool.uv]
 # Pre-release needed for og-test-v2-x402==0.0.11.dev5
 prerelease = "allow"
+exclude-newer = "2026-03-25T00:00:00Z"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,4 +54,4 @@ exclude = [".claude/worktrees"]
 [tool.uv]
 # Pre-release needed for og-test-v2-x402==0.0.11.dev5
 prerelease = "allow"
-exclude-newer = "2026-03-25T00:00:00Z"
+exclude-newer = "7d"


### PR DESCRIPTION
## Summary
Updated the UV package manager configuration to exclude packages released in last 7 days

## Changes
- Added `exclude-newer` constraint to `[tool.uv]` configuration in `pyproject.toml`

## Details
This configuration ensures that UV will not resolve to any packages with release dates newer than the specified timestamp. This can be useful for maintaining reproducible builds and preventing unexpected updates to newer package versions during dependency resolution.