### PR TITLE
Add Nous Research (Nous Portal) provider support

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -66,6 +66,7 @@ API keys (injected at runtime via POST /v1/keys — do NOT bake into the image):
 - `GOOGLE_API_KEY`
 - `XAI_API_KEY`
 - `ARK_API_KEY` (BytePlus / ByteDance ModelArk; injected as `bytedance_api_key`)
+- `NOUS_API_KEY` (Nous Research / Nous Portal; injected as `nous_api_key`)
 
 Server configuration:
 - `API_SERVER_PORT` (default: 8000)
@@ -116,6 +117,7 @@ Model name prefixes determine routing:
 - **Google**: gemini-2.5-flash, gemini-2.5-flash-lite, gemini-2.5-pro, gemini-3-pro-preview, gemini-3-flash-preview, gemini-3.1-pro-preview, gemini-3.1-flash-lite-preview, gemini-3.5-flash; image generation: gemini-2.5-flash-image, gemini-3.1-flash-image
 - **xAI**: grok-2, grok-3, grok-3-mini, grok-4, grok-4-fast, grok-4-1-fast; image generation: grok-2-image
 - **ByteDance** (BytePlus ModelArk, OpenAI-compatible, ap-southeast): seed-1.6, seed-1.8, seed-2.0-lite; image generation: seedream-4.0
+- **Nous Research** (Nous Portal, OpenAI-compatible): hermes-4-405b, hermes-4-70b
 
 Image generation via xAI (grok-2-image) and ByteDance (seedream-4.0) is served
 through a provider `/images/generations` endpoint rather than the chat path, but

--- a/scripts/run-enclave.sh
+++ b/scripts/run-enclave.sh
@@ -90,6 +90,7 @@ if [ -f "$ENV_FILE" ]; then
         ANTHROPIC_API_KEY="$(grep -E '^ANTHROPIC_API_KEY=' "$ENV_FILE" | cut -d'=' -f2-)"
         XAI_API_KEY="$(grep -E '^XAI_API_KEY=' "$ENV_FILE" | cut -d'=' -f2-)"
         ARK_API_KEY="$(grep -E '^ARK_API_KEY=' "$ENV_FILE" | cut -d'=' -f2-)"
+        NOUS_API_KEY="$(grep -E '^NOUS_API_KEY=' "$ENV_FILE" | cut -d'=' -f2-)"
 
         # FACILITATOR_URL is used for both x402 payment verification and the heartbeat relay.
         # HEARTBEAT_CONTRACT_ADDRESS and TEE_HEARTBEAT_INTERVAL are optional heartbeat parameters.
@@ -106,6 +107,7 @@ if [ -f "$ENV_FILE" ]; then
             --arg anthropic "$ANTHROPIC_API_KEY" \
             --arg xai "$XAI_API_KEY" \
             --arg bytedance "$ARK_API_KEY" \
+            --arg nous "$NOUS_API_KEY" \
             --arg hb_contract "$HEARTBEAT_CONTRACT_ADDRESS" \
             --arg facilitator "$FACILITATOR_URL" \
             --arg hb_interval "$TEE_HEARTBEAT_INTERVAL" \
@@ -114,7 +116,8 @@ if [ -f "$ENV_FILE" ]; then
                 google_api_key: $google,
                 anthropic_api_key: $anthropic,
                 xai_api_key: $xai,
-                bytedance_api_key: $bytedance
+                bytedance_api_key: $bytedance,
+                nous_api_key: $nous
             }
             + if $hb_contract != "" then {heartbeat_contract_address: $hb_contract} else {} end
             + if $facilitator != "" then {facilitator_url: $facilitator} else {} end

--- a/tee_gateway/__main__.py
+++ b/tee_gateway/__main__.py
@@ -393,6 +393,7 @@ def set_provider_keys():
             google_api_key=body.get("google_api_key") or None,
             xai_api_key=body.get("xai_api_key") or None,
             bytedance_api_key=body.get("bytedance_api_key") or None,
+            nous_api_key=body.get("nous_api_key") or None,
         )
         set_provider_config(provider_config)
 
@@ -452,6 +453,9 @@ def set_provider_keys():
             "  bytedance_api_key           : %s",
             _set(provider_config.bytedance_api_key),
         )
+        logger.info(
+            "  nous_api_key                : %s", _set(provider_config.nous_api_key)
+        )
         logger.info("  facilitator_url             : %s", facilitator_url)
         logger.info(
             "  heartbeat_contract_address  : %s",
@@ -484,6 +488,7 @@ def set_provider_keys():
             "anthropic": provider_config.anthropic_api_key,
             "xai": provider_config.xai_api_key,
             "bytedance": provider_config.bytedance_api_key,
+            "nous": provider_config.nous_api_key,
         }.items()
         if k
     ]

--- a/tee_gateway/config.py
+++ b/tee_gateway/config.py
@@ -28,6 +28,7 @@ class ProviderConfig:
     google_api_key: Optional[str] = None
     xai_api_key: Optional[str] = None
     bytedance_api_key: Optional[str] = None
+    nous_api_key: Optional[str] = None
 
     def initialized_providers(self) -> list[str]:
         """Return provider names whose API key is set (non-empty)."""
@@ -42,6 +43,8 @@ class ProviderConfig:
             providers.append("xai")
         if self.bytedance_api_key:
             providers.append("bytedance")
+        if self.nous_api_key:
+            providers.append("nous")
         return providers
 
 

--- a/tee_gateway/llm_backend.py
+++ b/tee_gateway/llm_backend.py
@@ -50,11 +50,15 @@ _LIMITS = httpx.Limits(
 # BytePlus ModelArk OpenAI-compatible endpoint (ap-southeast)
 BYTEDANCE_BASE_URL = "https://ark.ap-southeast.bytepluses.com/api/v3"
 
+# Nous Research OpenAI-compatible inference endpoint (Nous Portal).
+NOUS_BASE_URL = "https://inference-api.nousresearch.com/v1"
+
 # Shared synchronous HTTP clients for each provider.
 # Initialized to None; built by set_provider_config() after key injection.
 openai_http_client: Optional[httpx.Client] = None
 xai_http_client: Optional[httpx.Client] = None
 bytedance_http_client: Optional[httpx.Client] = None
+nous_http_client: Optional[httpx.Client] = None
 
 
 _provider_config: Optional[ProviderConfig] = None
@@ -63,10 +67,12 @@ _provider_config: Optional[ProviderConfig] = None
 def set_provider_config(config: ProviderConfig) -> None:
     """Store the provider config and rebuild HTTP clients. Called once after key injection."""
     global _provider_config, openai_http_client, xai_http_client, bytedance_http_client
+    global nous_http_client
 
     old_openai = openai_http_client
     old_xai = xai_http_client
     old_bytedance = bytedance_http_client
+    old_nous = nous_http_client
 
     openai_http_client = httpx.Client(
         base_url="https://api.openai.com/v1",
@@ -92,6 +98,14 @@ def set_provider_config(config: ProviderConfig) -> None:
         http2=True,
         follow_redirects=False,
     )
+    nous_http_client = httpx.Client(
+        base_url=NOUS_BASE_URL,
+        headers={"Authorization": f"Bearer {config.nous_api_key or ''}"},
+        timeout=_TIMEOUT,
+        limits=_LIMITS,
+        http2=True,
+        follow_redirects=False,
+    )
 
     get_chat_model_cached.cache_clear()
     _provider_config = config
@@ -102,6 +116,8 @@ def set_provider_config(config: ProviderConfig) -> None:
         old_xai.close()
     if old_bytedance is not None:
         old_bytedance.close()
+    if old_nous is not None:
+        old_nous.close()
 
 
 def get_provider_config() -> Optional[ProviderConfig]:
@@ -251,6 +267,24 @@ def get_chat_model_cached(
             http_client=bytedance_http_client,
             api_key=SecretStr(config.bytedance_api_key),
             base_url=BYTEDANCE_BASE_URL,
+            streaming=True,
+            stream_usage=True,
+        )  # type: ignore [call-arg]
+
+    elif provider == "nous":
+        if not config.nous_api_key:
+            raise ValueError("nous_api_key not set in ProviderConfig")
+
+        if nous_http_client is None:
+            raise RuntimeError("Nous HTTP client has not been initialized")
+
+        return ChatOpenAI(
+            model=api_name,
+            temperature=effective_temp,
+            max_tokens=max_tokens,
+            http_client=nous_http_client,
+            api_key=SecretStr(config.nous_api_key),
+            base_url=NOUS_BASE_URL,
             streaming=True,
             stream_usage=True,
         )  # type: ignore [call-arg]

--- a/tee_gateway/model_registry.py
+++ b/tee_gateway/model_registry.py
@@ -13,7 +13,7 @@ from typing import Optional
 
 @dataclass(frozen=True)
 class ModelConfig:
-    provider: str  # "openai" | "anthropic" | "google" | "x-ai" | "bytedance"
+    provider: str  # "openai" | "anthropic" | "google" | "x-ai" | "bytedance" | "nous"
     api_name: str  # model name sent to provider API
     input_price_usd: Decimal  # USD per token
     output_price_usd: Decimal  # USD per token
@@ -354,6 +354,22 @@ class SupportedModel(Enum):
         per_image_price_usd=Decimal("0.03"),
     )
 
+    # ── Nous Research (Nous Portal, OpenAI-compatible) ──────────────────
+    # Hermes 4 family, served via Nous's OpenAI-compatible inference API.
+    # Pricing mirrors Nous Portal's published per-token rates.
+    HERMES_4_405B = ModelConfig(
+        provider="nous",
+        api_name="hermes-4-405b",
+        input_price_usd=Decimal("0.00000009"),
+        output_price_usd=Decimal("0.00000037"),
+    )
+    HERMES_4_70B = ModelConfig(
+        provider="nous",
+        api_name="hermes-4-70b",
+        input_price_usd=Decimal("0.00000013"),
+        output_price_usd=Decimal("0.0000004"),
+    )
+
     # ── Legacy models (not in current SDK — retained for older SDK versions) ──
     GROK_3_MINI = ModelConfig(
         provider="x-ai",
@@ -430,6 +446,9 @@ _MODEL_LOOKUP: dict[str, SupportedModel] = {
     "seedream-4-0-250828": SupportedModel.SEEDREAM_4_0,
     "seedream-4.0": SupportedModel.SEEDREAM_4_0,
     "seedream-4-0": SupportedModel.SEEDREAM_4_0,
+    # Nous Research
+    "hermes-4-405b": SupportedModel.HERMES_4_405B,
+    "hermes-4-70b": SupportedModel.HERMES_4_70B,
     # Legacy — not in current SDK, retained for older SDK versions
     "grok-3-mini-beta": SupportedModel.GROK_3_MINI,  # old beta alias
     "grok-3-mini": SupportedModel.GROK_3_MINI,

--- a/tests/test_pricing.py
+++ b/tests/test_pricing.py
@@ -329,6 +329,22 @@ class TestModelRegistry(unittest.TestCase):
         cfg = get_model_config("seed-2-0-lite-260228")
         self.assertEqual(cfg, get_model_config("seed-2.0-lite"))
 
+    # ── Nous Research (Nous Portal) ─────────────────────────────────────────
+
+    def test_hermes_4_405b_resolves(self):
+        cfg = get_model_config("hermes-4-405b")
+        self.assertEqual(cfg.provider, "nous")
+        self.assertEqual(cfg.api_name, "hermes-4-405b")
+        self.assertEqual(cfg.input_price_usd, Decimal("0.00000009"))
+        self.assertEqual(cfg.output_price_usd, Decimal("0.00000037"))
+
+    def test_hermes_4_70b_resolves(self):
+        cfg = get_model_config("hermes-4-70b")
+        self.assertEqual(cfg.provider, "nous")
+        self.assertEqual(cfg.api_name, "hermes-4-70b")
+        self.assertEqual(cfg.input_price_usd, Decimal("0.00000013"))
+        self.assertEqual(cfg.output_price_usd, Decimal("0.0000004"))
+
     # ── Errors ───────────────────────────────────────────────────────────────
 
     def test_unknown_model_raises(self):


### PR DESCRIPTION
## Summary
Adds support for Nous Research's OpenAI-compatible inference API (Nous Portal) as a new LLM provider, enabling routing to Hermes 4 models (405B and 70B variants).

## Changes

### Core Provider Integration
- **`llm_backend.py`**: 
  - Added `NOUS_BASE_URL` constant for Nous Portal endpoint
  - Created `nous_http_client` global HTTP client with proper initialization and cleanup
  - Implemented provider routing logic in `get_chat_model_cached()` to instantiate `ChatOpenAI` with Nous credentials
  - Added validation for `nous_api_key` presence and client initialization

### Model Registry
- **`model_registry.py`**:
  - Added two Nous Research models to `SupportedModel` enum:
    - `HERMES_4_405B`: 0.09µ/input, 0.37µ/output
    - `HERMES_4_70B`: 0.13µ/input, 0.4µ/output
  - Updated provider type hint to include "nous"
  - Added model name aliases for routing (`hermes-4-405b`, `hermes-4-70b`)

### Configuration & Deployment
- **`config.py`**: Added `nous_api_key` field to `ProviderConfig` dataclass and `initialized_providers()` method
- **`__main__.py`**: 
  - Extract `nous_api_key` from POST `/v1/keys` request body
  - Log Nous API key status on startup
  - Include Nous in provider availability check
- **`scripts/run-enclave.sh`**: Extract `NOUS_API_KEY` from environment file and pass to jq config builder

### Testing
- **`tests/test_pricing.py`**: Added unit tests for both Hermes 4 models verifying provider, API name, and pricing

### Documentation
- **`CLAUDE.md`**: Updated supported providers list to include Nous Research with model names

## Implementation Details
- Follows existing provider pattern (OpenAI-compatible HTTP client with Bearer token auth)
- Uses same timeout/limits/HTTP2 configuration as other providers
- Integrates seamlessly with existing model routing and pricing infrastructure
- No dependency changes required (uses existing LangChain `ChatOpenAI` class)

https://claude.ai/code/session_01PKm4v3Rtj184ZsnC6CMkbi