### PR TITLE
Add Gemini 3.5 Flash to model registry

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -113,7 +113,7 @@ Server configuration:
 Model name prefixes determine routing:
 - **OpenAI**: gpt-4.1, gpt-5, gpt-5-mini, gpt-5.2, o4-mini
 - **Anthropic**: claude-sonnet-4-0/4-5/4-6, claude-haiku-4-5, claude-opus-4-5/4-6, claude-3-7-sonnet, claude-3-5-haiku
-- **Google**: gemini-2.5-flash, gemini-2.5-flash-lite, gemini-2.5-pro, gemini-3-pro-preview, gemini-3-flash-preview
+- **Google**: gemini-2.5-flash, gemini-2.5-flash-lite, gemini-2.5-pro, gemini-3-pro-preview, gemini-3-flash-preview, gemini-3.1-pro-preview, gemini-3.1-flash-lite-preview, gemini-3.5-flash
 - **xAI**: grok-2, grok-3, grok-3-mini, grok-4, grok-4-fast, grok-4-1-fast
 - **ByteDance** (BytePlus ModelArk, OpenAI-compatible, ap-southeast): seed-1.6, seed-1.8, seed-2.0-lite
 

--- a/tee_gateway/model_registry.py
+++ b/tee_gateway/model_registry.py
@@ -193,6 +193,12 @@ class SupportedModel(Enum):
         output_price_usd=Decimal("0.0000015"),
         thinking_budget=0,
     )
+    GEMINI_3_5_FLASH = ModelConfig(
+        provider="google",
+        api_name="gemini-3.5-flash",
+        input_price_usd=Decimal("0.0000015"),
+        output_price_usd=Decimal("0.000009"),
+    )
 
     # ── xAI Grok ────────────────────────────────────────────────────────
     GROK_4 = ModelConfig(
@@ -308,6 +314,7 @@ _MODEL_LOOKUP: dict[str, SupportedModel] = {
     "gemini-3-flash-preview": SupportedModel.GEMINI_3_FLASH_PREVIEW,
     "gemini-3.1-pro-preview": SupportedModel.GEMINI_3_1_PRO_PREVIEW,
     "gemini-3.1-flash-lite-preview": SupportedModel.GEMINI_3_1_FLASH_LITE_PREVIEW,
+    "gemini-3.5-flash": SupportedModel.GEMINI_3_5_FLASH,
     # xAI
     "grok-4": SupportedModel.GROK_4,
     "grok-4-fast": SupportedModel.GROK_4_FAST,

--- a/tests/test_pricing.py
+++ b/tests/test_pricing.py
@@ -222,6 +222,12 @@ class TestModelRegistry(unittest.TestCase):
         self.assertEqual(cfg.output_price_usd, Decimal("0.0000015"))
         self.assertEqual(cfg.thinking_budget, 0)
 
+    def test_gemini_3_5_flash_resolves(self):
+        cfg = get_model_config("gemini-3.5-flash")
+        self.assertEqual(cfg.provider, "google")
+        self.assertEqual(cfg.input_price_usd, Decimal("0.0000015"))
+        self.assertEqual(cfg.output_price_usd, Decimal("0.000009"))
+
     # ── xAI Grok ────────────────────────────────────────────────────────────
 
     def test_grok_4_resolves(self):


### PR DESCRIPTION
Register gemini-3.5-flash (Google) with $1.50/$9.00 per MTok input/output pricing. Adds lookup entry, a resolution test mirroring the other Gemini models, and updates the supported-provider list in CLAUDE.md.