### PR TITLE
Fix Nous Research model API names to match case-sensitive API

### DIFF
--- a/tee_gateway/model_registry.py
+++ b/tee_gateway/model_registry.py
@@ -357,15 +357,20 @@ class SupportedModel(Enum):
     # ── Nous Research (Nous Portal, OpenAI-compatible) ──────────────────
     # Hermes 4 family, served via Nous's OpenAI-compatible inference API.
     # Pricing mirrors Nous Portal's published per-token rates.
+    #
+    # The Nous inference API is an OpenRouter-style aggregator: model ids are
+    # namespaced as "<org>/<model>" (e.g. "nousresearch/hermes-4-405b"). The bare
+    # "hermes-4-405b" form is NOT an accepted alias and is rejected with HTTP 400,
+    # so the provider-facing api_name must carry the "nousresearch/" prefix.
     HERMES_4_405B = ModelConfig(
         provider="nous",
-        api_name="hermes-4-405b",
+        api_name="nousresearch/hermes-4-405b",
         input_price_usd=Decimal("0.00000009"),
         output_price_usd=Decimal("0.00000037"),
     )
     HERMES_4_70B = ModelConfig(
         provider="nous",
-        api_name="hermes-4-70b",
+        api_name="nousresearch/hermes-4-70b",
         input_price_usd=Decimal("0.00000013"),
         output_price_usd=Decimal("0.0000004"),
     )

--- a/tee_gateway/model_registry.py
+++ b/tee_gateway/model_registry.py
@@ -358,19 +358,19 @@ class SupportedModel(Enum):
     # Hermes 4 family, served via Nous's OpenAI-compatible inference API.
     # Pricing mirrors Nous Portal's published per-token rates.
     #
-    # The Nous inference API is an OpenRouter-style aggregator: model ids are
-    # namespaced as "<org>/<model>" (e.g. "nousresearch/hermes-4-405b"). The bare
-    # "hermes-4-405b" form is NOT an accepted alias and is rejected with HTTP 400,
-    # so the provider-facing api_name must carry the "nousresearch/" prefix.
+    # The Nous inference API is an OpenRouter-style aggregator with case-sensitive
+    # model-id matching. The bare lowercase "hermes-4-70b" is NOT an accepted
+    # alias and is rejected with HTTP 400; the accepted form is the capitalized
+    # "Hermes-4-70B" (the canonical id "nousresearch/hermes-4-70b" also works).
     HERMES_4_405B = ModelConfig(
         provider="nous",
-        api_name="nousresearch/hermes-4-405b",
+        api_name="Hermes-4-405B",
         input_price_usd=Decimal("0.00000009"),
         output_price_usd=Decimal("0.00000037"),
     )
     HERMES_4_70B = ModelConfig(
         provider="nous",
-        api_name="nousresearch/hermes-4-70b",
+        api_name="Hermes-4-70B",
         input_price_usd=Decimal("0.00000013"),
         output_price_usd=Decimal("0.0000004"),
     )

--- a/tests/test_pricing.py
+++ b/tests/test_pricing.py
@@ -334,14 +334,14 @@ class TestModelRegistry(unittest.TestCase):
     def test_hermes_4_405b_resolves(self):
         cfg = get_model_config("hermes-4-405b")
         self.assertEqual(cfg.provider, "nous")
-        self.assertEqual(cfg.api_name, "nousresearch/hermes-4-405b")
+        self.assertEqual(cfg.api_name, "Hermes-4-405B")
         self.assertEqual(cfg.input_price_usd, Decimal("0.00000009"))
         self.assertEqual(cfg.output_price_usd, Decimal("0.00000037"))
 
     def test_hermes_4_70b_resolves(self):
         cfg = get_model_config("hermes-4-70b")
         self.assertEqual(cfg.provider, "nous")
-        self.assertEqual(cfg.api_name, "nousresearch/hermes-4-70b")
+        self.assertEqual(cfg.api_name, "Hermes-4-70B")
         self.assertEqual(cfg.input_price_usd, Decimal("0.00000013"))
         self.assertEqual(cfg.output_price_usd, Decimal("0.0000004"))
 

--- a/tests/test_pricing.py
+++ b/tests/test_pricing.py
@@ -334,14 +334,14 @@ class TestModelRegistry(unittest.TestCase):
     def test_hermes_4_405b_resolves(self):
         cfg = get_model_config("hermes-4-405b")
         self.assertEqual(cfg.provider, "nous")
-        self.assertEqual(cfg.api_name, "hermes-4-405b")
+        self.assertEqual(cfg.api_name, "nousresearch/hermes-4-405b")
         self.assertEqual(cfg.input_price_usd, Decimal("0.00000009"))
         self.assertEqual(cfg.output_price_usd, Decimal("0.00000037"))
 
     def test_hermes_4_70b_resolves(self):
         cfg = get_model_config("hermes-4-70b")
         self.assertEqual(cfg.provider, "nous")
-        self.assertEqual(cfg.api_name, "hermes-4-70b")
+        self.assertEqual(cfg.api_name, "nousresearch/hermes-4-70b")
         self.assertEqual(cfg.input_price_usd, Decimal("0.00000013"))
         self.assertEqual(cfg.output_price_usd, Decimal("0.0000004"))
 


### PR DESCRIPTION
## Summary
Corrects the Nous Research Hermes model API names to use the proper capitalized format required by the Nous inference API, which enforces case-sensitive model-id matching.

## Changes
- Updated `HERMES_4_405B` model config: `api_name` changed from `"hermes-4-405b"` to `"Hermes-4-405B"`
- Updated `HERMES_4_70B` model config: `api_name` changed from `"hermes-4-70b"` to `"Hermes-4-70B"`
- Added documentation comment explaining that the Nous API is case-sensitive and rejects the bare lowercase form with HTTP 400
- Updated corresponding test assertions to expect the capitalized API names

## Details
The Nous inference API operates as an OpenRouter-style aggregator with strict case-sensitive model-id matching. The lowercase forms (`hermes-4-405b`, `hermes-4-70b`) are rejected with HTTP 400 errors. The accepted form is the capitalized variant (`Hermes-4-405B`, `Hermes-4-70B`), though the canonical id format (`nousresearch/hermes-4-70b`) also works.

This fix ensures that requests to Nous Research models will use the correct API names and succeed without HTTP 400 errors.

https://claude.ai/code/session_01RrpWdThAsUepVHEUipEUQq