### PR TITLE
Add OpenAI gpt-image-1 image generation model

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -111,18 +111,20 @@ Server configuration:
 ### Supported Providers
 
 Model name prefixes determine routing:
-- **OpenAI**: gpt-4.1, gpt-5, gpt-5-mini, gpt-5.2, o4-mini
+- **OpenAI**: gpt-4.1, gpt-5, gpt-5-mini, gpt-5.2, o4-mini; image generation: gpt-image-1
 - **Anthropic**: claude-sonnet-4-0/4-5/4-6, claude-haiku-4-5, claude-opus-4-5/4-6, claude-3-7-sonnet, claude-3-5-haiku
 - **Google**: gemini-2.5-flash, gemini-2.5-flash-lite, gemini-2.5-pro, gemini-3-pro-preview, gemini-3-flash-preview, gemini-3.1-pro-preview, gemini-3.1-flash-lite-preview, gemini-3.5-flash; image generation: gemini-2.5-flash-image, gemini-3.1-flash-image
 - **xAI**: grok-2, grok-3, grok-3-mini, grok-4, grok-4-fast, grok-4-1-fast; image generation: grok-2-image
 - **ByteDance** (BytePlus ModelArk, OpenAI-compatible, ap-southeast): seed-1.6, seed-1.8, seed-2.0-lite; image generation: seedream-4.0
 
-Image generation via xAI (grok-2-image) and ByteDance (seedream-4.0) is served
-through a provider `/images/generations` endpoint rather than the chat path, but
-is surfaced on `/v1/chat/completions` exactly like Gemini's inline-image models
-(images returned out-of-band under the message `images` key). These models are
-billed a flat per-image price (see `per_image_price_usd` in `model_registry.py`),
-not per token.
+Image generation via OpenAI (gpt-image-1), xAI (grok-2-image) and ByteDance
+(seedream-4.0) is served through a provider `/images/generations` endpoint rather
+than the chat path, but is surfaced on `/v1/chat/completions` exactly like
+Gemini's inline-image models (images returned out-of-band under the message
+`images` key). Grok and Seedream are billed a flat per-image price (see
+`per_image_price_usd` in `model_registry.py`); gpt-image-1 has no flat price and
+is billed on the token usage the endpoint reports (text input + generated-image
+output tokens).
 
 ## Verification Examples
 

--- a/tee_gateway/controllers/chat_controller.py
+++ b/tee_gateway/controllers/chat_controller.py
@@ -231,7 +231,7 @@ def _create_image_generation_response(
     """
     langchain_messages = convert_messages(chat_request.messages)
     prompt = _extract_image_prompt(langchain_messages)
-    images, image_count = generate_images(
+    images, image_count, image_usage = generate_images(
         chat_request.model, prompt, n=chat_request.n or 1
     )
 
@@ -259,7 +259,13 @@ def _create_image_generation_response(
         "tee_id": f"0x{tee_keys.get_tee_id()}",
     }
 
-    usage = {"prompt_tokens": 0, "completion_tokens": 0, "total_tokens": 0}
+    # gpt-image-1 reports real token usage we bill on; flat-priced models (Grok,
+    # Seedream) omit it, so fall back to zeros and let image_count drive the cost.
+    usage = image_usage or {
+        "prompt_tokens": 0,
+        "completion_tokens": 0,
+        "total_tokens": 0,
+    }
     openai_response["usage"] = usage
     cost = compute_session_cost(chat_request.model, usage, image_count=image_count)
     if cost is not None:
@@ -280,7 +286,7 @@ def _create_image_generation_streaming_response(
         try:
             langchain_messages = convert_messages(chat_request.messages)
             prompt = _extract_image_prompt(langchain_messages)
-            images, image_count = generate_images(
+            images, image_count, image_usage = generate_images(
                 chat_request.model, prompt, n=chat_request.n or 1
             )
 
@@ -303,7 +309,14 @@ def _create_image_generation_streaming_response(
             if images:
                 final_data["images"] = images
 
-            usage = {"prompt_tokens": 0, "completion_tokens": 0, "total_tokens": 0}
+            # gpt-image-1 reports real token usage we bill on; flat-priced models
+            # (Grok, Seedream) omit it, so fall back to zeros and let image_count
+            # drive the cost.
+            usage = image_usage or {
+                "prompt_tokens": 0,
+                "completion_tokens": 0,
+                "total_tokens": 0,
+            }
             final_data["usage"] = usage
             cost = compute_session_cost(
                 chat_request.model, usage, image_count=image_count

--- a/tee_gateway/llm_backend.py
+++ b/tee_gateway/llm_backend.py
@@ -263,26 +263,55 @@ def get_chat_model_cached(
 _IMAGE_GENERATION_PATH = "/images/generations"
 
 
-def generate_images(model: str, prompt: str, n: int = 1) -> tuple[list[str], int]:
+def _parse_image_usage(raw: Any) -> Optional[Dict[str, int]]:
+    """Normalize an images-endpoint ``usage`` object to token counts.
+
+    OpenAI's gpt-image-1 reports token usage (text input + generated-image
+    output) which we bill on; xAI/ByteDance image endpoints omit usage (they are
+    billed a flat per-image price instead, so ``None`` is returned).
+    """
+    if not isinstance(raw, dict):
+        return None
+    input_tokens = int(raw.get("input_tokens", 0) or 0)
+    output_tokens = int(raw.get("output_tokens", 0) or 0)
+    total_tokens = int(raw.get("total_tokens", input_tokens + output_tokens) or 0)
+    return {
+        "prompt_tokens": input_tokens,
+        "completion_tokens": output_tokens,
+        "total_tokens": total_tokens,
+    }
+
+
+def generate_images(
+    model: str, prompt: str, n: int = 1
+) -> tuple[list[str], int, Optional[Dict[str, int]]]:
     """Generate images via a provider's OpenAI-compatible images endpoint.
 
-    Unlike Gemini's inline-image chat models, xAI (Aurora) and ByteDance
-    (Seedream) expose image generation through a dedicated
+    Unlike Gemini's inline-image chat models, OpenAI (gpt-image-1), xAI (Aurora)
+    and ByteDance (Seedream) expose image generation through a dedicated
     ``POST /images/generations`` endpoint. We request ``b64_json`` so the image
     bytes ride inline inside the OHTTP/TEE envelope rather than as external URLs
     that leak the content and expire.
 
-    Returns ``(data_uris, image_count)`` where each entry is a ``data:`` URI. The
-    count is used for per-image billing. Falls back to provider-returned URLs if
-    a provider ignores ``b64_json``.
+    Returns ``(data_uris, image_count, usage)`` where each entry is a ``data:``
+    URI. ``usage`` is the endpoint's reported token usage (gpt-image-1) used for
+    token-based billing, or ``None`` for providers that omit it (flat per-image
+    billing). Falls back to provider-returned URLs if a provider ignores
+    ``b64_json``.
     """
     cfg = get_model_config(model)
     provider = cfg.provider
 
     if provider == "x-ai":
         client = xai_http_client
+        image_mime = "image/jpeg"
     elif provider == "bytedance":
         client = bytedance_http_client
+        image_mime = "image/jpeg"
+    elif provider == "openai":
+        client = openai_http_client
+        # gpt-image-1 returns PNG by default.
+        image_mime = "image/png"
     else:
         raise ValueError(
             f"Provider {provider!r} does not support the image-generation endpoint"
@@ -297,8 +326,12 @@ def generate_images(model: str, prompt: str, n: int = 1) -> tuple[list[str], int
         "model": cfg.api_name,
         "prompt": prompt,
         "n": count,
-        "response_format": "b64_json",
     }
+    # xAI/ByteDance return expiring URLs unless we request inline base64. OpenAI's
+    # gpt-image-1 always returns base64 and rejects ``response_format`` (HTTP 400),
+    # so only set it for the providers that need it.
+    if provider != "openai":
+        payload["response_format"] = "b64_json"
 
     logger.info(
         "Generating %d image(s) - Provider: %s, Model: %s",
@@ -308,7 +341,8 @@ def generate_images(model: str, prompt: str, n: int = 1) -> tuple[list[str], int
     )
     resp = client.post(_IMAGE_GENERATION_PATH, json=payload)
     resp.raise_for_status()
-    data = resp.json().get("data", []) or []
+    body = resp.json()
+    data = body.get("data", []) or []
 
     images: list[str] = []
     for item in data:
@@ -316,13 +350,14 @@ def generate_images(model: str, prompt: str, n: int = 1) -> tuple[list[str], int
             continue
         b64 = item.get("b64_json")
         if b64:
-            images.append(f"data:image/jpeg;base64,{b64}")
+            images.append(f"data:{image_mime};base64,{b64}")
             continue
         url = item.get("url")
         if url:
             images.append(url)
 
-    return images, len(images)
+    usage = _parse_image_usage(body.get("usage"))
+    return images, len(images), usage
 
 
 def _normalize_user_content_parts(content: list) -> list:

--- a/tee_gateway/model_registry.py
+++ b/tee_gateway/model_registry.py
@@ -27,12 +27,15 @@ class ModelConfig:
     # modality and the controller surfaces the image data on the response message.
     image_output: bool = False
     # Image-generation models served via a dedicated OpenAI-compatible
-    # ``POST /images/generations`` endpoint (e.g. xAI Grok, ByteDance Seedream)
-    # rather than the chat path. These are billed per generated image
-    # (``per_image_price_usd``) instead of per token.
+    # ``POST /images/generations`` endpoint (e.g. OpenAI gpt-image-1, xAI Grok,
+    # ByteDance Seedream) rather than the chat path. Billing depends on what the
+    # provider reports: models with ``per_image_price_usd`` set are charged a flat
+    # price per image (token prices 0); models without it are billed on the token
+    # usage the endpoint returns (e.g. gpt-image-1).
     image_generation: bool = False
-    # Flat USD price per generated image, for ``image_generation`` models. Token
-    # prices are ignored for these models (set to 0 in the registry).
+    # Flat USD price per generated image. When set, ``image_generation`` models are
+    # billed this per image and token prices are ignored (set to 0). Leave unset to
+    # bill on the endpoint's reported token usage instead.
     per_image_price_usd: Optional[Decimal] = None
     # Per-search USD surcharge billed when native web search is used. ``None``
     # means "use the provider default" (see WEB_SEARCH_PRICE_USD_BY_PROVIDER);
@@ -132,6 +135,18 @@ class SupportedModel(Enum):
         api_name="gpt-5.5",
         input_price_usd=Decimal("0.000005"),
         output_price_usd=Decimal("0.00003"),
+    )
+    # Image generation via OpenAI's OpenAI-compatible /images/generations
+    # endpoint (gpt-image-1). Unlike Grok/Seedream's flat per-image price, the
+    # endpoint reports real token usage, so we bill on it: text input at $5/MTok
+    # and generated-image output at $40/MTok. Token prices are therefore real and
+    # per_image_price_usd is intentionally left unset (no flat charge).
+    GPT_IMAGE_1 = ModelConfig(
+        provider="openai",
+        api_name="gpt-image-1",
+        input_price_usd=Decimal("0.000005"),
+        output_price_usd=Decimal("0.00004"),
+        image_generation=True,
     )
 
     # ── Anthropic ───────────────────────────────────────────────────────
@@ -377,6 +392,7 @@ _MODEL_LOOKUP: dict[str, SupportedModel] = {
     "gpt-5.4-mini": SupportedModel.GPT_5_4_MINI,
     "gpt-5.4-nano": SupportedModel.GPT_5_4_NANO,
     "gpt-5.5": SupportedModel.GPT_5_5,
+    "gpt-image-1": SupportedModel.GPT_IMAGE_1,
     # Anthropic
     "claude-sonnet-4-5": SupportedModel.CLAUDE_SONNET_4_5,
     "claude-sonnet-4-6": SupportedModel.CLAUDE_SONNET_4_6,

--- a/tee_gateway/test/test_image_generation.py
+++ b/tee_gateway/test/test_image_generation.py
@@ -24,12 +24,16 @@ from tee_gateway.pricing import compute_session_cost
 
 GROK_IMAGE = "grok-2-image"
 SEEDREAM = "seedream-4.0"
+GPT_IMAGE = "gpt-image-1"
 
 
-def _mock_response(data: list[dict]) -> MagicMock:
+def _mock_response(data: list[dict], usage: dict | None = None) -> MagicMock:
     resp = MagicMock()
     resp.raise_for_status.return_value = None
-    resp.json.return_value = {"data": data}
+    body: dict = {"data": data}
+    if usage is not None:
+        body["usage"] = usage
+    resp.json.return_value = body
     return resp
 
 
@@ -42,9 +46,10 @@ class TestGenerateImages(unittest.TestCase):
             [{"b64_json": "aGVsbG8="}, {"b64_json": "d29ybGQ="}]
         )
         with patch.object(llm_backend, "xai_http_client", client):
-            images, count = generate_images(GROK_IMAGE, "a red cube", n=2)
+            images, count, usage = generate_images(GROK_IMAGE, "a red cube", n=2)
 
         self.assertEqual(count, 2)
+        self.assertIsNone(usage)
         self.assertEqual(
             images,
             [
@@ -65,10 +70,31 @@ class TestGenerateImages(unittest.TestCase):
         client = MagicMock()
         client.post.return_value = _mock_response([{"url": "https://img/1.jpg"}])
         with patch.object(llm_backend, "bytedance_http_client", client):
-            images, count = generate_images(SEEDREAM, "a blue sphere", n=1)
+            images, count, _usage = generate_images(SEEDREAM, "a blue sphere", n=1)
 
         self.assertEqual(count, 1)
         self.assertEqual(images, ["https://img/1.jpg"])
+
+    def test_openai_omits_response_format_and_returns_usage(self):
+        # gpt-image-1 always returns base64 (PNG) and rejects response_format;
+        # it also reports token usage that we bill on.
+        client = MagicMock()
+        client.post.return_value = _mock_response(
+            [{"b64_json": "aW1n"}],
+            usage={"input_tokens": 12, "output_tokens": 1056, "total_tokens": 1068},
+        )
+        with patch.object(llm_backend, "openai_http_client", client):
+            images, count, usage = generate_images(GPT_IMAGE, "a green pyramid", n=1)
+
+        self.assertEqual(count, 1)
+        self.assertEqual(images, ["data:image/png;base64,aW1n"])
+        self.assertEqual(
+            usage,
+            {"prompt_tokens": 12, "completion_tokens": 1056, "total_tokens": 1068},
+        )
+        payload = client.post.call_args.kwargs["json"]
+        self.assertEqual(payload["model"], get_model_config(GPT_IMAGE).api_name)
+        self.assertNotIn("response_format", payload)
 
     def test_n_is_clamped_to_provider_range(self):
         client = MagicMock()
@@ -129,6 +155,19 @@ class TestPerImageBilling(unittest.TestCase):
         cost = compute_session_cost(GROK_IMAGE, self._zero_usage(), image_count=0)
         self.assertIsNotNone(cost)
         self.assertEqual(cost.cost_opg, 0)
+
+    def test_gpt_image_billed_on_tokens_not_flat(self):
+        # gpt-image-1 has no flat per-image price; it is billed on the token usage
+        # the endpoint reports. image_count is passed but must not add any charge.
+        cfg = get_model_config(GPT_IMAGE)
+        self.assertIsNone(cfg.per_image_price_usd)
+        usage = {"prompt_tokens": 12, "completion_tokens": 1056, "total_tokens": 1068}
+        expected_usd = (
+            Decimal(12) * cfg.input_price_usd + Decimal(1056) * cfg.output_price_usd
+        )
+        cost = compute_session_cost(GPT_IMAGE, usage, image_count=1)
+        self.assertIsNotNone(cost)
+        self.assertAlmostEqual(cost.cost_usd, expected_usd, places=9)
 
 
 if __name__ == "__main__":

--- a/tests/test_pricing.py
+++ b/tests/test_pricing.py
@@ -67,12 +67,13 @@ class TestModelRegistry(unittest.TestCase):
                 self.assertIsNotNone(cfg)
                 self.assertIsNotNone(cfg.provider)
                 self.assertIsNotNone(cfg.api_name)
-                if cfg.image_generation:
-                    # Endpoint-based image models (Grok, Seedream) bill a flat
+                if cfg.image_generation and cfg.per_image_price_usd is not None:
+                    # Flat-priced endpoint image models (Grok, Seedream) bill a
                     # per-image price; their token prices are intentionally 0.
-                    self.assertIsNotNone(cfg.per_image_price_usd)
                     self.assertGreater(cfg.per_image_price_usd, 0)
                 else:
+                    # Chat models and token-billed image models (gpt-image-1)
+                    # must have real per-token prices.
                     self.assertGreater(cfg.input_price_usd, 0)
                     self.assertGreater(cfg.output_price_usd, 0)
 


### PR DESCRIPTION
Routes gpt-image-1 through the existing /images/generations endpoint path (like Grok/Seedream). Unlike those flat-priced models, gpt-image-1 is billed on the real token usage the endpoint reports (text input + generated-image output tokens), so its token prices are set and per_image_price_usd is left unset.

- generate_images now supports the openai provider, omits response_format (gpt-image-1 always returns base64 and rejects it), uses PNG mime, and returns the endpoint's token usage.
- Chat controller threads that usage into compute_session_cost for both streaming and non-streaming image paths.
- Tests + docs updated.

https://claude.ai/code/session_01Ux3BMHiKKKAmTLqCwfFo9R