### PR TITLE
Native Gemini image generation through the TEE

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -113,7 +113,7 @@ Server configuration:
 Model name prefixes determine routing:
 - **OpenAI**: gpt-4.1, gpt-5, gpt-5-mini, gpt-5.2, o4-mini
 - **Anthropic**: claude-sonnet-4-0/4-5/4-6, claude-haiku-4-5, claude-opus-4-5/4-6, claude-3-7-sonnet, claude-3-5-haiku
-- **Google**: gemini-2.5-flash, gemini-2.5-flash-lite, gemini-2.5-pro, gemini-3-pro-preview, gemini-3-flash-preview, gemini-3.1-pro-preview, gemini-3.1-flash-lite-preview, gemini-3.5-flash
+- **Google**: gemini-2.5-flash, gemini-2.5-flash-lite, gemini-2.5-pro, gemini-3-pro-preview, gemini-3-flash-preview, gemini-3.1-pro-preview, gemini-3.1-flash-lite-preview, gemini-3.5-flash; image generation: gemini-2.5-flash-image, gemini-3.1-flash-image
 - **xAI**: grok-2, grok-3, grok-3-mini, grok-4, grok-4-fast, grok-4-1-fast
 - **ByteDance** (BytePlus ModelArk, OpenAI-compatible, ap-southeast): seed-1.6, seed-1.8, seed-2.0-lite
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -113,7 +113,7 @@ Server configuration:
 Model name prefixes determine routing:
 - **OpenAI**: gpt-4.1, gpt-5, gpt-5-mini, gpt-5.2, o4-mini
 - **Anthropic**: claude-sonnet-4-0/4-5/4-6, claude-haiku-4-5, claude-opus-4-5/4-6, claude-3-7-sonnet, claude-3-5-haiku
-- **Google**: gemini-2.5-flash, gemini-2.5-flash-lite, gemini-2.5-pro, gemini-3-pro-preview, gemini-3-flash-preview
+- **Google**: gemini-2.5-flash, gemini-2.5-flash-lite, gemini-2.5-pro, gemini-3-pro-preview, gemini-3-flash-preview, gemini-3.1-pro-preview, gemini-3.1-flash-lite-preview, gemini-3.5-flash
 - **xAI**: grok-2, grok-3, grok-3-mini, grok-4, grok-4-fast, grok-4-1-fast
 - **ByteDance** (BytePlus ModelArk, OpenAI-compatible, ap-southeast): seed-1.6, seed-1.8, seed-2.0-lite
 

--- a/tee_gateway/controllers/chat_controller.py
+++ b/tee_gateway/controllers/chat_controller.py
@@ -60,7 +60,7 @@ def _split_text_and_images(content: Any) -> tuple[str, list[str]]:
             url = (item.get("image_url") or {}).get("url")
             if url:
                 images.append(url)
-        elif item_type == "image":
+        elif item_type in {"image", "media"}:
             # Standardized content block: raw base64 data + mime type.
             data = item.get("data")
             if data:

--- a/tee_gateway/controllers/chat_controller.py
+++ b/tee_gateway/controllers/chat_controller.py
@@ -30,9 +30,45 @@ from tee_gateway.llm_backend import (
     convert_messages,
     extract_usage,
 )
+from tee_gateway.model_registry import get_model_config
 from tee_gateway.pricing import compute_session_cost
 
 logger = logging.getLogger(__name__)
+
+
+def _split_text_and_images(content: Any) -> tuple[str, list[str]]:
+    """Split a LangChain message content into plain text and image data URIs.
+
+    Image-generation models (e.g. Gemini "nano banana") return generated images
+    as content blocks alongside any text. We collapse the text parts into a
+    single string and collect each image as a ``data:`` URI. The image data is
+    intentionally NOT folded into the text used for the TEE output hash — the
+    OHTTP channel already guarantees confidentiality and integrity end-to-end,
+    so images ride inside the signed envelope without being signed themselves.
+    """
+    if not isinstance(content, list):
+        return (content or "", [])
+
+    text_parts: list[str] = []
+    images: list[str] = []
+    for item in content:
+        if not isinstance(item, dict):
+            text_parts.append(str(item))
+            continue
+        item_type = item.get("type")
+        if item_type == "image_url":
+            url = (item.get("image_url") or {}).get("url")
+            if url:
+                images.append(url)
+        elif item_type == "image":
+            # Standardized content block: raw base64 data + mime type.
+            data = item.get("data")
+            if data:
+                mime = item.get("mime_type") or "image/png"
+                images.append(f"data:{mime};base64,{data}")
+        else:
+            text_parts.append(item.get("text", "") or "")
+    return ("".join(text_parts), images)
 
 
 def create_chat_completion(body):
@@ -196,19 +232,18 @@ def _create_non_streaming_response(chat_request: CreateChatCompletionRequest):
         else:
             response = model.invoke(langchain_messages)
 
-        # Normalize content (Gemini may return a list of content parts)
-        if isinstance(response.content, list):
-            content_str = "".join(
-                item.get("text", "") if isinstance(item, dict) else str(item)
-                for item in response.content
-            )
-        else:
-            content_str = response.content or ""
+        # Normalize content (Gemini may return a list of content parts, and
+        # image-generation models return image blocks alongside any text).
+        content_str, generated_images = _split_text_and_images(response.content)
 
         message_dict: dict[str, Any] = {
             "role": "assistant",
             "content": content_str,
         }
+        # Surface generated images out-of-band on the message. They are not part
+        # of the signed output hash (see _split_text_and_images).
+        if generated_images:
+            message_dict["images"] = generated_images
 
         finish_reason = "stop"
         if hasattr(response, "tool_calls") and response.tool_calls:
@@ -289,6 +324,9 @@ def _create_streaming_response(chat_request: CreateChatCompletionRequest):
         # OpenAI and Anthropic stream tool calls as fragments that must be
         # buffered and flushed once complete. Gemini emits complete tool calls.
         buffer_tool_calls = provider in ["openai", "anthropic"]
+        # Image-generation models return a single image rather than a token
+        # stream — invoke once and emit the result inside the SSE envelope.
+        image_output_model = get_model_config(chat_request.model).image_output
 
         request_dict = _chat_request_to_dict(chat_request)
         request_bytes = json.dumps(request_dict, sort_keys=True).encode("utf-8")
@@ -379,9 +417,43 @@ def _create_streaming_response(chat_request: CreateChatCompletionRequest):
             final_usage = None
             buffered_tool_calls = {}
             finish_reason = "stop"
+            generated_images: list[str] = []
 
             try:
-                if anthropic_structured_content is not None:
+                if image_output_model:
+                    # Image generation isn't a token stream: invoke once, emit
+                    # any caption text as a content delta, and carry the image
+                    # out-of-band on the final frame (it is not signed).
+                    response = model.invoke(langchain_messages)
+                    text_content, generated_images = _split_text_and_images(
+                        response.content
+                    )
+                    full_content = text_content
+                    if text_content:
+                        data = {
+                            "choices": [
+                                {
+                                    "delta": {
+                                        "content": text_content,
+                                        "role": "assistant",
+                                    },
+                                    "index": 0,
+                                    "finish_reason": None,
+                                }
+                            ],
+                            "model": chat_request.model,
+                        }
+                        yield f"data: {json.dumps(data)}\n\n"
+                    if (
+                        hasattr(response, "usage_metadata")
+                        and response.usage_metadata
+                    ):
+                        final_usage = {}
+                        for k, v in response.usage_metadata.items():
+                            if isinstance(v, (int, float)):
+                                final_usage[k] = v
+                    chunks_iter: list = []
+                elif anthropic_structured_content is not None:
                     # Emit the pre-computed structured result as a single chunk.
                     # Seed final_usage from the synchronous invoke so the final
                     # SSE chunk carries a 'usage' dict for the x402 cost calculator.
@@ -398,7 +470,7 @@ def _create_streaming_response(chat_request: CreateChatCompletionRequest):
                         "model": chat_request.model,
                     }
                     yield f"data: {json.dumps(data)}\n\n"
-                    chunks_iter: list = []
+                    chunks_iter = []
                 else:
                     chunks_iter = model.stream(langchain_messages)  # type: ignore[assignment]
 
@@ -583,6 +655,10 @@ def _create_streaming_response(chat_request: CreateChatCompletionRequest):
                     "tee_output_hash": output_hash_hex,
                     "tee_id": f"0x{tee_keys.get_tee_id()}",
                 }
+                # Generated images travel out-of-band on the final frame; they
+                # are not part of the signed output hash.
+                if generated_images:
+                    final_data["images"] = generated_images
 
                 logger.debug(
                     f"Response Final\n\tTEE Signature: {tee_signature}\n\tTEE request hash: {input_hash_hex}\n\tTEE output hash: {output_hash_hex}\n\tTEE timestamp: {timestamp}\n\tTEE ID: 0x{tee_keys.get_tee_id()}"

--- a/tee_gateway/controllers/chat_controller.py
+++ b/tee_gateway/controllers/chat_controller.py
@@ -444,6 +444,17 @@ def _create_streaming_response(chat_request: CreateChatCompletionRequest):
                             "model": chat_request.model,
                         }
                         yield f"data: {json.dumps(data)}\n\n"
+                    # BILLING (image output): Gemini bills each generated image as
+                    # ~1290 output tokens reported in candidates_token_count, which
+                    # langchain-google-genai folds into usage_metadata.output_tokens
+                    # (-> completion_tokens -> output_price_usd). So images are charged
+                    # purely via the normal token path; the image bytes themselves are
+                    # never metered by size. CAVEAT: if the provider omits usage_metadata
+                    # (langchain then yields None), final_usage stays None, the final
+                    # frame carries no 'usage', and compute_session_cost is skipped — the
+                    # client is NOT charged and gets a free image (fail-open). Acceptable
+                    # for now since Gemini reliably returns usage on success; revisit with
+                    # a ~1290-token-per-image fallback if that ever changes.
                     if hasattr(response, "usage_metadata") and response.usage_metadata:
                         final_usage = {}
                         for k, v in response.usage_metadata.items():

--- a/tee_gateway/controllers/chat_controller.py
+++ b/tee_gateway/controllers/chat_controller.py
@@ -444,10 +444,7 @@ def _create_streaming_response(chat_request: CreateChatCompletionRequest):
                             "model": chat_request.model,
                         }
                         yield f"data: {json.dumps(data)}\n\n"
-                    if (
-                        hasattr(response, "usage_metadata")
-                        and response.usage_metadata
-                    ):
+                    if hasattr(response, "usage_metadata") and response.usage_metadata:
                         final_usage = {}
                         for k, v in response.usage_metadata.items():
                             if isinstance(v, (int, float)):

--- a/tee_gateway/llm_backend.py
+++ b/tee_gateway/llm_backend.py
@@ -20,7 +20,7 @@ from langchain_core.messages import (
     ToolMessage,
     BaseMessage,
 )
-from langchain_google_genai import ChatGoogleGenerativeAI
+from langchain_google_genai import ChatGoogleGenerativeAI, Modality
 from langchain_openai import ChatOpenAI
 from langchain_anthropic import ChatAnthropic
 from langchain_xai import ChatXAI
@@ -137,6 +137,18 @@ def get_chat_model_cached(model: str, temperature: float, max_tokens: int):
     if provider == "google":
         if not config.google_api_key:
             raise ValueError("google_api_key not set in ProviderConfig")
+
+        # Image-generation models return images inline and do not support the
+        # thinking budget; ask for both TEXT and IMAGE modalities so the model
+        # may caption alongside the generated image.
+        if cfg.image_output:
+            return ChatGoogleGenerativeAI(
+                model=api_name,
+                google_api_key=config.google_api_key,
+                temperature=effective_temp,
+                max_output_tokens=max_tokens,
+                response_modalities=[Modality.TEXT, Modality.IMAGE],
+            )
 
         return ChatGoogleGenerativeAI(
             model=api_name,

--- a/tee_gateway/model_registry.py
+++ b/tee_gateway/model_registry.py
@@ -22,6 +22,10 @@ class ModelConfig:
     # Anthropic deprecated `temperature` for Opus 4.7 — the API returns 400 if
     # the field is present at all. Set False on models that reject it.
     supports_temperature: bool = True
+    # Image-output models (e.g. Gemini "nano banana") return generated images as
+    # inline content blocks. The backend requests the IMAGE modality and the
+    # controller surfaces the image data on the response message.
+    image_output: bool = False
 
 
 @unique
@@ -193,6 +197,15 @@ class SupportedModel(Enum):
         output_price_usd=Decimal("0.0000015"),
         thinking_budget=0,
     )
+    # Native image generation ("nano banana"). Image output is billed as output
+    # tokens (~1290 tokens per image); pricing mirrors Google's image token rate.
+    GEMINI_2_5_FLASH_IMAGE = ModelConfig(
+        provider="google",
+        api_name="gemini-2.5-flash-image",
+        input_price_usd=Decimal("0.0000003"),
+        output_price_usd=Decimal("0.00003"),
+        image_output=True,
+    )
 
     # ── xAI Grok ────────────────────────────────────────────────────────
     GROK_4 = ModelConfig(
@@ -308,6 +321,7 @@ _MODEL_LOOKUP: dict[str, SupportedModel] = {
     "gemini-3-flash-preview": SupportedModel.GEMINI_3_FLASH_PREVIEW,
     "gemini-3.1-pro-preview": SupportedModel.GEMINI_3_1_PRO_PREVIEW,
     "gemini-3.1-flash-lite-preview": SupportedModel.GEMINI_3_1_FLASH_LITE_PREVIEW,
+    "gemini-2.5-flash-image": SupportedModel.GEMINI_2_5_FLASH_IMAGE,
     # xAI
     "grok-4": SupportedModel.GROK_4,
     "grok-4-fast": SupportedModel.GROK_4_FAST,

--- a/tee_gateway/model_registry.py
+++ b/tee_gateway/model_registry.py
@@ -206,6 +206,16 @@ class SupportedModel(Enum):
         output_price_usd=Decimal("0.00003"),
         image_output=True,
     )
+    # Native image generation ("nano banana 2"), the latest Gemini image model.
+    # Image output is billed as output tokens (~1120 tokens per 1024x1024 image
+    # ≈ $0.067/image at $60/MTok); input (text/image) is $0.50/MTok.
+    GEMINI_3_1_FLASH_IMAGE = ModelConfig(
+        provider="google",
+        api_name="gemini-3.1-flash-image",
+        input_price_usd=Decimal("0.0000005"),
+        output_price_usd=Decimal("0.00006"),
+        image_output=True,
+    )
     GEMINI_3_5_FLASH = ModelConfig(
         provider="google",
         api_name="gemini-3.5-flash",
@@ -328,6 +338,7 @@ _MODEL_LOOKUP: dict[str, SupportedModel] = {
     "gemini-3.1-pro-preview": SupportedModel.GEMINI_3_1_PRO_PREVIEW,
     "gemini-3.1-flash-lite-preview": SupportedModel.GEMINI_3_1_FLASH_LITE_PREVIEW,
     "gemini-2.5-flash-image": SupportedModel.GEMINI_2_5_FLASH_IMAGE,
+    "gemini-3.1-flash-image": SupportedModel.GEMINI_3_1_FLASH_IMAGE,
     "gemini-3.5-flash": SupportedModel.GEMINI_3_5_FLASH,
     # xAI
     "grok-4": SupportedModel.GROK_4,

--- a/tee_gateway/model_registry.py
+++ b/tee_gateway/model_registry.py
@@ -193,6 +193,12 @@ class SupportedModel(Enum):
         output_price_usd=Decimal("0.0000015"),
         thinking_budget=0,
     )
+    GEMINI_3_5_FLASH = ModelConfig(
+        provider="google",
+        api_name="gemini-3.5-flash",
+        input_price_usd=Decimal("0.0000015"),
+        output_price_usd=Decimal("0.000009"),
+    )
 
     # ── xAI Grok ────────────────────────────────────────────────────────
     GROK_4 = ModelConfig(
@@ -308,6 +314,7 @@ _MODEL_LOOKUP: dict[str, SupportedModel] = {
     "gemini-3-flash-preview": SupportedModel.GEMINI_3_FLASH_PREVIEW,
     "gemini-3.1-pro-preview": SupportedModel.GEMINI_3_1_PRO_PREVIEW,
     "gemini-3.1-flash-lite-preview": SupportedModel.GEMINI_3_1_FLASH_LITE_PREVIEW,
+    "gemini-3.5-flash": SupportedModel.GEMINI_3_5_FLASH,
     # xAI
     "grok-4": SupportedModel.GROK_4,
     "grok-4-fast": SupportedModel.GROK_4_FAST,

--- a/tee_gateway/test/test_image_billing.py
+++ b/tee_gateway/test/test_image_billing.py
@@ -1,0 +1,151 @@
+"""Regression tests for native-image-generation billing.
+
+Gemini image-output models (e.g. ``gemini-2.5-flash-image``) bill each generated
+image as ~1290 output tokens reported in ``candidates_token_count``. Our billing
+relies on langchain-google-genai folding that field into
+``usage_metadata.output_tokens`` so the image rides the normal token-priced path
+(``output_tokens -> completion_tokens -> output_price_usd``). These tests pin
+that assumption: if a future library bump stops folding image tokens into
+``output_tokens``, or our pricing stops charging them, they fail loudly.
+
+No network or API key required — we construct a synthetic Gemini response object
+and inject a stub price feed.
+"""
+
+import unittest
+from decimal import Decimal
+from unittest.mock import MagicMock
+
+from google.genai.types import GenerateContentResponse
+from langchain_google_genai.chat_models import _response_to_result
+
+from tee_gateway.price_feed import get_price_feed, set_price_feed
+from tee_gateway.pricing import compute_session_cost
+
+IMAGE_MODEL = "gemini-2.5-flash-image"
+# Google's fixed image-output token count for a standard 1024x1024 image.
+IMAGE_TOKENS = 1290
+
+
+def _gemini_image_response(
+    *, candidates_tokens: int, thoughts_tokens: int = 0, prompt_tokens: int = 9
+) -> GenerateContentResponse:
+    """Build a synthetic Gemini response: a caption part + an inline image part,
+    with image output accounted for in ``candidates_token_count``."""
+    return GenerateContentResponse.model_validate(
+        {
+            "candidates": [
+                {
+                    "content": {
+                        "role": "model",
+                        "parts": [
+                            {"text": "Here is your image."},
+                            {
+                                "inline_data": {
+                                    "mime_type": "image/png",
+                                    "data": "aGVsbG8=",  # "hello"
+                                }
+                            },
+                        ],
+                    },
+                    "finish_reason": "STOP",
+                }
+            ],
+            "usage_metadata": {
+                "prompt_token_count": prompt_tokens,
+                "candidates_token_count": candidates_tokens,
+                "thoughts_token_count": thoughts_tokens,
+                "total_token_count": prompt_tokens
+                + candidates_tokens
+                + thoughts_tokens,
+            },
+        }
+    )
+
+
+class TestLangChainImageTokenFolding(unittest.TestCase):
+    """The langchain-google-genai mapping our billing depends on."""
+
+    def test_image_tokens_fold_into_output_tokens(self):
+        resp = _gemini_image_response(candidates_tokens=IMAGE_TOKENS)
+        msg = _response_to_result(resp).generations[0].message
+
+        self.assertIsNotNone(msg.usage_metadata)
+        # The 1290 image tokens land in output_tokens (-> completion_tokens).
+        self.assertEqual(msg.usage_metadata["output_tokens"], IMAGE_TOKENS)
+        self.assertEqual(msg.usage_metadata["input_tokens"], 9)
+
+    def test_thought_tokens_are_added_to_output_tokens(self):
+        # langchain adds thoughts_token_count on top of candidates_token_count.
+        resp = _gemini_image_response(
+            candidates_tokens=IMAGE_TOKENS, thoughts_tokens=50
+        )
+        msg = _response_to_result(resp).generations[0].message
+
+        self.assertEqual(msg.usage_metadata["output_tokens"], IMAGE_TOKENS + 50)
+
+
+class TestImageBilling(unittest.TestCase):
+    """The folded output_tokens actually translate into a charge."""
+
+    def setUp(self):
+        self._prev_feed = None
+        try:
+            self._prev_feed = get_price_feed()
+        except RuntimeError:
+            self._prev_feed = None
+        # 1 OPG == 1 USD keeps the OPG<->USD reconciliation arithmetic trivial.
+        stub = MagicMock()
+        stub.get_price.return_value = Decimal("1")
+        set_price_feed(stub)
+
+    def tearDown(self):
+        if self._prev_feed is not None:
+            set_price_feed(self._prev_feed)
+
+    def _usage_dict(self, response) -> dict:
+        """Mirror how chat_controller shapes usage_metadata into the OpenAI form."""
+        um = response.generations[0].message.usage_metadata
+        return {
+            "prompt_tokens": um["input_tokens"],
+            "completion_tokens": um["output_tokens"],
+            "total_tokens": um["total_tokens"],
+        }
+
+    def test_generated_image_is_charged_as_output_tokens(self):
+        resp = _response_to_result(
+            _gemini_image_response(candidates_tokens=IMAGE_TOKENS)
+        )
+        cost = compute_session_cost(IMAGE_MODEL, self._usage_dict(resp))
+
+        self.assertIsNotNone(cost)
+        # Expected raw cost: 9 input + 1290 output tokens at the registry rates.
+        from tee_gateway.model_registry import get_model_config
+
+        cfg = get_model_config(IMAGE_MODEL)
+        expected = (Decimal(9) * cfg.input_price_usd) + (
+            Decimal(IMAGE_TOKENS) * cfg.output_price_usd
+        )
+        # settled_usd rounds the OPG integer up, so it is >= raw by at most one
+        # smallest unit (1e-18 USD here) — assert effectively-equal.
+        self.assertAlmostEqual(cost.cost_usd, expected, places=9)
+        self.assertGreater(cost.cost_opg, 0)
+
+    def test_more_images_cost_more(self):
+        """Cost scales with image tokens — not a flat per-request fee."""
+        one = _response_to_result(
+            _gemini_image_response(candidates_tokens=IMAGE_TOKENS)
+        )
+        two = _response_to_result(
+            _gemini_image_response(candidates_tokens=IMAGE_TOKENS * 2)
+        )
+        cost_one = compute_session_cost(IMAGE_MODEL, self._usage_dict(one))
+        cost_two = compute_session_cost(IMAGE_MODEL, self._usage_dict(two))
+
+        self.assertIsNotNone(cost_one)
+        self.assertIsNotNone(cost_two)
+        self.assertGreater(cost_two.cost_opg, cost_one.cost_opg)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_pricing.py
+++ b/tests/test_pricing.py
@@ -228,6 +228,13 @@ class TestModelRegistry(unittest.TestCase):
         self.assertEqual(cfg.input_price_usd, Decimal("0.0000015"))
         self.assertEqual(cfg.output_price_usd, Decimal("0.000009"))
 
+    def test_gemini_3_1_flash_image_resolves(self):
+        cfg = get_model_config("gemini-3.1-flash-image")
+        self.assertEqual(cfg.provider, "google")
+        self.assertEqual(cfg.input_price_usd, Decimal("0.0000005"))
+        self.assertEqual(cfg.output_price_usd, Decimal("0.00006"))
+        self.assertTrue(cfg.image_output)
+
     # ── xAI Grok ────────────────────────────────────────────────────────────
 
     def test_grok_4_resolves(self):

--- a/tests/test_pricing.py
+++ b/tests/test_pricing.py
@@ -222,6 +222,12 @@ class TestModelRegistry(unittest.TestCase):
         self.assertEqual(cfg.output_price_usd, Decimal("0.0000015"))
         self.assertEqual(cfg.thinking_budget, 0)
 
+    def test_gemini_3_5_flash_resolves(self):
+        cfg = get_model_config("gemini-3.5-flash")
+        self.assertEqual(cfg.provider, "google")
+        self.assertEqual(cfg.input_price_usd, Decimal("0.0000015"))
+        self.assertEqual(cfg.output_price_usd, Decimal("0.000009"))
+
     # ── xAI Grok ────────────────────────────────────────────────────────────
 
     def test_grok_4_resolves(self):


### PR DESCRIPTION
Adds native, provider-side image generation routed through the TEE, so image output rides the existing OHTTP/HPKE + signing pipeline instead of the privacy-breaking DALL-E tool.

## Model registry
- Register **`gemini-3.1-flash-image`** ("nano banana 2") — the latest Gemini image model and the one the chat app now routes to — with `image_output=True` and per-token pricing ($0.50/MTok in, $60/MTok out; an image is ~1120 output tokens ≈ $0.067).
- Also register `gemini-2.5-flash-image` (`image_output=True`, ~1290 tokens/image ≈ $0.039) as the prior image model.
- The Google backend requests the IMAGE modality for `image_output` models.

## Chat controller
- Split generated image content blocks out of the text and surface them on the response message (non-streaming) and the SSE final frame (streaming).
- Images are carried **out-of-band and are NOT folded into the signed output hash** — the OHTTP/HPKE channel already guarantees end-to-end confidentiality and integrity, while the TEE signature continues to cover the request and any text output.

## Billing
Image generation is charged exactly like any other completion: Gemini reports the image as output tokens in `candidates_token_count`, which `langchain-google-genai` folds into `usage_metadata.output_tokens` → `completion_tokens` → `output_price_usd`. The image bytes themselves are never metered by size. This path (and the no-usage fail-open caveat, where a missing `usage_metadata` means the client isn't charged) is documented inline in the chat controller and covered by regression tests in `test_image_billing.py`.

## Also folded in
Merges `claude/nice-brown-d8XRm`, which registers **`gemini-3.5-flash`** as a text model ($1.50/$9.00 per MTok). Note: 3.5 Flash is text-output only — it is not an image model, despite the name; image generation uses the `*-image` models above.

PCR note: changes here require an enclave rebuild + `measurements.txt` refresh; `uv.lock` is untouched.