### PR TITLE
Add support for Claude Opus 4.8 model

### DIFF
--- a/tee_gateway/model_registry.py
+++ b/tee_gateway/model_registry.py
@@ -140,6 +140,13 @@ class SupportedModel(Enum):
         output_price_usd=Decimal("0.000025"),
         supports_temperature=False,
     )
+    CLAUDE_OPUS_4_8 = ModelConfig(
+        provider="anthropic",
+        api_name="claude-opus-4-8",
+        input_price_usd=Decimal("0.000005"),
+        output_price_usd=Decimal("0.000025"),
+        supports_temperature=False,
+    )
 
     # ── Google Gemini ───────────────────────────────────────────────────
     # Note: gemini-2.5-flash, gemini-2.5-pro, and gemini-2.5-flash-lite are scheduled
@@ -293,6 +300,7 @@ _MODEL_LOOKUP: dict[str, SupportedModel] = {
     "claude-opus-4-5": SupportedModel.CLAUDE_OPUS_4_5,
     "claude-opus-4-6": SupportedModel.CLAUDE_OPUS_4_6,
     "claude-opus-4-7": SupportedModel.CLAUDE_OPUS_4_7,
+    "claude-opus-4-8": SupportedModel.CLAUDE_OPUS_4_8,
     # Google
     "gemini-2.5-flash": SupportedModel.GEMINI_2_5_FLASH,
     "gemini-2.5-pro": SupportedModel.GEMINI_2_5_PRO,

--- a/tests/test_pricing.py
+++ b/tests/test_pricing.py
@@ -104,6 +104,14 @@ class TestModelRegistry(unittest.TestCase):
         cfg = get_model_config("claude-opus-4-6")
         self.assertEqual(cfg.provider, "anthropic")
 
+    def test_claude_opus_4_8_resolves(self):
+        cfg = get_model_config("claude-opus-4-8")
+        self.assertEqual(cfg.provider, "anthropic")
+        self.assertEqual(cfg.input_price_usd, Decimal("0.000005"))
+        self.assertEqual(cfg.output_price_usd, Decimal("0.000025"))
+        # Opus 4.7+ rejects the `temperature` field (HTTP 400)
+        self.assertFalse(cfg.supports_temperature)
+
     # ── OpenAI ──────────────────────────────────────────────────────────────
 
     def test_gpt_4_1_resolves(self):


### PR DESCRIPTION
## Summary
Adds support for the Claude Opus 4.8 model to the TEE gateway's model registry and pricing configuration.

## Changes
- **Model Registry**: Added `CLAUDE_OPUS_4_8` enum entry with Anthropic provider configuration
  - Input pricing: $0.000005 per token
  - Output pricing: $0.000025 per token
  - Temperature parameter not supported (consistent with Opus 4.7+)
- **Model Mapping**: Registered "claude-opus-4-8" string identifier in the model lookup dictionary
- **Tests**: Added `test_claude_opus_4_8_resolves()` to verify model configuration resolution and pricing values

## Implementation Details
The new model follows the same configuration pattern as existing Claude Opus variants (4.5, 4.6, 4.7), with `supports_temperature=False` to match the API behavior of recent Opus versions that reject the temperature field with HTTP 400 errors.
