### PR TITLE
Fix: drop unsupported `temperature` field for Claude Opus 4.7

### DIFF
--- a/tee_gateway/llm_backend.py
+++ b/tee_gateway/llm_backend.py
@@ -168,10 +168,16 @@ def get_chat_model_cached(model: str, temperature: float, max_tokens: int):
         if not config.anthropic_api_key:
             raise ValueError("anthropic_api_key not set in ProviderConfig")
 
+        # Opus 4.7+ rejects `temperature` outright (HTTP 400). Pass None so
+        # langchain-anthropic strips the field from the outgoing payload.
+        anthropic_temperature: Optional[float] = (
+            effective_temp if cfg.supports_temperature else None
+        )
+
         return ChatAnthropic(
             model=api_name,
             api_key=SecretStr(config.anthropic_api_key),
-            temperature=effective_temp,
+            temperature=anthropic_temperature,
             max_tokens=max_tokens,
             timeout=ANTHROPIC_TIMEOUT,
             streaming=True,

--- a/tee_gateway/model_registry.py
+++ b/tee_gateway/model_registry.py
@@ -19,6 +19,9 @@ class ModelConfig:
     output_price_usd: Decimal  # USD per token
     force_temperature: Optional[float] = None
     thinking_budget: Optional[int] = None
+    # Anthropic deprecated `temperature` for Opus 4.7 — the API returns 400 if
+    # the field is present at all. Set False on models that reject it.
+    supports_temperature: bool = True
 
 
 @unique
@@ -135,6 +138,7 @@ class SupportedModel(Enum):
         api_name="claude-opus-4-7",
         input_price_usd=Decimal("0.000005"),
         output_price_usd=Decimal("0.000025"),
+        supports_temperature=False,
     )
 
     # ── Google Gemini ───────────────────────────────────────────────────


### PR DESCRIPTION
Opus 4.7 returns HTTP 400 ("temperature is deprecated for this model") whenever `temperature` is present, even at the default 0.0. The gateway always populated it, so every Opus 4.7 chat completion failed with a BadRequestError surfaced to callers as HTTP 500.

Adds a `supports_temperature` flag to ModelConfig (default True) and flips it off for Opus 4.7. The Anthropic backend now passes None for unsupported models, which langchain-anthropic strips from the outbound payload.
