### PR TITLE
Add Claude Sonnet 5 model support

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -115,7 +115,7 @@ Server configuration:
 
 Model name prefixes determine routing:
 - **OpenAI**: gpt-4.1, gpt-5, gpt-5-mini, gpt-5.2, o4-mini; image generation: gpt-image-2
-- **Anthropic**: claude-sonnet-4-0/4-5/4-6, claude-haiku-4-5, claude-opus-4-5/4-6/4-7/4-8, claude-fable-5, claude-3-7-sonnet, claude-3-5-haiku
+- **Anthropic**: claude-sonnet-4-0/4-5/4-6, claude-sonnet-5, claude-haiku-4-5, claude-opus-4-5/4-6/4-7/4-8, claude-fable-5, claude-3-7-sonnet, claude-3-5-haiku
 - **Google**: gemini-2.5-flash, gemini-2.5-flash-lite, gemini-2.5-pro, gemini-3-pro-preview, gemini-3-flash-preview, gemini-3.1-pro-preview, gemini-3.1-flash-lite-preview, gemini-3.5-flash; image generation: gemini-2.5-flash-image, gemini-3.1-flash-image
 - **xAI**: grok-2, grok-3, grok-3-mini, grok-4, grok-4-fast, grok-4-1-fast; image generation: grok-2-image
 - **ByteDance** (BytePlus ModelArk, OpenAI-compatible, ap-southeast): seed-1.6, seed-1.8, seed-2.0-lite, deepseek-v4-flash, deepseek-v4-pro; image generation: seedream-4.0, seedream-5.0-lite, seedance-4.5

--- a/tee_gateway/model_registry.py
+++ b/tee_gateway/model_registry.py
@@ -214,6 +214,17 @@ class SupportedModel(Enum):
         input_price_usd=Decimal("0.000003"),
         output_price_usd=Decimal("0.000015"),
     )
+    # Claude Sonnet 5 — near-Opus quality on coding/agentic work at Sonnet cost.
+    # Adaptive-thinking-only; like Opus 4.7+ it rejects the `temperature` field
+    # (HTTP 400), so supports_temperature=False. Priced at the standard Sonnet
+    # sticker ($3/$15 per MTok; an intro rate applied through 2026-08-31).
+    CLAUDE_SONNET_5 = ModelConfig(
+        provider="anthropic",
+        api_name="claude-sonnet-5",
+        input_price_usd=Decimal("0.000003"),
+        output_price_usd=Decimal("0.000015"),
+        supports_temperature=False,
+    )
     CLAUDE_HAIKU_4_5 = ModelConfig(
         provider="anthropic",
         api_name="claude-haiku-4-5-20251001",
@@ -558,6 +569,7 @@ _MODEL_LOOKUP: dict[str, SupportedModel] = {
     # Anthropic
     "claude-sonnet-4-5": SupportedModel.CLAUDE_SONNET_4_5,
     "claude-sonnet-4-6": SupportedModel.CLAUDE_SONNET_4_6,
+    "claude-sonnet-5": SupportedModel.CLAUDE_SONNET_5,
     "claude-haiku-4-5": SupportedModel.CLAUDE_HAIKU_4_5,
     "claude-opus-4-5": SupportedModel.CLAUDE_OPUS_4_5,
     "claude-opus-4-6": SupportedModel.CLAUDE_OPUS_4_6,

--- a/tests/test_pricing.py
+++ b/tests/test_pricing.py
@@ -90,6 +90,15 @@ class TestModelRegistry(unittest.TestCase):
         self.assertEqual(cfg.input_price_usd, Decimal("0.000003"))
         self.assertEqual(cfg.output_price_usd, Decimal("0.000015"))
 
+    def test_claude_sonnet_5_resolves(self):
+        cfg = get_model_config("claude-sonnet-5")
+        self.assertEqual(cfg.provider, "anthropic")
+        self.assertEqual(cfg.api_name, "claude-sonnet-5")
+        self.assertEqual(cfg.input_price_usd, Decimal("0.000003"))
+        self.assertEqual(cfg.output_price_usd, Decimal("0.000015"))
+        # Adaptive-thinking-only; rejects the `temperature` field (HTTP 400)
+        self.assertFalse(cfg.supports_temperature)
+
     # ── Anthropic Haiku ─────────────────────────────────────────────────────
 
     def test_claude_haiku_4_5_resolves(self):


### PR DESCRIPTION
## Summary
Add support for Claude Sonnet 5 (claude-sonnet-5), Anthropic's new adaptive-thinking model that offers near-Opus quality on coding and agentic work at Sonnet pricing.

## Changes
- **Model Registry**: Added `CLAUDE_SONNET_5` enum entry with:
  - Provider: Anthropic
  - API name: `claude-sonnet-5`
  - Pricing: $0.000003 per input token, $0.000015 per output token (standard Sonnet rate through 2026-08-31)
  - `supports_temperature=False` — model rejects the `temperature` field (HTTP 400), consistent with Opus 4.7+ behavior
- **Model Mapping**: Registered `"claude-sonnet-5"` string key in the model lookup dictionary
- **Tests**: Added `test_claude_sonnet_5_resolves()` to verify model config resolution and temperature support flag
- **Documentation**: Updated CLAUDE.md supported models list to include `claude-sonnet-5`

## Implementation Details
Claude Sonnet 5 is adaptive-thinking-only and does not support the `temperature` parameter, similar to recent Opus versions. The model is priced at the standard Sonnet tier ($3/$15 per MTok) as an introductory rate through August 31, 2026.

https://claude.ai/code/session_01G6uf2MTAT3LYjPMogmxddk