### PR TITLE
Add OpenAI gpt-image-2 image generation support

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -114,7 +114,7 @@ Server configuration:
 ### Supported Providers
 
 Model name prefixes determine routing:
-- **OpenAI**: gpt-4.1, gpt-5, gpt-5-mini, gpt-5.2, o4-mini
+- **OpenAI**: gpt-4.1, gpt-5, gpt-5-mini, gpt-5.2, o4-mini; image generation: gpt-image-2
 - **Anthropic**: claude-sonnet-4-0/4-5/4-6, claude-haiku-4-5, claude-opus-4-5/4-6/4-7/4-8, claude-fable-5, claude-3-7-sonnet, claude-3-5-haiku
 - **Google**: gemini-2.5-flash, gemini-2.5-flash-lite, gemini-2.5-pro, gemini-3-pro-preview, gemini-3-flash-preview, gemini-3.1-pro-preview, gemini-3.1-flash-lite-preview, gemini-3.5-flash; image generation: gemini-2.5-flash-image, gemini-3.1-flash-image
 - **xAI**: grok-2, grok-3, grok-3-mini, grok-4, grok-4-fast, grok-4-1-fast; image generation: grok-2-image
@@ -122,9 +122,9 @@ Model name prefixes determine routing:
 - **Nous Research** (Nous Portal, OpenAI-compatible): hermes-4-405b, hermes-4-70b
 - **Z.ai** (Model API, OpenAI-compatible): glm-5.2; image generation: glm-image
 
-Image generation via xAI (grok-2-image), ByteDance (seedream-4.0,
-seedream-5.0-lite, seedance-4.5), and Z.ai (glm-image) is served through a
-provider `/images/generations` endpoint rather than the chat path (see
+Image generation via OpenAI (gpt-image-2), xAI (grok-2-image), ByteDance
+(seedream-4.0, seedream-5.0-lite, seedance-4.5), and Z.ai (glm-image) is served
+through a provider `/images/generations` endpoint rather than the chat path (see
 `image_generation.py`), but is surfaced on `/v1/chat/completions` exactly like
 Gemini's inline-image models (images returned out-of-band under the message
 `images` key). The client always receives inline bytes: providers that hand back

--- a/tee_gateway/image_generation.py
+++ b/tee_gateway/image_generation.py
@@ -1,9 +1,9 @@
 """Endpoint-based image generation.
 
-xAI (Aurora), ByteDance (Seedream/Seedance) and Z.ai (GLM-Image) expose image
-generation through a dedicated OpenAI-compatible ``POST /images/generations``
-endpoint rather than the chat path. This module owns everything specific to that
-flow:
+OpenAI (gpt-image), xAI (Aurora), ByteDance (Seedream/Seedance) and Z.ai
+(GLM-Image) expose image generation through a dedicated OpenAI-compatible
+``POST /images/generations`` endpoint rather than the chat path. This module
+owns everything specific to that flow:
 
   * ``generate_images`` — shape and send the provider request, always returning
     inline ``data:`` URIs (a provider-hosted URL is fetched into the enclave so
@@ -49,6 +49,7 @@ _IMAGE_GENERATION_PATH = "/images/generations"
 # Provider -> the shared HTTP client attribute on ``llm_backend`` (built after
 # key injection). Looked up by attribute so a patched/rebuilt client is picked up.
 _IMAGE_CLIENT_ATTRS = {
+    "openai": "openai_http_client",
     "x-ai": "xai_http_client",
     "bytedance": "bytedance_http_client",
     "zai": "zai_http_client",

--- a/tee_gateway/model_registry.py
+++ b/tee_gateway/model_registry.py
@@ -168,6 +168,23 @@ class SupportedModel(Enum):
         input_price_usd=Decimal("0.000005"),
         output_price_usd=Decimal("0.00003"),
     )
+    # Image generation via OpenAI's /images/generations endpoint (gpt-image).
+    # Unlike DALL·E, gpt-image models always return base64 (``b64_json``) and
+    # reject the ``response_format`` field, so it's omitted. Image-to-image
+    # editing is a separate ``/images/edits`` endpoint OpenAI-side, so reference
+    # images aren't forwarded here (text-to-image only). Size/quality are pinned
+    # so the flat per-image price stays predictable. Billed at a flat $0.05 per
+    # generated image; token prices unused.
+    GPT_IMAGE_2 = ModelConfig(
+        provider="openai",
+        api_name="gpt-image-2",
+        input_price_usd=Decimal("0"),
+        output_price_usd=Decimal("0"),
+        image_generation=True,
+        per_image_price_usd=Decimal("0.05"),
+        image_response_format=None,
+        image_extra_params={"size": "1024x1024", "quality": "medium"},
+    )
 
     # ── Anthropic ───────────────────────────────────────────────────────
     CLAUDE_SONNET_4_5 = ModelConfig(
@@ -522,6 +539,7 @@ _MODEL_LOOKUP: dict[str, SupportedModel] = {
     "gpt-5.4-mini": SupportedModel.GPT_5_4_MINI,
     "gpt-5.4-nano": SupportedModel.GPT_5_4_NANO,
     "gpt-5.5": SupportedModel.GPT_5_5,
+    "gpt-image-2": SupportedModel.GPT_IMAGE_2,
     # Anthropic
     "claude-sonnet-4-5": SupportedModel.CLAUDE_SONNET_4_5,
     "claude-sonnet-4-6": SupportedModel.CLAUDE_SONNET_4_6,

--- a/tee_gateway/test/test_image_generation.py
+++ b/tee_gateway/test/test_image_generation.py
@@ -1,5 +1,5 @@
-"""Tests for endpoint-based image generation (xAI Grok, ByteDance Seedream,
-ByteDance Seedance, Z.ai GLM-Image).
+"""Tests for endpoint-based image generation (OpenAI gpt-image, xAI Grok,
+ByteDance Seedream, ByteDance Seedance, Z.ai GLM-Image).
 
 Unlike Gemini's inline-image chat models (see test_image_billing.py), these
 models are served via a dedicated OpenAI-compatible ``/images/generations``
@@ -28,6 +28,7 @@ SEEDREAM = "seedream-4.0"
 SEEDREAM_5_LITE = "seedream-5.0-lite"
 SEEDANCE = "seedance-4.5"
 GLM_IMAGE = "glm-image"
+GPT_IMAGE = "gpt-image-2"
 
 
 def _mock_response(data: list[dict]) -> MagicMock:
@@ -106,6 +107,27 @@ class TestGenerateImages(unittest.TestCase):
         self.assertEqual(payload["prompt"], "a poster")
         self.assertEqual(payload["size"], "1280x1280")
         self.assertNotIn("n", payload)
+        self.assertNotIn("response_format", payload)
+
+    def test_openai_gpt_image_omits_response_format_and_pins_size_quality(self):
+        # gpt-image models always return base64 and reject `response_format`, so
+        # the field must be omitted; size/quality are pinned for predictable
+        # billing. The shared openai_http_client is reused (base_url ends in /v1,
+        # so the request lands on OpenAI's /v1/images/generations).
+        client = MagicMock()
+        client.post.return_value = _mock_response([{"b64_json": "aGVsbG8="}])
+        with patch.object(llm_backend, "openai_http_client", client):
+            images, count = generate_images(GPT_IMAGE, "a red cube", n=1)
+
+        self.assertEqual(count, 1)
+        self.assertEqual(images, ["data:image/jpeg;base64,aGVsbG8="])
+
+        payload = client.post.call_args.kwargs["json"]
+        self.assertEqual(payload["model"], get_model_config(GPT_IMAGE).api_name)
+        self.assertEqual(payload["prompt"], "a red cube")
+        self.assertEqual(payload["n"], 1)
+        self.assertEqual(payload["size"], "1024x1024")
+        self.assertEqual(payload["quality"], "medium")
         self.assertNotIn("response_format", payload)
 
     def test_seedance_uses_url_format_and_extra_params(self):
@@ -426,7 +448,7 @@ class TestPerImageBilling(unittest.TestCase):
         return {"prompt_tokens": 0, "completion_tokens": 0, "total_tokens": 0}
 
     def test_single_image_charged_flat_price(self):
-        for model in (GROK_IMAGE, SEEDREAM, SEEDANCE, GLM_IMAGE):
+        for model in (GROK_IMAGE, SEEDREAM, SEEDANCE, GLM_IMAGE, GPT_IMAGE):
             with self.subTest(model=model):
                 cfg = get_model_config(model)
                 cost = compute_session_cost(model, self._zero_usage(), image_count=1)


### PR DESCRIPTION
## Summary
Adds support for OpenAI's `gpt-image-2` model for image generation via the `/images/generations` endpoint, alongside existing providers (xAI, ByteDance, Z.ai).

## Changes

- **model_registry.py**: Register `GPT_IMAGE_2` model config with:
  - Flat per-image pricing at $0.05 (token prices unused)
  - Pinned size (`1024x1024`) and quality (`medium`) for predictable billing
  - `response_format` omitted (gpt-image always returns base64)
  - Routed through OpenAI's shared HTTP client (base_url ends in `/v1`)

- **image_generation.py**: 
  - Add `"openai": "openai_http_client"` to `_IMAGE_CLIENT_ATTRS` mapping
  - Update module docstring to include OpenAI as an image generation provider

- **test_image_generation.py**:
  - Add `GPT_IMAGE = "gpt-image-2"` constant
  - Add `test_openai_gpt_image_omits_response_format_and_pins_size_quality()` test verifying:
    - `response_format` field is omitted from request payload
    - Size and quality are pinned as configured
    - Base64 response (`b64_json`) is correctly converted to inline `data:` URI
    - Shared OpenAI HTTP client is reused
  - Include `GPT_IMAGE` in billing test coverage

- **CLAUDE.md**: Update documentation to list `gpt-image-2` under OpenAI's supported models and note it uses the `/images/generations` endpoint flow

## Implementation Details

The gpt-image model integrates seamlessly with the existing endpoint-based image generation flow. Unlike DALL·E (which uses the chat path), gpt-image is served through a dedicated `/images/generations` endpoint and always returns base64-encoded images, rejecting the `response_format` parameter. The implementation pins size and quality to ensure predictable per-image billing costs.

https://claude.ai/code/session_01Soor3BDk2mqheoiWFssi9N