### PR TITLE
Increase Anthropic API read timeout to 180 seconds

### DIFF
--- a/tee_gateway/llm_backend.py
+++ b/tee_gateway/llm_backend.py
@@ -31,12 +31,12 @@ from tee_gateway.model_registry import get_model_config
 logger = logging.getLogger(__name__)
 
 # HTTP Client Configuration
-ANTHROPIC_TIMEOUT = 120.0
+READ_TIMEOUT = 180.0
 
 _TIMEOUT = httpx.Timeout(
     timeout=120.0,
     connect=15.0,
-    read=60.0,
+    read=READ_TIMEOUT,
     write=60.0,
     pool=10.0,
 )
@@ -242,7 +242,7 @@ def get_chat_model_cached(
             api_key=SecretStr(config.anthropic_api_key),
             temperature=anthropic_temperature,
             max_tokens=max_tokens,
-            timeout=ANTHROPIC_TIMEOUT,
+            timeout=READ_TIMEOUT,
             streaming=True,
             stream_usage=True,
         )  # type: ignore [call-arg]


### PR DESCRIPTION
## Summary
Increases the HTTP read timeout for Anthropic API requests from 60 seconds to 180 seconds to accommodate longer response times from the Anthropic backend.

## Changes
- Renamed `ANTHROPIC_TIMEOUT` constant to `READ_TIMEOUT` for clarity (180.0 seconds)
- Updated the httpx `Timeout` configuration to use the new `READ_TIMEOUT` constant for the `read` parameter (previously hardcoded to 60.0)
- Updated the Anthropic client instantiation to use `READ_TIMEOUT` instead of the old `ANTHROPIC_TIMEOUT` constant

## Details
The read timeout was increased from 60 to 180 seconds to provide more headroom for Anthropic API responses, which may take longer to generate depending on model complexity and load. The constant was renamed to better reflect its purpose as a read-specific timeout rather than a general Anthropic timeout, improving code clarity for future maintenance.

https://claude.ai/code/session_01D2q3s89NMUGT5RA4KYq8vh