### PR TITLE
Add file content part support for multimodal chat completions

### DIFF
--- a/tee_gateway/openapi/openapi.yaml
+++ b/tee_gateway/openapi/openapi.yaml
@@ -2092,6 +2092,45 @@ components:
       - type
       title: Image content part
       type: object
+    ChatCompletionRequestMessageContentPartFile:
+      description: |
+        Learn about [file inputs](/docs/guides/text-generation) for text generation.
+      properties:
+        type:
+          description: The type of the content part. Always `file`.
+          enum:
+          - file
+          title: type
+          type: string
+        file:
+          $ref: "#/components/schemas/ChatCompletionRequestMessageContentPartFile_file"
+      required:
+      - file
+      - type
+      title: File content part
+      type: object
+    ChatCompletionRequestMessageContentPartFile_file:
+      description: |
+        The file to pass to the model. Either inline base64 data (`file_data`,
+        optionally with a `filename`) or a reference to a previously uploaded
+        file (`file_id`).
+      properties:
+        filename:
+          description: The name of the file, used when passing the file to the model
+            as inline data.
+          title: filename
+          type: string
+        file_data:
+          description: The base64 encoded file data (data URI), used when passing
+            the file to the model as inline data.
+          title: file_data
+          type: string
+        file_id:
+          description: The ID of an uploaded file to use as input.
+          title: file_id
+          type: string
+      title: ChatCompletionRequestMessageContentPartFile_file
+      type: object
     ChatCompletionRequestMessageContentPartRefusal:
       properties:
         type:
@@ -2204,6 +2243,7 @@ components:
       - $ref: "#/components/schemas/ChatCompletionRequestMessageContentPartText"
       - $ref: "#/components/schemas/ChatCompletionRequestMessageContentPartImage"
       - $ref: "#/components/schemas/ChatCompletionRequestMessageContentPartAudio"
+      - $ref: "#/components/schemas/ChatCompletionRequestMessageContentPartFile"
       title: ChatCompletionRequestUserMessageContentPart
       x-oaiExpandable: true
     ChatCompletionResponseMessage:

--- a/tee_gateway/test/test_chat_controller.py
+++ b/tee_gateway/test/test_chat_controller.py
@@ -1,8 +1,73 @@
 import unittest
 
+import connexion
 from flask import json
 
+from tee_gateway.encoder import JSONEncoder
 from tee_gateway.test import BaseTestCase
+
+
+def _build_app():
+    """Build a connexion app from the OpenAPI spec for request-validation tests.
+
+    Kept independent of ``BaseTestCase`` (which needs the optional
+    ``flask_testing`` dep) so this runs in the lean ``test`` dep group.
+    """
+    app = connexion.App(__name__, specification_dir="../openapi/")
+    app.app.json_encoder = JSONEncoder
+    app.add_api("openapi.yaml", pythonic_params=True)
+    return app.app
+
+
+class TestUserMessageContentPartValidation(unittest.TestCase):
+    """Schema-validation tests for multimodal user-message content parts.
+
+    Regression guard for the "secure attachments" feature: PDF attachments
+    arrive as OpenAI ``file`` content parts and must survive connexion's
+    request-body validation (the OHTTP inner request runs through the full
+    validation pipeline). Before the ``file`` branch was added to the user
+    content-part ``oneOf``, PDFs were rejected with a 400 while images passed.
+    """
+
+    def setUp(self):
+        self.client = _build_app().test_client()
+
+    def _post(self, part):
+        body = {
+            "model": "gpt-4.1",
+            "messages": [
+                {"role": "user", "content": [{"type": "text", "text": "hi"}, part]}
+            ],
+        }
+        return self.client.post(
+            "/v1/chat/completions",
+            data=json.dumps(body),
+            content_type="application/json",
+            headers={"Authorization": "Bearer test"},
+        )
+
+    def test_image_part_passes_schema_validation(self):
+        resp = self._post(
+            {
+                "type": "image_url",
+                "image_url": {"url": "data:image/jpeg;base64,/9j/4AAQ"},
+            }
+        )
+        # Passes validation; only fails later (500) because no provider keys
+        # are injected in this unit test. The point is it is NOT a 400.
+        self.assertNotEqual(400, resp.status_code, resp.data.decode("utf-8"))
+
+    def test_pdf_file_part_passes_schema_validation(self):
+        resp = self._post(
+            {
+                "type": "file",
+                "file": {
+                    "filename": "doc.pdf",
+                    "file_data": "data:application/pdf;base64,JVBERi0x",
+                },
+            }
+        )
+        self.assertNotEqual(400, resp.status_code, resp.data.decode("utf-8"))
 
 
 class TestChatController(BaseTestCase):


### PR DESCRIPTION
## Summary
Adds support for file content parts in multimodal chat completion requests, enabling the gateway to handle PDF attachments and other file inputs alongside text and image content. This is a prerequisite for the "secure attachments" feature where PDF files arrive as OpenAI `file` content parts.

## Changes

- **OpenAPI Schema**: Added `ChatCompletionRequestMessageContentPartFile` schema with nested `file` object supporting three input modes:
  - `file_data`: Base64-encoded inline file data (with optional `filename`)
  - `file_id`: Reference to a previously uploaded file
  - `filename`: Name hint for inline data
  
  Updated the `ChatCompletionRequestUserMessageContentPart` `oneOf` union to include the new file part type alongside existing text, image, and audio parts.

- **Test Coverage**: Added `TestUserMessageContentPartValidation` unit test class with schema-validation regression tests:
  - `test_image_part_passes_schema_validation`: Verifies image content parts pass validation (baseline)
  - `test_pdf_file_part_passes_schema_validation`: Verifies file content parts with PDF data pass validation
  
  Tests use a standalone `_build_app()` helper to build a connexion app directly from the OpenAPI spec, avoiding the optional `flask_testing` dependency and ensuring validation runs in the lean test environment.

## Implementation Details

- File parts are validated at the connexion request-body validation layer, the same pipeline that processes OHTTP inner requests
- The schema allows flexible file input modes (inline base64, file ID, or filename) to support various attachment workflows
- Tests confirm that PDFs no longer receive 400 validation errors (they may fail later with 500 if provider keys are missing, but that's expected in unit tests)

https://claude.ai/code/session_01HF83iVseKjA673AM4n4uN2