### PR TITLE
Add native web search with per-search billing

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,9 @@ The gateway solves this by running inside a hardware-isolated Nitro Enclave wher
 - **Request integrity** - SHA256 hash of original request included in signed response
 - **Streaming support** - SSE streaming for chat completions
 - **Tool/function calling** - Full support for LLM tool use
+- **Native web search** - Opt-in `web_search` flag enables each provider's built-in
+  web search (OpenAI, Anthropic, Google, xAI); searches are billed per search on top
+  of token usage
 
 ## Supported Models
 
@@ -84,7 +87,22 @@ curl -X POST http://127.0.0.1:8000/v1/completions \
     "model": "claude-3.7-sonnet",
     "prompt": "Explain quantum computing in one sentence"
   }'
+
+# Native web search (set "web_search": true on any supported model)
+curl -X POST http://127.0.0.1:8000/v1/chat/completions \
+  -H "Content-Type: application/json" \
+  -d '{
+    "model": "claude-sonnet-4-5",
+    "messages": [{"role": "user", "content": "What happened in the news today?"}],
+    "web_search": true
+  }'
 ```
+
+> **Web search & billing.** When `web_search` is `true`, the gateway enables the
+> provider's built-in web search (OpenAI, Anthropic, Google, xAI). Each search is
+> billed per search on top of token usage — at the provider's list price — and the
+> charge is reflected in the dynamically-settled x402 amount. Providers without
+> native web search (e.g. ByteDance/ModelArk) ignore the flag and are not charged.
 
 ## Deployment to Nitro Enclave
 

--- a/tee_gateway/controllers/chat_controller.py
+++ b/tee_gateway/controllers/chat_controller.py
@@ -27,6 +27,8 @@ from tee_gateway.tee_manager import get_tee_keys, compute_tee_msg_hash
 from tee_gateway.llm_backend import (
     get_provider_from_model,
     get_chat_model_cached,
+    get_web_search_tool,
+    extract_web_search_count,
     convert_messages,
     extract_usage,
 )
@@ -51,6 +53,33 @@ def create_chat_completion(body):
         return _create_streaming_response(chat_request)
     else:
         return _create_non_streaming_response(chat_request)
+
+
+def _build_tools_list(chat_request: CreateChatCompletionRequest, provider: str) -> list:
+    """Build the combined tools list (user tools + native web search tool).
+
+    User-supplied function tools and the provider's built-in web search tool are
+    bound together in a single bind_tools() call. xAI configures search at
+    construction time (no tool), and providers without native web search return
+    no tool — in both cases only user tools are included.
+    """
+    tools_list: list = []
+    if chat_request.tools:
+        for tool in chat_request.tools:
+            if isinstance(tool, dict):
+                func = tool.get("function", {})
+                tools_list.append(
+                    {"type": tool.get("type", "function"), "function": func}
+                )
+            else:
+                tools_list.append(tool)
+
+    if getattr(chat_request, "web_search", False):
+        ws_tool = get_web_search_tool(provider)
+        if ws_tool is not None:
+            tools_list.append(ws_tool)
+
+    return tools_list
 
 
 def _normalize_response_format(rf) -> dict:
@@ -143,6 +172,8 @@ def _create_non_streaming_response(chat_request: CreateChatCompletionRequest):
         logger.info(f"Chat request for model: {chat_request.model}")
         logger.info(f"Number of messages: {len(chat_request.messages)}")
 
+        provider = get_provider_from_model(chat_request.model)
+
         # Serialize request for hashing (canonical, deterministic)
         request_dict = _chat_request_to_dict(chat_request)
         request_bytes = json.dumps(request_dict, sort_keys=True).encode("utf-8")
@@ -153,19 +184,12 @@ def _create_non_streaming_response(chat_request: CreateChatCompletionRequest):
             if chat_request.temperature is not None
             else 0.0,
             max_tokens=chat_request.max_tokens or 4096,
+            web_search=bool(chat_request.web_search),
         )
 
-        # Bind tools if provided
-        if chat_request.tools:
-            tools_list = []
-            for tool in chat_request.tools:
-                if isinstance(tool, dict):
-                    func = tool.get("function", {})
-                    tools_list.append(
-                        {"type": tool.get("type", "function"), "function": func}
-                    )
-                else:
-                    tools_list.append(tool)
+        # Bind user tools and/or the native web search tool if requested.
+        tools_list = _build_tools_list(chat_request, provider)
+        if tools_list:
             model = model.bind_tools(tools_list)
 
         # Bind response_format if provided (json_object or json_schema).
@@ -177,7 +201,7 @@ def _create_non_streaming_response(chat_request: CreateChatCompletionRequest):
             rf = _normalize_response_format(chat_request.response_format)
             if rf.get("type", "text") != "text":
                 rf_dict = rf
-                if get_provider_from_model(chat_request.model) != "anthropic":
+                if provider != "anthropic":
                     model = model.bind(response_format=rf_dict)
 
         langchain_messages = convert_messages(chat_request.messages)
@@ -191,7 +215,7 @@ def _create_non_streaming_response(chat_request: CreateChatCompletionRequest):
                     SystemMessage(content="Respond in JSON format.")
                 ] + langchain_messages
 
-        if rf_dict and get_provider_from_model(chat_request.model) == "anthropic":
+        if rf_dict and provider == "anthropic":
             response = _invoke_anthropic_structured(model, rf_dict, langchain_messages)
         else:
             response = model.invoke(langchain_messages)
@@ -266,7 +290,12 @@ def _create_non_streaming_response(chat_request: CreateChatCompletionRequest):
         usage = extract_usage(response)
         if usage:
             openai_response["usage"] = usage
-            cost = compute_session_cost(chat_request.model, usage)
+            web_search_count = (
+                extract_web_search_count(response) if chat_request.web_search else 0
+            )
+            cost = compute_session_cost(
+                chat_request.model, usage, web_search_count=web_search_count
+            )
             if cost is not None:
                 openai_response["opengradient"] = cost.model_dump(mode="json")
 
@@ -299,18 +328,12 @@ def _create_streaming_response(chat_request: CreateChatCompletionRequest):
             if chat_request.temperature is not None
             else 0.0,
             max_tokens=chat_request.max_tokens or 4096,
+            web_search=bool(chat_request.web_search),
         )
 
-        if chat_request.tools:
-            tools_list = []
-            for tool in chat_request.tools:
-                if isinstance(tool, dict):
-                    func = tool.get("function", {})
-                    tools_list.append(
-                        {"type": tool.get("type", "function"), "function": func}
-                    )
-                else:
-                    tools_list.append(tool)
+        # Bind user tools and/or the native web search tool if requested.
+        tools_list = _build_tools_list(chat_request, provider)
+        if tools_list:
             model = model.bind_tools(tools_list)
 
         # Bind response_format if provided (json_object or json_schema).
@@ -379,6 +402,10 @@ def _create_streaming_response(chat_request: CreateChatCompletionRequest):
             final_usage = None
             buffered_tool_calls = {}
             finish_reason = "stop"
+            # Accumulate streamed chunks so native web-search activity (content
+            # blocks, citations, grounding metadata) can be counted for billing
+            # once the stream completes.
+            merged_chunk = None
 
             try:
                 if anthropic_structured_content is not None:
@@ -403,6 +430,13 @@ def _create_streaming_response(chat_request: CreateChatCompletionRequest):
                     chunks_iter = model.stream(langchain_messages)  # type: ignore[assignment]
 
                 for chunk in chunks_iter:
+                    # Accumulate for post-stream web-search billing (cheap: merges
+                    # content/metadata deltas into a single AIMessageChunk).
+                    if chat_request.web_search:
+                        merged_chunk = (
+                            chunk if merged_chunk is None else merged_chunk + chunk
+                        )
+
                     # --- Text content ---
                     if chunk.content:
                         if isinstance(chunk.content, str):
@@ -595,7 +629,16 @@ def _create_streaming_response(chat_request: CreateChatCompletionRequest):
                         "completion_tokens": final_usage.get("output_tokens", 0),
                         "total_tokens": final_usage.get("total_tokens", 0),
                     }
-                    cost = compute_session_cost(chat_request.model, final_data["usage"])
+                    web_search_count = (
+                        extract_web_search_count(merged_chunk)
+                        if chat_request.web_search
+                        else 0
+                    )
+                    cost = compute_session_cost(
+                        chat_request.model,
+                        final_data["usage"],
+                        web_search_count=web_search_count,
+                    )
                     if cost is not None:
                         # final_data is hand-serialized to SSE via json.dumps below,
                         # which doesn't go through Flask's JSONEncoder — so do the
@@ -698,6 +741,8 @@ def _chat_request_to_dict(chat_request: CreateChatCompletionRequest) -> dict:
         )
     if chat_request.response_format:
         d["response_format"] = _normalize_response_format(chat_request.response_format)
+    if chat_request.web_search:
+        d["web_search"] = True
     return d
 
 
@@ -720,6 +765,7 @@ def _parse_chat_request(chat_request_dict: dict) -> CreateChatCompletionRequest:
         tools=chat_request_dict.get("tools"),
         tool_choice=chat_request_dict.get("tool_choice"),
         user=chat_request_dict.get("user"),
+        web_search=chat_request_dict.get("web_search", False),
     )
 
 

--- a/tee_gateway/controllers/completions_controller.py
+++ b/tee_gateway/controllers/completions_controller.py
@@ -11,7 +11,13 @@ from langchain_core.messages import HumanMessage
 from tee_gateway.models.create_completion_request import CreateCompletionRequest
 
 from tee_gateway.tee_manager import get_tee_keys, compute_tee_msg_hash
-from tee_gateway.llm_backend import get_chat_model_cached, extract_usage
+from tee_gateway.llm_backend import (
+    get_chat_model_cached,
+    get_provider_from_model,
+    get_web_search_tool,
+    extract_web_search_count,
+    extract_usage,
+)
 from tee_gateway.pricing import compute_session_cost
 
 logger = logging.getLogger(__name__)
@@ -25,6 +31,8 @@ def create_completion(body):
         return {"error": "Request must be application/json"}, 415
 
     try:
+        web_search = bool(getattr(body, "web_search", False))
+
         request_dict = {
             "model": body.model,
             "prompt": body.prompt,
@@ -36,6 +44,8 @@ def create_completion(body):
             request_dict["max_tokens"] = body.max_tokens
         if body.stop:
             request_dict["stop"] = body.stop
+        if web_search:
+            request_dict["web_search"] = True
 
         request_bytes = json.dumps(request_dict, sort_keys=True).encode("utf-8")
 
@@ -45,12 +55,28 @@ def create_completion(body):
             if body.temperature is not None
             else 0.0,
             max_tokens=body.max_tokens or 4096,
+            web_search=web_search,
         )
+
+        # Enable the provider's native web search tool where binding is required
+        # (xAI configures it at construction; unsupported providers return None).
+        if web_search:
+            ws_tool = get_web_search_tool(get_provider_from_model(body.model))
+            if ws_tool is not None:
+                model = model.bind_tools([ws_tool])
 
         messages = [HumanMessage(content=body.prompt)]
         response = model.invoke(messages)
 
-        response_content = response.content or ""
+        # Web search (OpenAI Responses API / Gemini) can return content as a list
+        # of blocks; flatten to the text the caller expects.
+        if isinstance(response.content, list):
+            response_content = "".join(
+                item.get("text", "") if isinstance(item, dict) else str(item)
+                for item in response.content
+            )
+        else:
+            response_content = response.content or ""
         usage = extract_usage(response)
 
         timestamp = int(time.time())
@@ -80,7 +106,10 @@ def create_completion(body):
             "tee_id": f"0x{tee_keys.get_tee_id()}",
         }
         if usage:
-            cost = compute_session_cost(body.model, usage)
+            web_search_count = extract_web_search_count(response) if web_search else 0
+            cost = compute_session_cost(
+                body.model, usage, web_search_count=web_search_count
+            )
             if cost is not None:
                 completion_response["opengradient"] = cost.model_dump(mode="json")
         return completion_response

--- a/tee_gateway/llm_backend.py
+++ b/tee_gateway/llm_backend.py
@@ -114,12 +114,19 @@ def get_provider_from_model(model: str) -> str:
     return cfg.provider
 
 
-@lru_cache(maxsize=32)
-def get_chat_model_cached(model: str, temperature: float, max_tokens: int):
+@lru_cache(maxsize=64)
+def get_chat_model_cached(
+    model: str, temperature: float, max_tokens: int, web_search: bool = False
+):
     """Get cached chat model instance using the injected ProviderConfig.
 
-    Models are cached by (model, temperature, max_tokens) tuple.
+    Models are cached by (model, temperature, max_tokens, web_search) tuple.
     Cache is cleared by set_provider_config() after key injection.
+
+    When ``web_search`` is True, provider-specific native web search is enabled.
+    Some providers (OpenAI, xAI) require search configuration at construction
+    time; others (Anthropic, Google) enable it by binding a tool — see
+    ``get_web_search_tool``. Providers without native web search ignore the flag.
     """
     config = _provider_config
     if config is None:
@@ -154,6 +161,15 @@ def get_chat_model_cached(model: str, temperature: float, max_tokens: int):
         if openai_http_client is None:
             raise RuntimeError("OpenAI HTTP client has not been initialized")
 
+        # OpenAI's built-in web_search tool is only available through the
+        # Responses API, so switch to it when web search is requested. The
+        # responses/v1 output format surfaces web_search_call items in the
+        # message content, which we count for billing.
+        openai_kwargs: dict[str, Any] = {}
+        if web_search:
+            openai_kwargs["use_responses_api"] = True
+            openai_kwargs["output_version"] = "responses/v1"
+
         return ChatOpenAI(
             model=api_name,
             temperature=effective_temp,
@@ -162,6 +178,7 @@ def get_chat_model_cached(model: str, temperature: float, max_tokens: int):
             api_key=SecretStr(config.openai_api_key),
             streaming=True,
             stream_usage=True,
+            **openai_kwargs,
         )  # type: ignore [call-arg]
 
     elif provider == "anthropic":
@@ -191,6 +208,12 @@ def get_chat_model_cached(model: str, temperature: float, max_tokens: int):
         if xai_http_client is None:
             raise RuntimeError("XAI HTTP client has not been initialized")
 
+        # xAI enables Live Search via the search_parameters constructor arg
+        # rather than a bound tool. "auto" lets Grok decide whether to search.
+        xai_kwargs: dict[str, Any] = {}
+        if web_search:
+            xai_kwargs["search_parameters"] = {"mode": "auto"}
+
         return ChatXAI(
             model=api_name,
             api_key=SecretStr(config.xai_api_key),
@@ -199,6 +222,7 @@ def get_chat_model_cached(model: str, temperature: float, max_tokens: int):
             http_client=xai_http_client,
             streaming=True,
             stream_usage=True,
+            **xai_kwargs,
         )
 
     elif provider == "bytedance":
@@ -325,3 +349,72 @@ def extract_usage(response) -> Optional[Dict[str, int]]:
             "total_tokens": meta.get("total_tokens", 0),
         }
     return None
+
+
+# Anthropic's server-side web search tool. The dated type string is the current
+# tool version; max_uses caps searches per request to bound cost.
+ANTHROPIC_WEB_SEARCH_TOOL: Dict[str, Any] = {
+    "type": "web_search_20250305",
+    "name": "web_search",
+    "max_uses": 5,
+}
+
+
+def get_web_search_tool(provider: str) -> Optional[Dict[str, Any]]:
+    """Return the provider-specific web search tool spec to bind, or None.
+
+    OpenAI/Anthropic/Google enable web search by binding a built-in tool.
+    xAI configures search at construction (see get_chat_model_cached) and so
+    returns None here. Providers without native web search also return None.
+    """
+    if provider == "openai":
+        return {"type": "web_search"}
+    if provider == "anthropic":
+        return dict(ANTHROPIC_WEB_SEARCH_TOOL)
+    if provider == "google":
+        return {"google_search": {}}
+    # x-ai is handled via search_parameters; bytedance has no native web search.
+    return None
+
+
+def extract_web_search_count(message) -> int:
+    """Best-effort count of billable web-search units the model performed.
+
+    Each provider reports search activity differently and bills a different
+    unit, so we count the unit that matches that provider's list price:
+
+    - OpenAI (Responses API): ``web_search_call`` content blocks (per call)
+    - Anthropic: ``server_tool_use`` web_search content blocks (per request)
+    - xAI Live Search: ``citations`` returned in additional_kwargs (per source)
+    - Google: 1 per grounded response (per grounded request)
+
+    Works on a completed AIMessage or an accumulated AIMessageChunk.
+    """
+    if message is None:
+        return 0
+
+    count = 0
+
+    content = getattr(message, "content", None)
+    if isinstance(content, list):
+        for block in content:
+            if not isinstance(block, dict):
+                continue
+            btype = block.get("type")
+            if btype == "web_search_call":
+                count += 1
+            elif btype == "server_tool_use" and block.get("name") == "web_search":
+                count += 1
+
+    # xAI returns the list of sources it grounded on as `citations`.
+    additional_kwargs = getattr(message, "additional_kwargs", None) or {}
+    citations = additional_kwargs.get("citations")
+    if citations:
+        count += len(citations)
+
+    # Google reports grounding via response_metadata; billed per grounded request.
+    response_metadata = getattr(message, "response_metadata", None) or {}
+    if response_metadata.get("grounding_metadata"):
+        count += 1
+
+    return count

--- a/tee_gateway/model_registry.py
+++ b/tee_gateway/model_registry.py
@@ -22,6 +22,26 @@ class ModelConfig:
     # Anthropic deprecated `temperature` for Opus 4.7 — the API returns 400 if
     # the field is present at all. Set False on models that reject it.
     supports_temperature: bool = True
+    # Per-search USD surcharge billed when native web search is used. ``None``
+    # means "use the provider default" (see WEB_SEARCH_PRICE_USD_BY_PROVIDER);
+    # set an explicit value here to override a single model's web-search price.
+    web_search_price_usd: Optional[Decimal] = None
+
+
+# Default per-search USD price charged when a model uses native web search.
+# The billable "unit" differs per provider (see extract_web_search_count in
+# llm_backend.py) and these mirror each provider's public list price:
+#   - OpenAI:    per web_search tool call          (~$10 / 1k calls)
+#   - Anthropic: per web_search request            ($10 / 1k searches)
+#   - xAI:       per source returned by Live Search ($25 / 1k sources)
+#   - Google:    per grounded request               ($35 / 1k requests)
+# Providers without native web search are omitted (charged nothing).
+WEB_SEARCH_PRICE_USD_BY_PROVIDER: dict[str, Decimal] = {
+    "openai": Decimal("0.01"),
+    "anthropic": Decimal("0.01"),
+    "x-ai": Decimal("0.025"),
+    "google": Decimal("0.035"),
+}
 
 
 @unique
@@ -357,3 +377,21 @@ def get_rate_card(model: str) -> dict[str, Decimal]:
     """Return {"input": ..., "output": ...} pricing for a model. Raises on unknown."""
     cfg = get_model_config(model)
     return {"input": cfg.input_price_usd, "output": cfg.output_price_usd}
+
+
+def get_web_search_price_usd(model: str) -> Decimal:
+    """Return the per-search USD surcharge for a model's native web search.
+
+    Falls back to the provider default when the model does not override it, and
+    to ``Decimal("0")`` for providers with no native web search support. Raises
+    ValueError if the model is unknown.
+    """
+    cfg = get_model_config(model)
+    if cfg.web_search_price_usd is not None:
+        return cfg.web_search_price_usd
+    return WEB_SEARCH_PRICE_USD_BY_PROVIDER.get(cfg.provider, Decimal("0"))
+
+
+def provider_supports_web_search(provider: str) -> bool:
+    """Whether the given provider has native web search the gateway can enable."""
+    return provider in WEB_SEARCH_PRICE_USD_BY_PROVIDER

--- a/tee_gateway/models/create_chat_completion_request.py
+++ b/tee_gateway/models/create_chat_completion_request.py
@@ -33,6 +33,7 @@ class CreateChatCompletionRequest:
         user=None,
         function_call=None,
         functions=None,
+        web_search=False,
     ):
         self.messages = messages
         self.model = model
@@ -64,6 +65,7 @@ class CreateChatCompletionRequest:
         self.user = user
         self.function_call = function_call
         self.functions = functions
+        self.web_search = web_search
 
     @classmethod
     def from_dict(cls, dikt) -> "CreateChatCompletionRequest":
@@ -100,5 +102,6 @@ class CreateChatCompletionRequest:
             "user",
             "function_call",
             "functions",
+            "web_search",
         }
         return cls(**{k: v for k, v in dikt.items() if k in known})

--- a/tee_gateway/models/create_completion_request.py
+++ b/tee_gateway/models/create_completion_request.py
@@ -21,6 +21,7 @@ class CreateCompletionRequest:
         temperature=1,
         top_p=1,
         user=None,
+        web_search=False,
     ):
         self.model = model
         self.prompt = prompt
@@ -40,6 +41,7 @@ class CreateCompletionRequest:
         self.temperature = temperature
         self.top_p = top_p
         self.user = user
+        self.web_search = web_search
 
     @classmethod
     def from_dict(cls, dikt) -> "CreateCompletionRequest":
@@ -64,5 +66,6 @@ class CreateCompletionRequest:
             "temperature",
             "top_p",
             "user",
+            "web_search",
         }
         return cls(**{k: v for k, v in dikt.items() if k in known})

--- a/tee_gateway/openapi/openapi.yaml
+++ b/tee_gateway/openapi/openapi.yaml
@@ -2844,6 +2844,17 @@ components:
           type: array
         model:
           $ref: "#/components/schemas/CreateChatCompletionRequest_model"
+        web_search:
+          default: false
+          description: |
+            Enable the model's native web search capability. When `true`, the
+            gateway turns on the provider's built-in web search (OpenAI, Anthropic,
+            Google, and xAI). Searches performed are billed per search on top of
+            token usage. Models whose provider has no native web search ignore
+            this flag and are not charged for it.
+          nullable: true
+          title: web_search
+          type: boolean
         store:
           default: false
           description: "Whether or not to store the output of this chat completion\
@@ -3496,6 +3507,15 @@ components:
             Echo back the prompt in addition to the completion
           nullable: true
           title: echo
+          type: boolean
+        web_search:
+          default: false
+          description: |
+            Enable the model's native web search capability. Searches performed
+            are billed per search on top of token usage. Models whose provider
+            has no native web search ignore this flag and are not charged for it.
+          nullable: true
+          title: web_search
           type: boolean
         frequency_penalty:
           default: 0

--- a/tee_gateway/pricing.py
+++ b/tee_gateway/pricing.py
@@ -17,7 +17,7 @@ from tee_gateway.definitions import (
     ASSET_DECIMALS_BY_ADDRESS,
     BASE_MAINNET_OPG_ADDRESS,
 )
-from tee_gateway.model_registry import get_model_config
+from tee_gateway.model_registry import get_model_config, get_web_search_price_usd
 
 logger = logging.getLogger("llm_server.dynamic_pricing")
 
@@ -49,7 +49,9 @@ class SessionCost(BaseModel):
         return format(value, "f")
 
 
-def compute_session_cost(model: str, usage: dict) -> SessionCost | None:
+def compute_session_cost(
+    model: str, usage: dict, web_search_count: int = 0
+) -> SessionCost | None:
     """Compute the settled cost for a completed inference request.
 
     Returns the SessionCost pydantic model, or ``None`` on failure.  Predictable
@@ -76,6 +78,16 @@ def compute_session_cost(model: str, usage: dict) -> SessionCost | None:
         raw_usd = (Decimal(in_tok) * cfg.input_price_usd) + (
             Decimal(out_tok) * cfg.output_price_usd
         )
+
+        # Native web search is billed per search unit on top of token cost.
+        searches = max(0, int(web_search_count))
+        web_search_usd = (
+            Decimal(searches) * get_web_search_price_usd(model)
+            if searches
+            else Decimal(0)
+        )
+        raw_usd += web_search_usd
+
         token_price_usd = get_price_feed().get_price()
         if token_price_usd <= 0:
             raise ValueError(f"Token price is non-positive: {token_price_usd}")
@@ -95,10 +107,13 @@ def compute_session_cost(model: str, usage: dict) -> SessionCost | None:
 
         logger.info(
             "DYNAMIC_SESSION_COST model=%s input_tokens=%d output_tokens=%d "
-            "raw_usd=%s settled_usd=%s token_price_usd=%s decimals=%d cost=%d",
+            "web_searches=%d web_search_usd=%s raw_usd=%s settled_usd=%s "
+            "token_price_usd=%s decimals=%d cost=%d",
             model,
             in_tok,
             out_tok,
+            searches,
+            str(web_search_usd),
             str(raw_usd),
             str(settled_usd),
             str(token_price_usd),

--- a/tee_gateway/test/test_web_search.py
+++ b/tee_gateway/test/test_web_search.py
@@ -1,0 +1,277 @@
+"""
+Unit tests for native web search support across providers.
+
+Covers:
+  - model_registry: per-search pricing lookup and provider support predicate
+  - llm_backend.get_web_search_tool: provider-specific tool specs
+  - llm_backend.extract_web_search_count: counting billable search units from
+    each provider's response shape
+  - pricing.compute_session_cost: per-search surcharge added to token cost
+  - chat_controller: web_search flag binds the tool and bills the searches
+"""
+
+import unittest
+from decimal import Decimal
+from types import SimpleNamespace
+from unittest.mock import patch, Mock
+
+from langchain_core.messages import AIMessage
+
+from tee_gateway.model_registry import (
+    get_web_search_price_usd,
+    provider_supports_web_search,
+)
+from tee_gateway.llm_backend import (
+    get_web_search_tool,
+    extract_web_search_count,
+)
+from tee_gateway.pricing import SessionCost, compute_session_cost
+from tee_gateway.controllers.chat_controller import create_chat_completion
+
+
+# ---------------------------------------------------------------------------
+# model_registry pricing
+# ---------------------------------------------------------------------------
+
+
+class TestWebSearchPricing(unittest.TestCase):
+    def test_provider_support_predicate(self):
+        for provider in ("openai", "anthropic", "google", "x-ai"):
+            self.assertTrue(provider_supports_web_search(provider))
+        self.assertFalse(provider_supports_web_search("bytedance"))
+
+    def test_price_uses_provider_default(self):
+        # gpt-4.1 -> openai default ($0.01/search)
+        self.assertEqual(get_web_search_price_usd("gpt-4.1"), Decimal("0.01"))
+        # grok-4 -> xAI default ($0.025/source)
+        self.assertEqual(get_web_search_price_usd("grok-4"), Decimal("0.025"))
+        # gemini -> google default ($0.035/grounded request)
+        self.assertEqual(get_web_search_price_usd("gemini-2.5-flash"), Decimal("0.035"))
+
+    def test_unsupported_provider_is_free(self):
+        # ByteDance has no native web search -> no charge
+        self.assertEqual(get_web_search_price_usd("seed-1.6"), Decimal("0"))
+
+    def test_unknown_model_raises(self):
+        with self.assertRaises(ValueError):
+            get_web_search_price_usd("not-a-real-model")
+
+
+# ---------------------------------------------------------------------------
+# llm_backend.get_web_search_tool
+# ---------------------------------------------------------------------------
+
+
+class TestGetWebSearchTool(unittest.TestCase):
+    def test_openai_tool(self):
+        self.assertEqual(get_web_search_tool("openai"), {"type": "web_search"})
+
+    def test_anthropic_tool(self):
+        tool = get_web_search_tool("anthropic")
+        self.assertEqual(tool["type"], "web_search_20250305")
+        self.assertEqual(tool["name"], "web_search")
+
+    def test_google_tool(self):
+        self.assertEqual(get_web_search_tool("google"), {"google_search": {}})
+
+    def test_xai_and_bytedance_have_no_bound_tool(self):
+        # xAI configures search at construction; bytedance is unsupported.
+        self.assertIsNone(get_web_search_tool("x-ai"))
+        self.assertIsNone(get_web_search_tool("bytedance"))
+
+
+# ---------------------------------------------------------------------------
+# llm_backend.extract_web_search_count
+# ---------------------------------------------------------------------------
+
+
+class TestExtractWebSearchCount(unittest.TestCase):
+    def test_none_message(self):
+        self.assertEqual(extract_web_search_count(None), 0)
+
+    def test_plain_text_response_has_no_searches(self):
+        self.assertEqual(extract_web_search_count(AIMessage(content="hi")), 0)
+
+    def test_openai_web_search_call_blocks(self):
+        msg = AIMessage(
+            content=[
+                {"type": "web_search_call", "id": "ws_1"},
+                {"type": "text", "text": "answer"},
+                {"type": "web_search_call", "id": "ws_2"},
+            ]
+        )
+        self.assertEqual(extract_web_search_count(msg), 2)
+
+    def test_anthropic_server_tool_use_blocks(self):
+        msg = AIMessage(
+            content=[
+                {"type": "text", "text": "let me search"},
+                {"type": "server_tool_use", "name": "web_search", "id": "srv_1"},
+                {"type": "web_search_tool_result", "content": []},
+            ]
+        )
+        # Only the server_tool_use (the request) is billed, not the result block.
+        self.assertEqual(extract_web_search_count(msg), 1)
+
+    def test_xai_citations_counted_as_sources(self):
+        msg = AIMessage(content="answer")
+        msg.additional_kwargs = {
+            "citations": ["https://a.com", "https://b.com", "https://c.com"]
+        }
+        self.assertEqual(extract_web_search_count(msg), 3)
+
+    def test_google_grounding_counts_as_one_request(self):
+        msg = AIMessage(content="answer")
+        msg.response_metadata = {
+            "grounding_metadata": {"web_search_queries": ["q1", "q2"]}
+        }
+        # Google bills per grounded request, not per query.
+        self.assertEqual(extract_web_search_count(msg), 1)
+
+
+# ---------------------------------------------------------------------------
+# pricing.compute_session_cost with web search
+# ---------------------------------------------------------------------------
+
+
+def _usage(input_tokens: int = 100, output_tokens: int = 50) -> dict:
+    return {"prompt_tokens": input_tokens, "completion_tokens": output_tokens}
+
+
+def _call(usage, model, web_search_count=0, price=Decimal("0.10")):
+    feed = SimpleNamespace(get_price=lambda: price)
+    with patch("tee_gateway.price_feed.get_price_feed", return_value=feed):
+        return compute_session_cost(model, usage, web_search_count=web_search_count)
+
+
+class TestSessionCostWithWebSearch(unittest.TestCase):
+    def test_web_search_increases_cost(self):
+        base = _call(_usage(), "gpt-4.1")
+        searched = _call(_usage(), "gpt-4.1", web_search_count=2)
+        self.assertIsInstance(base, SessionCost)
+        self.assertIsInstance(searched, SessionCost)
+        self.assertGreater(searched.cost_opg, base.cost_opg)
+
+    def test_web_search_surcharge_amount(self):
+        """Two openai searches at $0.01 each add $0.02 of USD cost."""
+        base = _call(_usage(), "gpt-4.1")
+        searched = _call(_usage(), "gpt-4.1", web_search_count=2)
+        # cost_usd is reconciled from rounded OPG; compare via the underlying math.
+        # At price $0.10/OPG, $0.02 surcharge ≈ 0.2 OPG = 2e17 smallest units.
+        delta_opg = searched.cost_opg - base.cost_opg
+        scale = Decimal(10) ** 18
+        delta_usd = (Decimal(delta_opg) / scale) * Decimal("0.10")
+        # Allow a tiny rounding tolerance from ceiling rounding on each call.
+        self.assertAlmostEqual(delta_usd, Decimal("0.02"), places=6)
+
+    def test_zero_searches_matches_no_web_search(self):
+        a = _call(_usage(), "gpt-4.1", web_search_count=0)
+        b = _call(_usage(), "gpt-4.1")
+        self.assertEqual(a.cost_opg, b.cost_opg)
+
+    def test_unsupported_provider_not_charged_for_search(self):
+        # Even if a count slips through, bytedance price is 0 -> no surcharge.
+        base = _call(_usage(), "seed-1.6")
+        searched = _call(_usage(), "seed-1.6", web_search_count=5)
+        self.assertEqual(searched.cost_opg, base.cost_opg)
+
+
+# ---------------------------------------------------------------------------
+# chat_controller integration
+# ---------------------------------------------------------------------------
+
+
+class _MockResponse:
+    def __init__(self, content="", tool_calls=None, usage=None):
+        self.content = content
+        self.tool_calls = tool_calls or []
+        self.usage_metadata = usage or {
+            "input_tokens": 10,
+            "output_tokens": 5,
+            "total_tokens": 15,
+        }
+
+
+def _mock_tee_keys():
+    tee = Mock()
+    tee.sign_data.return_value = "bW9ja3NpZ25hdHVyZQ=="
+    tee.get_tee_id.return_value = "abcdef01" * 8
+    return tee
+
+
+class TestChatControllerWebSearch(unittest.TestCase):
+    @patch("tee_gateway.controllers.chat_controller.compute_session_cost")
+    @patch("tee_gateway.controllers.chat_controller.get_tee_keys")
+    @patch("tee_gateway.controllers.chat_controller.get_chat_model_cached")
+    @patch("tee_gateway.controllers.chat_controller.connexion")
+    def test_web_search_flag_binds_tool_and_bills(
+        self, mock_connexion, mock_get_model, mock_get_tee_keys, mock_cost
+    ):
+        mock_connexion.request.is_json = True
+        mock_connexion.request.get_json.return_value = {
+            "model": "claude-sonnet-4-5",
+            "messages": [{"role": "user", "content": "latest news?"}],
+            "web_search": True,
+            "stream": False,
+        }
+
+        # Anthropic response with a server_tool_use web_search block.
+        response = _MockResponse(
+            content=[
+                {"type": "text", "text": "Here is the news."},
+                {"type": "server_tool_use", "name": "web_search", "id": "srv_1"},
+            ]
+        )
+        model = Mock()
+        model.invoke.return_value = response
+        model.bind_tools.return_value = model
+        mock_get_model.return_value = model
+        mock_get_tee_keys.return_value = _mock_tee_keys()
+        mock_cost.return_value = None
+
+        result = create_chat_completion(None)
+
+        # Model must be constructed with web_search=True.
+        self.assertTrue(mock_get_model.call_args.kwargs["web_search"])
+        # The anthropic web search tool must be bound.
+        bound = model.bind_tools.call_args[0][0]
+        self.assertTrue(
+            any(
+                isinstance(t, dict) and t.get("type") == "web_search_20250305"
+                for t in bound
+            )
+        )
+        # Billing must receive the detected search count (1 server_tool_use).
+        self.assertEqual(mock_cost.call_args.kwargs["web_search_count"], 1)
+        self.assertIn("choices", result)
+
+    @patch("tee_gateway.controllers.chat_controller.compute_session_cost")
+    @patch("tee_gateway.controllers.chat_controller.get_tee_keys")
+    @patch("tee_gateway.controllers.chat_controller.get_chat_model_cached")
+    @patch("tee_gateway.controllers.chat_controller.connexion")
+    def test_no_web_search_does_not_bind_or_bill_search(
+        self, mock_connexion, mock_get_model, mock_get_tee_keys, mock_cost
+    ):
+        mock_connexion.request.is_json = True
+        mock_connexion.request.get_json.return_value = {
+            "model": "gpt-4.1",
+            "messages": [{"role": "user", "content": "hello"}],
+            "stream": False,
+        }
+        model = Mock()
+        model.invoke.return_value = _MockResponse(content="hi")
+        model.bind_tools.return_value = model
+        mock_get_model.return_value = model
+        mock_get_tee_keys.return_value = _mock_tee_keys()
+        mock_cost.return_value = None
+
+        create_chat_completion(None)
+
+        self.assertFalse(mock_get_model.call_args.kwargs["web_search"])
+        # No tools and no web search -> bind_tools must not be called.
+        model.bind_tools.assert_not_called()
+        self.assertEqual(mock_cost.call_args.kwargs["web_search_count"], 0)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Add an opt-in `web_search` flag to chat and text completion requests that
enables each provider's built-in web search and bills per search on top of
token usage.

- model_registry: per-search USD pricing (provider list prices) via
  get_web_search_price_usd + provider_supports_web_search predicate
- llm_backend: get_chat_model_cached gains a web_search arg (OpenAI uses the
  Responses API, xAI sets search_parameters); get_web_search_tool returns the
  bind-time tool spec for OpenAI/Anthropic/Google; extract_web_search_count
  counts the billable unit per provider (calls/requests/sources/grounded req)
- controllers: parse and forward the flag, bind the web search tool alongside
  user tools, cover the flag in the signed request hash, and pass the detected
  search count into compute_session_cost (streaming + non-streaming)
- pricing: compute_session_cost adds the per-search surcharge
- models + openapi: add the web_search request field
- tests: provider pricing, tool specs, count extraction, surcharge math, and
  controller binding/billing integration

Providers without native web search (ByteDance/ModelArk) ignore the flag and
are not charged.