### PR TITLE
Add Claude Fable 5 model support

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -113,7 +113,7 @@ Server configuration:
 
 Model name prefixes determine routing:
 - **OpenAI**: gpt-4.1, gpt-5, gpt-5-mini, gpt-5.2, o4-mini
-- **Anthropic**: claude-sonnet-4-0/4-5/4-6, claude-haiku-4-5, claude-opus-4-5/4-6, claude-3-7-sonnet, claude-3-5-haiku
+- **Anthropic**: claude-sonnet-4-0/4-5/4-6, claude-haiku-4-5, claude-opus-4-5/4-6/4-7/4-8, claude-fable-5, claude-3-7-sonnet, claude-3-5-haiku
 - **Google**: gemini-2.5-flash, gemini-2.5-flash-lite, gemini-2.5-pro, gemini-3-pro-preview, gemini-3-flash-preview, gemini-3.1-pro-preview, gemini-3.1-flash-lite-preview, gemini-3.5-flash; image generation: gemini-2.5-flash-image, gemini-3.1-flash-image
 - **xAI**: grok-2, grok-3, grok-3-mini, grok-4, grok-4-fast, grok-4-1-fast; image generation: grok-2-image
 - **ByteDance** (BytePlus ModelArk, OpenAI-compatible, ap-southeast): seed-1.6, seed-1.8, seed-2.0-lite; image generation: seedream-4.0

--- a/tee_gateway/model_registry.py
+++ b/tee_gateway/model_registry.py
@@ -187,6 +187,16 @@ class SupportedModel(Enum):
         output_price_usd=Decimal("0.000025"),
         supports_temperature=False,
     )
+    # Claude Fable 5 — Anthropic's most capable widely released model (GA on the
+    # first-party API from 2026-06-09). Adaptive-thinking-only; like Opus 4.7+ it
+    # rejects `temperature` (HTTP 400), so supports_temperature=False.
+    CLAUDE_FABLE_5 = ModelConfig(
+        provider="anthropic",
+        api_name="claude-fable-5",
+        input_price_usd=Decimal("0.00001"),
+        output_price_usd=Decimal("0.00005"),
+        supports_temperature=False,
+    )
 
     # ── Google Gemini ───────────────────────────────────────────────────
     # Note: gemini-2.5-flash, gemini-2.5-pro, and gemini-2.5-flash-lite are scheduled
@@ -418,6 +428,7 @@ _MODEL_LOOKUP: dict[str, SupportedModel] = {
     "claude-opus-4-6": SupportedModel.CLAUDE_OPUS_4_6,
     "claude-opus-4-7": SupportedModel.CLAUDE_OPUS_4_7,
     "claude-opus-4-8": SupportedModel.CLAUDE_OPUS_4_8,
+    "claude-fable-5": SupportedModel.CLAUDE_FABLE_5,
     # Google
     "gemini-2.5-flash": SupportedModel.GEMINI_2_5_FLASH,
     "gemini-2.5-pro": SupportedModel.GEMINI_2_5_PRO,

--- a/tests/test_pricing.py
+++ b/tests/test_pricing.py
@@ -118,6 +118,15 @@ class TestModelRegistry(unittest.TestCase):
         # Opus 4.7+ rejects the `temperature` field (HTTP 400)
         self.assertFalse(cfg.supports_temperature)
 
+    def test_claude_fable_5_resolves(self):
+        cfg = get_model_config("claude-fable-5")
+        self.assertEqual(cfg.provider, "anthropic")
+        self.assertEqual(cfg.api_name, "claude-fable-5")
+        self.assertEqual(cfg.input_price_usd, Decimal("0.00001"))
+        self.assertEqual(cfg.output_price_usd, Decimal("0.00005"))
+        # Adaptive-thinking-only; rejects the `temperature` field (HTTP 400)
+        self.assertFalse(cfg.supports_temperature)
+
     # ── OpenAI ──────────────────────────────────────────────────────────────
 
     def test_gpt_4_1_resolves(self):


### PR DESCRIPTION
## Summary
Add support for Anthropic's Claude Fable 5 model to the TEE gateway. This is Anthropic's most capable widely released model, available on the first-party API from 2026-06-09.

## Changes
- **Model Registry**: Added `CLAUDE_FABLE_5` enum entry with Anthropic provider configuration
  - API name: `claude-fable-5`
  - Input pricing: $0.00001 per token
  - Output pricing: $0.00005 per token
  - `supports_temperature=False` (adaptive-thinking-only model rejects temperature parameter with HTTP 400, similar to Opus 4.7+)
- **Model Mapping**: Registered `"claude-fable-5"` string key in the model name lookup dictionary
- **Tests**: Added `test_claude_fable_5_resolves()` to verify model configuration resolution and pricing
- **Documentation**: Updated `CLAUDE.md` to include Claude Fable 5 in the list of supported Anthropic model prefixes

## Implementation Details
Claude Fable 5 is an adaptive-thinking-only model that does not support the `temperature` parameter (returns HTTP 400 if provided), consistent with recent Opus models (4.7+). The pricing reflects the model's capability tier relative to other Claude variants.

https://claude.ai/code/session_01RawhhYfSfUkatbo7WUvoEA