### PR TITLE
Add exception type to error responses in chat and completion endpoints

### DIFF
--- a/tee_gateway/controllers/chat_controller.py
+++ b/tee_gateway/controllers/chat_controller.py
@@ -272,7 +272,10 @@ def _create_non_streaming_response(chat_request: CreateChatCompletionRequest):
 
     except Exception as e:
         logger.error(f"Chat completion error: {str(e)}", exc_info=True)
-        return {"error": "Request processing failed"}, 500
+        return {
+            "error": "Request processing failed",
+            "exception_type": type(e).__name__,
+        }, 500
 
 
 def _create_streaming_response(chat_request: CreateChatCompletionRequest):
@@ -598,7 +601,7 @@ def _create_streaming_response(chat_request: CreateChatCompletionRequest):
 
             except Exception as e:
                 logger.error(f"Streaming error: {str(e)}", exc_info=True)
-                yield f"data: {json.dumps({'error': 'Stream processing failed'})}\n\n"
+                yield f"data: {json.dumps({'error': 'Stream processing failed', 'exception_type': type(e).__name__})}\n\n"
 
         return Response(
             generate(),
@@ -611,7 +614,10 @@ def _create_streaming_response(chat_request: CreateChatCompletionRequest):
 
     except Exception as e:
         logger.error(f"Stream setup error: {str(e)}", exc_info=True)
-        return {"error": "Stream setup failed"}, 500
+        return {
+            "error": "Stream setup failed",
+            "exception_type": type(e).__name__,
+        }, 500
 
 
 # ---------------------------------------------------------------------------

--- a/tee_gateway/controllers/completions_controller.py
+++ b/tee_gateway/controllers/completions_controller.py
@@ -79,4 +79,7 @@ def create_completion(body):
 
     except Exception as e:
         logger.error(f"Completion error: {str(e)}", exc_info=True)
-        return {"error": "Request processing failed"}, 500
+        return {
+            "error": "Request processing failed",
+            "exception_type": type(e).__name__,
+        }, 500


### PR DESCRIPTION
## Summary
Enhanced error responses across chat and completion endpoints to include the exception type, improving debugging and error handling visibility.

## Key Changes
- **Chat Controller** (`_create_non_streaming_response`): Added `exception_type` field to non-streaming error responses
- **Chat Controller** (`_create_streaming_response`): Added `exception_type` field to streaming error responses and stream setup error responses
- **Completions Controller** (`create_completion`): Added `exception_type` field to completion error responses

## Implementation Details
- All error responses now include `exception_type: type(e).__name__` alongside the existing error message
- This change applies to three error handling paths:
  1. Non-streaming chat completions
  2. Streaming chat completions (both stream generation and setup phases)
  3. Text completions
- The exception type is extracted using Python's built-in `type(e).__name__` to provide the class name of the caught exception
- Logging behavior remains unchanged; only the response payload is enhanced