### PR TITLE
fix: add missing gemini-3-pro-preview model listed in README but absent from registry

### DIFF
--- a/tee_gateway/model_registry.py
+++ b/tee_gateway/model_registry.py
@@ -116,6 +116,12 @@ class SupportedModel(Enum):
         input_price_usd=Decimal("0.0000005"),
         output_price_usd=Decimal("0.000003"),
     )
+    GEMINI_3_PRO_PREVIEW = ModelConfig(
+        provider="google",
+        api_name="gemini-3-pro-preview",
+        input_price_usd=Decimal("0.00000125"),
+        output_price_usd=Decimal("0.00001"),
+    )
 
     # ── xAI Grok ────────────────────────────────────────────────────────
     GROK_4 = ModelConfig(
@@ -185,6 +191,7 @@ _MODEL_LOOKUP: dict[str, SupportedModel] = {
     "gemini-2.5-pro": SupportedModel.GEMINI_2_5_PRO,
     "gemini-2.5-flash-lite": SupportedModel.GEMINI_2_5_FLASH_LITE,
     "gemini-3-flash-preview": SupportedModel.GEMINI_3_FLASH_PREVIEW,
+    "gemini-3-pro-preview": SupportedModel.GEMINI_3_PRO_PREVIEW,
     # xAI
     "grok-4": SupportedModel.GROK_4,
     "grok-4-fast": SupportedModel.GROK_4_FAST,


### PR DESCRIPTION
## Bug
The README lists `gemini-3-pro-preview` as a supported model:

> Google | gemini-2.5-flash, gemini-2.5-flash-lite, gemini-2.5-pro, 
> gemini-3-pro-preview, gemini-3-flash-preview

But the model was missing from both `SupportedModel` enum and 
`_MODEL_LOOKUP` in `model_registry.py`. Any request using 
`"model": "gemini-3-pro-preview"` would fail with: