### PR TITLE
test: lock canonical request-hash contract for image-studio edits

### DIFF
--- a/tee_gateway/test/test_tee_core.py
+++ b/tee_gateway/test/test_tee_core.py
@@ -22,7 +22,11 @@ from eth_hash.auto import keccak
 from langchain_core.messages import AIMessage, HumanMessage, SystemMessage, ToolMessage
 
 from tee_gateway import ohttp
-from tee_gateway.controllers.chat_controller import _canonical_user_content
+from tee_gateway.controllers.chat_controller import (
+    _canonical_user_content,
+    _chat_request_to_dict,
+    _parse_chat_request,
+)
 from tee_gateway.llm_backend import (
     AttachmentValidationError,
     convert_messages,
@@ -865,6 +869,71 @@ class TestCanonicalUserContent(unittest.TestCase):
         self.assertEqual(
             _canonical_user_content(content), _canonical_user_content(content)
         )
+
+
+class TestImageEditRequestHashContract(unittest.TestCase):
+    """Locks the exact canonical request hash for an image-studio "edit the last
+    image" request: a user turn carrying the edit instruction plus the prior
+    generation inline as an ``image_url`` data URI.
+
+    The chat-app reproduces this same canonical form client-side to verify the
+    TEE signature (it mirrors ``_convert_content_part`` / ``_canonical_user_content``).
+    If this serialization ever changes, the client's signature verification
+    breaks — so this test pins the byte-exact output as a cross-repo contract.
+    """
+
+    def _edit_request(self) -> dict:
+        return {
+            "model": "gemini-2.5-flash-image",
+            "messages": [
+                {"role": "system", "content": "env preamble"},
+                {"role": "user", "content": "generate a cat"},
+                {"role": "assistant", "content": "[image]"},
+                {
+                    "role": "user",
+                    "content": [
+                        {"type": "text", "text": "make it brighter"},
+                        {
+                            "type": "image_url",
+                            "image_url": {
+                                "url": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUg=="
+                            },
+                        },
+                    ],
+                },
+            ],
+            "temperature": 0.0,
+        }
+
+    def test_canonical_request_is_byte_exact(self):
+        parsed = _parse_chat_request(self._edit_request())
+        canonical = json.dumps(_chat_request_to_dict(parsed), sort_keys=True)
+
+        expected_digest = hashlib.sha256(b"iVBORw0KGgoAAAANSUhEUg==").hexdigest()
+        expected = (
+            "{"
+            '"messages": ['
+            '{"content": "env preamble", "role": "system"}, '
+            '{"content": "generate a cat", "role": "user"}, '
+            '{"content": "[image]", "role": "assistant"}, '
+            '{"content": ['
+            '{"text": "make it brighter", "type": "text"}, '
+            '{"mime_type": "image/png", '
+            f'"sha256": "{expected_digest}", "type": "image"}}'
+            '], "role": "user"}'
+            "], "
+            '"model": "gemini-2.5-flash-image", '
+            '"temperature": 0.0'
+            "}"
+        )
+        self.assertEqual(canonical, expected)
+
+    def test_image_bytes_never_in_signed_payload(self):
+        # The raw base64 image must be digested away, never inlined into the
+        # signed request hash payload.
+        parsed = _parse_chat_request(self._edit_request())
+        canonical = json.dumps(_chat_request_to_dict(parsed), sort_keys=True)
+        self.assertNotIn("iVBORw0KGgoAAAANSUhEUg==", canonical)
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Stacked on top of #82 (Secure attachments).

## Context

The chat-app Image Studio's "edit the last image" flow was throwing errors whenever there was an image in the history: the prior generation was inlined into the message **content string** as a base64 markdown image, so the gateway forwarded it to the model as a giant text prompt (which the provider rejects) instead of as an actual image. The fix is to send the image as a native `image_url` content part — which is exactly what #82's multimodal `convert_messages` / `_canonical_user_content` already handle. The companion client change is in chat-app (`OpenGradient/chat-app`, branch `claude/jolly-hypatia-4BrYt`).

## What this PR adds

A single regression test (`TestImageEditRequestHashContract`) that pins, **byte-exact**, the canonical request-hash serialization for an image-edit request (user turn = edit instruction + prior image as an inline `image_url` data URI).

The chat-app reproduces this same canonical form client-side to verify the TEE signature (it mirrors `_convert_content_part` / `_canonical_user_content`). If the gateway's attachment-digesting serialization ever changes, the client's signature verification silently breaks — this test guards that cross-repo contract, and asserts the raw image bytes are digested away (never inlined) in the signed payload.

## Note on the base branch

#82's branch was stale (cut from an old `main`, missing the image-generation/`image_output` models the studio uses, and in merge conflict). I rebased it onto current `main` and force-pushed so it's clean and testable; this PR stacks on the rebased branch. Verified locally: full suite (64 tests) green; the canonical form matches the chat-app client byte-for-byte (409 bytes).

🤖 Generated with [Claude Code](https://claude.ai/code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Cm2aTqMnQdtRZA2f5n4LrF)_