### PR TITLE
Add image generation support for xAI Grok and ByteDance Seedream

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -114,8 +114,15 @@ Model name prefixes determine routing:
 - **OpenAI**: gpt-4.1, gpt-5, gpt-5-mini, gpt-5.2, o4-mini
 - **Anthropic**: claude-sonnet-4-0/4-5/4-6, claude-haiku-4-5, claude-opus-4-5/4-6, claude-3-7-sonnet, claude-3-5-haiku
 - **Google**: gemini-2.5-flash, gemini-2.5-flash-lite, gemini-2.5-pro, gemini-3-pro-preview, gemini-3-flash-preview, gemini-3.1-pro-preview, gemini-3.1-flash-lite-preview, gemini-3.5-flash; image generation: gemini-2.5-flash-image, gemini-3.1-flash-image
-- **xAI**: grok-2, grok-3, grok-3-mini, grok-4, grok-4-fast, grok-4-1-fast
-- **ByteDance** (BytePlus ModelArk, OpenAI-compatible, ap-southeast): seed-1.6, seed-1.8, seed-2.0-lite
+- **xAI**: grok-2, grok-3, grok-3-mini, grok-4, grok-4-fast, grok-4-1-fast; image generation: grok-2-image
+- **ByteDance** (BytePlus ModelArk, OpenAI-compatible, ap-southeast): seed-1.6, seed-1.8, seed-2.0-lite; image generation: seedream-4.0
+
+Image generation via xAI (grok-2-image) and ByteDance (seedream-4.0) is served
+through a provider `/images/generations` endpoint rather than the chat path, but
+is surfaced on `/v1/chat/completions` exactly like Gemini's inline-image models
+(images returned out-of-band under the message `images` key). These models are
+billed a flat per-image price (see `per_image_price_usd` in `model_registry.py`),
+not per token.
 
 ## Verification Examples
 

--- a/tee_gateway/controllers/chat_controller.py
+++ b/tee_gateway/controllers/chat_controller.py
@@ -31,6 +31,7 @@ from tee_gateway.llm_backend import (
     extract_web_search_count,
     convert_messages,
     extract_usage,
+    generate_images,
 )
 from tee_gateway.model_registry import get_model_config
 from tee_gateway.pricing import compute_session_cost
@@ -71,6 +72,23 @@ def _split_text_and_images(content: Any) -> tuple[str, list[str]]:
         else:
             text_parts.append(item.get("text", "") or "")
     return ("".join(text_parts), images)
+
+
+def _extract_image_prompt(langchain_messages: list) -> str:
+    """Collapse the user-turn text into a single image-generation prompt.
+
+    Image-generation models (xAI Grok, ByteDance Seedream) take a single text
+    prompt rather than a chat transcript, so we join the text of all human
+    messages. System/assistant/tool turns are ignored.
+    """
+    from langchain_core.messages import HumanMessage
+
+    parts: list[str] = []
+    for m in langchain_messages:
+        if isinstance(m, HumanMessage):
+            content = m.content
+            parts.append(content if isinstance(content, str) else str(content))
+    return "\n".join(p for p in parts if p)
 
 
 def create_chat_completion(body):
@@ -201,6 +219,111 @@ def _messages_contain_json_word(messages: list) -> bool:
     return False
 
 
+def _create_image_generation_response(
+    chat_request: CreateChatCompletionRequest, request_bytes: bytes
+):
+    """Non-streaming image generation via a provider's images endpoint.
+
+    Surfaces generated images on the message under the ``images`` key exactly
+    like Gemini's inline-image models. There is no text to sign, so the signature
+    covers the request hash and an empty output; the image bytes ride out-of-band
+    inside the OHTTP envelope. Billing is flat per generated image.
+    """
+    langchain_messages = convert_messages(chat_request.messages)
+    prompt = _extract_image_prompt(langchain_messages)
+    images, image_count = generate_images(
+        chat_request.model, prompt, n=chat_request.n or 1
+    )
+
+    message_dict: dict[str, Any] = {"role": "assistant", "content": ""}
+    if images:
+        message_dict["images"] = images
+
+    timestamp = int(time.time())
+    msg_hash, input_hash_hex, output_hash_hex = compute_tee_msg_hash(
+        request_bytes, "", timestamp
+    )
+    tee_keys = get_tee_keys()
+    signature = tee_keys.sign_data(msg_hash)
+
+    openai_response: dict[str, Any] = {
+        "id": f"chatcmpl-{uuid.uuid4()}",
+        "object": "chat.completion",
+        "created": timestamp,
+        "model": chat_request.model,
+        "choices": [{"index": 0, "message": message_dict, "finish_reason": "stop"}],
+        "tee_signature": signature,
+        "tee_request_hash": input_hash_hex,
+        "tee_output_hash": output_hash_hex,
+        "tee_timestamp": timestamp,
+        "tee_id": f"0x{tee_keys.get_tee_id()}",
+    }
+
+    usage = {"prompt_tokens": 0, "completion_tokens": 0, "total_tokens": 0}
+    openai_response["usage"] = usage
+    cost = compute_session_cost(chat_request.model, usage, image_count=image_count)
+    if cost is not None:
+        openai_response["opengradient"] = cost.model_dump(mode="json")
+
+    CreateChatCompletionResponse.from_dict(openai_response)
+    return openai_response
+
+
+def _create_image_generation_streaming_response(
+    chat_request: CreateChatCompletionRequest, request_bytes: bytes
+):
+    """Streaming image generation: image gen is not a token stream, so we invoke
+    once and emit the result on the final SSE frame (mirrors the Gemini path)."""
+    tee_keys = get_tee_keys()
+
+    def generate():
+        try:
+            langchain_messages = convert_messages(chat_request.messages)
+            prompt = _extract_image_prompt(langchain_messages)
+            images, image_count = generate_images(
+                chat_request.model, prompt, n=chat_request.n or 1
+            )
+
+            timestamp = int(time.time())
+            msg_hash, input_hash_hex, output_hash_hex = compute_tee_msg_hash(
+                request_bytes, "", timestamp
+            )
+            tee_signature = tee_keys.sign_data(msg_hash)
+
+            final_data: dict[str, Any] = {
+                "choices": [{"delta": {}, "index": 0, "finish_reason": "stop"}],
+                "model": chat_request.model,
+                "tee_signature": tee_signature,
+                "tee_timestamp": timestamp,
+                "tee_request_hash": input_hash_hex,
+                "tee_output_hash": output_hash_hex,
+                "tee_id": f"0x{tee_keys.get_tee_id()}",
+            }
+            # Images travel out-of-band on the final frame; not part of the hash.
+            if images:
+                final_data["images"] = images
+
+            usage = {"prompt_tokens": 0, "completion_tokens": 0, "total_tokens": 0}
+            final_data["usage"] = usage
+            cost = compute_session_cost(
+                chat_request.model, usage, image_count=image_count
+            )
+            if cost is not None:
+                final_data["opengradient"] = cost.model_dump(mode="json")
+
+            yield f"data: {json.dumps(final_data)}\n\n"
+            yield "data: [DONE]\n\n"
+        except Exception as e:
+            logger.error(f"Image generation streaming error: {str(e)}", exc_info=True)
+            yield f"data: {json.dumps({'error': 'Stream processing failed', 'exception_type': type(e).__name__})}\n\n"
+
+    return Response(
+        generate(),
+        mimetype="text/event-stream",
+        headers={"Cache-Control": "no-cache", "Connection": "keep-alive"},
+    )
+
+
 def _create_non_streaming_response(chat_request: CreateChatCompletionRequest):
     """Handle non-streaming chat completion via direct LangChain call."""
     try:
@@ -209,10 +332,18 @@ def _create_non_streaming_response(chat_request: CreateChatCompletionRequest):
         logger.info(f"Number of messages: {len(chat_request.messages)}")
 
         provider = get_provider_from_model(chat_request.model)
+        cfg = get_model_config(chat_request.model)
 
         # Serialize request for hashing (canonical, deterministic)
         request_dict = _chat_request_to_dict(chat_request)
         request_bytes = json.dumps(request_dict, sort_keys=True).encode("utf-8")
+
+        # Image-generation models (xAI Grok, ByteDance Seedream) are served via a
+        # dedicated /images/generations endpoint — not the chat path — but are
+        # surfaced through this same endpoint, returning images out-of-band just
+        # like Gemini's inline-image models.
+        if cfg.image_generation:
+            return _create_image_generation_response(chat_request, request_bytes)
 
         model = get_chat_model_cached(
             model=chat_request.model,
@@ -353,12 +484,19 @@ def _create_streaming_response(chat_request: CreateChatCompletionRequest):
         # OpenAI and Anthropic stream tool calls as fragments that must be
         # buffered and flushed once complete. Gemini emits complete tool calls.
         buffer_tool_calls = provider in ["openai", "anthropic"]
-        # Image-generation models return a single image rather than a token
+        # Gemini inline-image models return a single image rather than a token
         # stream — invoke once and emit the result inside the SSE envelope.
         image_output_model = get_model_config(chat_request.model).image_output
 
         request_dict = _chat_request_to_dict(chat_request)
         request_bytes = json.dumps(request_dict, sort_keys=True).encode("utf-8")
+
+        # Image-generation models (xAI Grok, ByteDance Seedream) use a dedicated
+        # images endpoint; handle them without building a chat model.
+        if get_model_config(chat_request.model).image_generation:
+            return _create_image_generation_streaming_response(
+                chat_request, request_bytes
+            )
 
         model = get_chat_model_cached(
             model=chat_request.model,

--- a/tee_gateway/llm_backend.py
+++ b/tee_gateway/llm_backend.py
@@ -259,6 +259,72 @@ def get_chat_model_cached(
         raise ValueError(f"Unsupported provider: {provider}")
 
 
+# Endpoint path appended to each provider's OpenAI-compatible base URL.
+_IMAGE_GENERATION_PATH = "/images/generations"
+
+
+def generate_images(model: str, prompt: str, n: int = 1) -> tuple[list[str], int]:
+    """Generate images via a provider's OpenAI-compatible images endpoint.
+
+    Unlike Gemini's inline-image chat models, xAI (Aurora) and ByteDance
+    (Seedream) expose image generation through a dedicated
+    ``POST /images/generations`` endpoint. We request ``b64_json`` so the image
+    bytes ride inline inside the OHTTP/TEE envelope rather than as external URLs
+    that leak the content and expire.
+
+    Returns ``(data_uris, image_count)`` where each entry is a ``data:`` URI. The
+    count is used for per-image billing. Falls back to provider-returned URLs if
+    a provider ignores ``b64_json``.
+    """
+    cfg = get_model_config(model)
+    provider = cfg.provider
+
+    if provider == "x-ai":
+        client = xai_http_client
+    elif provider == "bytedance":
+        client = bytedance_http_client
+    else:
+        raise ValueError(
+            f"Provider {provider!r} does not support the image-generation endpoint"
+        )
+
+    if client is None:
+        raise RuntimeError(f"{provider} HTTP client has not been initialized")
+
+    # n is clamped to the providers' documented 1..10 range.
+    count = max(1, min(int(n), 10))
+    payload: dict[str, Any] = {
+        "model": cfg.api_name,
+        "prompt": prompt,
+        "n": count,
+        "response_format": "b64_json",
+    }
+
+    logger.info(
+        "Generating %d image(s) - Provider: %s, Model: %s",
+        count,
+        provider,
+        cfg.api_name,
+    )
+    resp = client.post(_IMAGE_GENERATION_PATH, json=payload)
+    resp.raise_for_status()
+    data = resp.json().get("data", []) or []
+
+    images: list[str] = []
+    for item in data:
+        if not isinstance(item, dict):
+            continue
+        b64 = item.get("b64_json")
+        if b64:
+            images.append(f"data:image/jpeg;base64,{b64}")
+            continue
+        url = item.get("url")
+        if url:
+            images.append(url)
+
+    return images, len(images)
+
+
 def convert_messages(messages: list) -> List[Any]:
     """Convert OpenAI-format message objects or dicts to LangChain message objects."""
     langchain_messages: List[BaseMessage] = []

--- a/tee_gateway/model_registry.py
+++ b/tee_gateway/model_registry.py
@@ -23,9 +23,17 @@ class ModelConfig:
     # the field is present at all. Set False on models that reject it.
     supports_temperature: bool = True
     # Image-output models (e.g. Gemini "nano banana") return generated images as
-    # inline content blocks. The backend requests the IMAGE modality and the
-    # controller surfaces the image data on the response message.
+    # inline content blocks of a chat response. The backend requests the IMAGE
+    # modality and the controller surfaces the image data on the response message.
     image_output: bool = False
+    # Image-generation models served via a dedicated OpenAI-compatible
+    # ``POST /images/generations`` endpoint (e.g. xAI Grok, ByteDance Seedream)
+    # rather than the chat path. These are billed per generated image
+    # (``per_image_price_usd``) instead of per token.
+    image_generation: bool = False
+    # Flat USD price per generated image, for ``image_generation`` models. Token
+    # prices are ignored for these models (set to 0 in the registry).
+    per_image_price_usd: Optional[Decimal] = None
     # Per-search USD surcharge billed when native web search is used. ``None``
     # means "use the provider default" (see WEB_SEARCH_PRICE_USD_BY_PROVIDER);
     # set an explicit value here to override a single model's web-search price.
@@ -292,6 +300,16 @@ class SupportedModel(Enum):
         input_price_usd=Decimal("0.0000002"),
         output_price_usd=Decimal("0.0000015"),
     )
+    # Image generation via xAI's OpenAI-compatible /images/generations endpoint
+    # (Aurora). Billed at a flat $0.07 per generated image; token prices unused.
+    GROK_2_IMAGE = ModelConfig(
+        provider="x-ai",
+        api_name="grok-2-image-1212",
+        input_price_usd=Decimal("0"),
+        output_price_usd=Decimal("0"),
+        image_generation=True,
+        per_image_price_usd=Decimal("0.07"),
+    )
 
     # ── ByteDance (BytePlus ModelArk, OpenAI-compatible) ────────────────
     SEED_1_6 = ModelConfig(
@@ -311,6 +329,17 @@ class SupportedModel(Enum):
         api_name="seed-2-0-lite-260228",
         input_price_usd=Decimal("0.0000004"),
         output_price_usd=Decimal("0.0000016"),
+    )
+    # Seedream 4.0 image generation via ModelArk's OpenAI-compatible
+    # /images/generations endpoint. Billed at a flat $0.03 per generated image;
+    # token prices unused.
+    SEEDREAM_4_0 = ModelConfig(
+        provider="bytedance",
+        api_name="seedream-4-0-250828",
+        input_price_usd=Decimal("0"),
+        output_price_usd=Decimal("0"),
+        image_generation=True,
+        per_image_price_usd=Decimal("0.03"),
     )
 
     # ── Legacy models (not in current SDK — retained for older SDK versions) ──
@@ -376,6 +405,9 @@ _MODEL_LOOKUP: dict[str, SupportedModel] = {
     "grok-4.20-reasoning": SupportedModel.GROK_4_20_REASONING,
     "grok-4.20-non-reasoning": SupportedModel.GROK_4_20_NON_REASONING,
     "grok-code-fast-1": SupportedModel.GROK_CODE_FAST_1,
+    "grok-2-image": SupportedModel.GROK_2_IMAGE,
+    "grok-2-image-1212": SupportedModel.GROK_2_IMAGE,
+    "grok-2-image-latest": SupportedModel.GROK_2_IMAGE,
     # ByteDance
     "seed-1-6-250615": SupportedModel.SEED_1_6,
     "seed-1.6": SupportedModel.SEED_1_6,
@@ -383,6 +415,9 @@ _MODEL_LOOKUP: dict[str, SupportedModel] = {
     "seed-1.8": SupportedModel.SEED_1_8,
     "seed-2-0-lite-260228": SupportedModel.SEED_2_0_LITE,
     "seed-2.0-lite": SupportedModel.SEED_2_0_LITE,
+    "seedream-4-0-250828": SupportedModel.SEEDREAM_4_0,
+    "seedream-4.0": SupportedModel.SEEDREAM_4_0,
+    "seedream-4-0": SupportedModel.SEEDREAM_4_0,
     # Legacy — not in current SDK, retained for older SDK versions
     "grok-3-mini-beta": SupportedModel.GROK_3_MINI,  # old beta alias
     "grok-3-mini": SupportedModel.GROK_3_MINI,

--- a/tee_gateway/pricing.py
+++ b/tee_gateway/pricing.py
@@ -50,7 +50,7 @@ class SessionCost(BaseModel):
 
 
 def compute_session_cost(
-    model: str, usage: dict, web_search_count: int = 0
+    model: str, usage: dict, web_search_count: int = 0, image_count: int = 0
 ) -> SessionCost | None:
     """Compute the settled cost for a completed inference request.
 
@@ -88,6 +88,16 @@ def compute_session_cost(
         )
         raw_usd += web_search_usd
 
+        # Image-generation models (xAI Grok, ByteDance Seedream) are billed a flat
+        # price per generated image rather than per token; token prices are 0.
+        images = max(0, int(image_count))
+        image_usd = (
+            Decimal(images) * cfg.per_image_price_usd
+            if images and cfg.per_image_price_usd is not None
+            else Decimal(0)
+        )
+        raw_usd += image_usd
+
         token_price_usd = get_price_feed().get_price()
         if token_price_usd <= 0:
             raise ValueError(f"Token price is non-positive: {token_price_usd}")
@@ -107,13 +117,15 @@ def compute_session_cost(
 
         logger.info(
             "DYNAMIC_SESSION_COST model=%s input_tokens=%d output_tokens=%d "
-            "web_searches=%d web_search_usd=%s raw_usd=%s settled_usd=%s "
-            "token_price_usd=%s decimals=%d cost=%d",
+            "web_searches=%d web_search_usd=%s images=%d image_usd=%s raw_usd=%s "
+            "settled_usd=%s token_price_usd=%s decimals=%d cost=%d",
             model,
             in_tok,
             out_tok,
             searches,
             str(web_search_usd),
+            images,
+            str(image_usd),
             str(raw_usd),
             str(settled_usd),
             str(token_price_usd),

--- a/tee_gateway/test/test_image_generation.py
+++ b/tee_gateway/test/test_image_generation.py
@@ -1,0 +1,135 @@
+"""Tests for endpoint-based image generation (xAI Grok, ByteDance Seedream).
+
+Unlike Gemini's inline-image chat models (see test_image_billing.py), these
+models are served via a dedicated OpenAI-compatible ``/images/generations``
+endpoint and billed a flat price per generated image. These tests pin:
+
+  1. The request/response handling in ``generate_images`` (b64_json -> data URI,
+     n clamping, url fallback).
+  2. The flat per-image billing in ``compute_session_cost``.
+
+No network or API key required — the provider HTTP client is mocked and a stub
+price feed is injected.
+"""
+
+import unittest
+from decimal import Decimal
+from unittest.mock import MagicMock, patch
+
+from tee_gateway import llm_backend
+from tee_gateway.llm_backend import generate_images
+from tee_gateway.model_registry import get_model_config
+from tee_gateway.price_feed import get_price_feed, set_price_feed
+from tee_gateway.pricing import compute_session_cost
+
+GROK_IMAGE = "grok-2-image"
+SEEDREAM = "seedream-4.0"
+
+
+def _mock_response(data: list[dict]) -> MagicMock:
+    resp = MagicMock()
+    resp.raise_for_status.return_value = None
+    resp.json.return_value = {"data": data}
+    return resp
+
+
+class TestGenerateImages(unittest.TestCase):
+    """Request shaping and response parsing for the images endpoint."""
+
+    def test_b64_json_becomes_data_uri(self):
+        client = MagicMock()
+        client.post.return_value = _mock_response(
+            [{"b64_json": "aGVsbG8="}, {"b64_json": "d29ybGQ="}]
+        )
+        with patch.object(llm_backend, "xai_http_client", client):
+            images, count = generate_images(GROK_IMAGE, "a red cube", n=2)
+
+        self.assertEqual(count, 2)
+        self.assertEqual(
+            images,
+            [
+                "data:image/jpeg;base64,aGVsbG8=",
+                "data:image/jpeg;base64,d29ybGQ=",
+            ],
+        )
+
+        # Verify the outgoing request shape.
+        _, kwargs = client.post.call_args
+        payload = kwargs["json"]
+        self.assertEqual(payload["model"], get_model_config(GROK_IMAGE).api_name)
+        self.assertEqual(payload["prompt"], "a red cube")
+        self.assertEqual(payload["n"], 2)
+        self.assertEqual(payload["response_format"], "b64_json")
+
+    def test_url_fallback_when_no_b64(self):
+        client = MagicMock()
+        client.post.return_value = _mock_response([{"url": "https://img/1.jpg"}])
+        with patch.object(llm_backend, "bytedance_http_client", client):
+            images, count = generate_images(SEEDREAM, "a blue sphere", n=1)
+
+        self.assertEqual(count, 1)
+        self.assertEqual(images, ["https://img/1.jpg"])
+
+    def test_n_is_clamped_to_provider_range(self):
+        client = MagicMock()
+        client.post.return_value = _mock_response([{"b64_json": "x"}])
+        with patch.object(llm_backend, "xai_http_client", client):
+            generate_images(GROK_IMAGE, "p", n=999)
+        self.assertEqual(client.post.call_args.kwargs["json"]["n"], 10)
+
+        with patch.object(llm_backend, "xai_http_client", client):
+            generate_images(GROK_IMAGE, "p", n=0)
+        self.assertEqual(client.post.call_args.kwargs["json"]["n"], 1)
+
+    def test_uninitialized_client_raises(self):
+        with patch.object(llm_backend, "xai_http_client", None):
+            with self.assertRaises(RuntimeError):
+                generate_images(GROK_IMAGE, "p", n=1)
+
+
+class TestPerImageBilling(unittest.TestCase):
+    """Flat per-image pricing, independent of token usage."""
+
+    def setUp(self):
+        try:
+            self._prev_feed = get_price_feed()
+        except RuntimeError:
+            self._prev_feed = None
+        # 1 OPG == 1 USD keeps the OPG<->USD reconciliation arithmetic trivial.
+        stub = MagicMock()
+        stub.get_price.return_value = Decimal("1")
+        set_price_feed(stub)
+
+    def tearDown(self):
+        if self._prev_feed is not None:
+            set_price_feed(self._prev_feed)
+
+    @staticmethod
+    def _zero_usage() -> dict:
+        return {"prompt_tokens": 0, "completion_tokens": 0, "total_tokens": 0}
+
+    def test_single_image_charged_flat_price(self):
+        for model in (GROK_IMAGE, SEEDREAM):
+            with self.subTest(model=model):
+                cfg = get_model_config(model)
+                cost = compute_session_cost(model, self._zero_usage(), image_count=1)
+                self.assertIsNotNone(cost)
+                self.assertAlmostEqual(cost.cost_usd, cfg.per_image_price_usd, places=9)
+
+    def test_cost_scales_with_image_count(self):
+        cfg = get_model_config(GROK_IMAGE)
+        one = compute_session_cost(GROK_IMAGE, self._zero_usage(), image_count=1)
+        three = compute_session_cost(GROK_IMAGE, self._zero_usage(), image_count=3)
+        self.assertIsNotNone(one)
+        self.assertIsNotNone(three)
+        self.assertAlmostEqual(three.cost_usd, cfg.per_image_price_usd * 3, places=9)
+        self.assertGreater(three.cost_opg, one.cost_opg)
+
+    def test_zero_images_is_free(self):
+        cost = compute_session_cost(GROK_IMAGE, self._zero_usage(), image_count=0)
+        self.assertIsNotNone(cost)
+        self.assertEqual(cost.cost_opg, 0)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_pricing.py
+++ b/tests/test_pricing.py
@@ -67,8 +67,14 @@ class TestModelRegistry(unittest.TestCase):
                 self.assertIsNotNone(cfg)
                 self.assertIsNotNone(cfg.provider)
                 self.assertIsNotNone(cfg.api_name)
-                self.assertGreater(cfg.input_price_usd, 0)
-                self.assertGreater(cfg.output_price_usd, 0)
+                if cfg.image_generation:
+                    # Endpoint-based image models (Grok, Seedream) bill a flat
+                    # per-image price; their token prices are intentionally 0.
+                    self.assertIsNotNone(cfg.per_image_price_usd)
+                    self.assertGreater(cfg.per_image_price_usd, 0)
+                else:
+                    self.assertGreater(cfg.input_price_usd, 0)
+                    self.assertGreater(cfg.output_price_usd, 0)
 
     # ── Anthropic Sonnet ────────────────────────────────────────────────────
 


### PR DESCRIPTION
## Summary

Add support for image generation models (xAI Grok 2 Image, ByteDance Seedream 4.0) served via OpenAI-compatible `/images/generations` endpoints. These models are surfaced through `/v1/chat/completions` like Gemini's inline-image models but use a dedicated endpoint and flat per-image billing instead of token-based pricing.

## Key Changes

- **New `generate_images()` function** (`llm_backend.py`): Calls provider `/images/generations` endpoints, handles `b64_json` → data URI conversion, clamps `n` to provider range (1–10), and falls back to URLs if providers ignore `b64_json`.

- **Image generation response handlers** (`chat_controller.py`):
  - `_extract_image_prompt()`: Collapses multi-turn chat into a single text prompt (image models don't understand chat transcripts).
  - `_create_image_generation_response()`: Non-streaming path; generates images, signs empty output, includes images out-of-band on the response message.
  - `_create_image_generation_streaming_response()`: Streaming path; invokes image generation once and emits result on final SSE frame (mirrors Gemini behavior).

- **Model registry updates** (`model_registry.py`):
  - Added `GROK_2_IMAGE` (xAI Aurora, $0.07/image)
  - Added `SEEDREAM_4_0` (ByteDance, $0.03/image)
  - New config fields: `image_generation` (bool), `per_image_price_usd` (Decimal)
  - Updated model name aliases for both models

- **Billing integration** (`pricing.py`):
  - Extended `compute_session_cost()` to accept `image_count` parameter
  - Flat per-image pricing: `image_count × per_image_price_usd`
  - Token prices set to 0 for image-generation models

- **Request routing** (`chat_controller.py`):
  - Both streaming and non-streaming paths check `cfg.image_generation` flag
  - If true, bypass chat model instantiation and use dedicated image generation handlers
  - Request/output hashing and TEE signing work identically to chat responses

- **Comprehensive test suite** (`test_image_generation.py`):
  - Request shaping validation (model name, prompt, n clamping, response format)
  - Response parsing (b64_json → data URI, URL fallback)
  - Per-image billing verification (flat pricing, scaling with count, zero-image case)

## Implementation Details

- Images are returned as `data:image/jpeg;base64,...` URIs (inline in OHTTP envelope, no external URLs that leak content or expire)
- Empty text output (`""`) is signed; images travel out-of-band on the response message under the `images` key
- Token usage is zeroed for image models (prompt_tokens, completion_tokens both 0)
- Provider HTTP clients (`xai_http_client`, `bytedance_http_client`) must be initialized before use; raises `RuntimeError` if not
- Fully compatible with existing TEE signing, attestation, and x402 payment infrastructure

https://claude.ai/code/session_01AAeoTLJE1qHCshwBt4ufjT