### PR TITLE
Add SSE keepalive comments to prevent connection idle timeouts

### DIFF
--- a/tee_gateway/controllers/chat_controller.py
+++ b/tee_gateway/controllers/chat_controller.py
@@ -38,6 +38,7 @@ from tee_gateway.llm_backend import (
 from tee_gateway.image_generation import (
     create_image_generation_response,
     create_image_generation_streaming_response,
+    run_with_sse_keepalive,
 )
 from tee_gateway.model_registry import get_model_config
 from tee_gateway.pricing import compute_session_cost
@@ -484,8 +485,12 @@ def _create_streaming_response(chat_request: CreateChatCompletionRequest):
                 if image_output_model:
                     # Image generation isn't a token stream: invoke once, emit
                     # any caption text as a content delta, and carry the image
-                    # out-of-band on the final frame (it is not signed).
-                    response = model.invoke(langchain_messages)
+                    # out-of-band on the final frame (it is not signed). SSE
+                    # keepalive comments are streamed while the blocking invoke
+                    # runs so intermediaries don't idle-time-out the connection.
+                    response = yield from run_with_sse_keepalive(
+                        model.invoke, langchain_messages
+                    )
                     text_content, generated_images = _split_text_and_images(
                         response.content
                     )

--- a/tee_gateway/image_generation.py
+++ b/tee_gateway/image_generation.py
@@ -23,12 +23,13 @@ editing, extra params) live in the model registry, keeping this code flat.
 
 import base64
 import binascii
+import concurrent.futures
 import ipaddress
 import json
 import logging
 import time
 import uuid
-from typing import Any, List, Optional
+from typing import Any, Callable, Generator, List, Optional, TypeVar
 from urllib.parse import urlparse
 
 import httpx
@@ -67,6 +68,47 @@ _ALLOWED_FETCH_SCHEMES = {"http", "https"}
 
 # Shared keyless client for fetching provider-hosted image URLs into the enclave.
 _image_fetch_client: Optional[httpx.Client] = None
+
+# Image generation is a single blocking provider call that can run well past a
+# minute (gpt-image routinely takes 60-120s), during which the SSE response
+# would otherwise carry zero bytes. Intermediaries between the browser and the
+# enclave (the OHTTP relay, its load balancer, the browser's HTTP/2 session)
+# kill connections idle that long — surfacing client-side as
+# ERR_HTTP2_PROTOCOL_ERROR at ~60s — so while the provider call runs we emit
+# SSE comment lines, which every hop forwards (the OHTTP controller seals each
+# yielded chunk as it arrives) and SSE parsers ignore by spec. 10s keeps the
+# wire busy even for hops with the shortest common (30s) idle windows, allowing
+# for the OHTTP controller's one-chunk look-ahead delaying each chunk by one
+# interval.
+_KEEPALIVE_INTERVAL_SECONDS = 10.0
+_SSE_KEEPALIVE = ": keepalive\n\n"
+
+_T = TypeVar("_T")
+
+
+def run_with_sse_keepalive(
+    fn: Callable[..., _T], *args: Any, **kwargs: Any
+) -> Generator[str, None, _T]:
+    """Run ``fn`` in a worker thread, yielding SSE keepalive comments while it runs.
+
+    For use inside an SSE generator as ``result = yield from
+    run_with_sse_keepalive(fn, ...)``: the caller streams out each keepalive as
+    it is yielded and receives ``fn``'s return value once it completes. An
+    exception raised by ``fn`` propagates to the caller (surfacing through the
+    generator's normal error frame). If the client disconnects mid-generation
+    the generator is closed at a yield; the worker thread is not joined, so the
+    in-flight provider call simply runs to completion in the background.
+    """
+    executor = concurrent.futures.ThreadPoolExecutor(max_workers=1)
+    try:
+        future = executor.submit(fn, *args, **kwargs)
+        while True:
+            try:
+                return future.result(timeout=_KEEPALIVE_INTERVAL_SECONDS)
+            except concurrent.futures.TimeoutError:
+                yield _SSE_KEEPALIVE
+    finally:
+        executor.shutdown(wait=False)
 
 
 def _validate_fetch_url(url: str) -> None:
@@ -469,11 +511,16 @@ def create_image_generation_streaming_response(
     chat_request: CreateChatCompletionRequest, request_bytes: bytes
 ):
     """Streaming image generation: image gen is not a token stream, so we invoke
-    once and emit the result on the final SSE frame (mirrors the Gemini path)."""
+    once and emit the result on the final SSE frame (mirrors the Gemini path).
+    Keepalive comments are streamed while the provider call runs so no hop on
+    the way to the browser idle-times-out the connection (see
+    ``run_with_sse_keepalive``)."""
 
     def generate():
         try:
-            result = _run_image_generation(chat_request, request_bytes)
+            result = yield from run_with_sse_keepalive(
+                _run_image_generation, chat_request, request_bytes
+            )
 
             final_data: dict[str, Any] = {
                 "choices": [{"delta": {}, "index": 0, "finish_reason": "stop"}],

--- a/tee_gateway/test/test_image_generation.py
+++ b/tee_gateway/test/test_image_generation.py
@@ -13,6 +13,8 @@ No network or API key required — the provider HTTP client is mocked, the URL
 fetch is patched, and a stub price feed is injected.
 """
 
+import json
+import time
 import unittest
 from decimal import Decimal
 from unittest.mock import MagicMock, patch
@@ -490,6 +492,110 @@ class TestExtractImageInputs(unittest.TestCase):
         prompt, refs = image_generation._extract_image_inputs(msgs)
         self.assertEqual(prompt, "p")
         self.assertEqual(refs, [])
+
+
+class TestSseKeepalive(unittest.TestCase):
+    """SSE keepalives emitted while the blocking provider call runs.
+
+    Image generation can block for 60-120s with no bytes on the wire, which
+    intermediaries (OHTTP relay, load balancers, the browser's HTTP/2 session)
+    kill as idle at ~60s. These tests pin that keepalive comments flow while
+    the call runs and that results/errors still surface exactly as before.
+    """
+
+    @staticmethod
+    def _drive(gen):
+        """Exhaust a generator, returning (yielded_chunks, return_value)."""
+        out = []
+        while True:
+            try:
+                out.append(next(gen))
+            except StopIteration as stop:
+                return out, stop.value
+
+    def test_yields_keepalives_until_result(self):
+        def slow():
+            time.sleep(0.05)
+            return "done"
+
+        with patch.object(image_generation, "_KEEPALIVE_INTERVAL_SECONDS", 0.01):
+            chunks, value = self._drive(image_generation.run_with_sse_keepalive(slow))
+
+        self.assertEqual(value, "done")
+        self.assertGreaterEqual(len(chunks), 1)
+        # Every yielded chunk is an SSE comment — ignored by SSE parsers by spec.
+        self.assertTrue(all(c == ": keepalive\n\n" for c in chunks))
+
+    def test_fast_result_yields_no_keepalives(self):
+        chunks, value = self._drive(image_generation.run_with_sse_keepalive(lambda: 42))
+        self.assertEqual(value, 42)
+        self.assertEqual(chunks, [])
+
+    def test_propagates_exceptions(self):
+        def boom():
+            raise RuntimeError("provider failed")
+
+        with self.assertRaises(RuntimeError):
+            self._drive(image_generation.run_with_sse_keepalive(boom))
+
+    def test_streaming_response_emits_keepalives_before_final_frame(self):
+        result = {
+            "images": ["data:image/png;base64,QUJD"],
+            "usage": {"prompt_tokens": 0, "completion_tokens": 0, "total_tokens": 0},
+            "opengradient": None,
+            "tee_signature": "sig",
+            "tee_request_hash": "req-hash",
+            "tee_output_hash": "out-hash",
+            "tee_timestamp": 1700000000,
+            "tee_id": "0xabc",
+        }
+
+        def slow_run(chat_request, request_bytes):
+            time.sleep(0.05)
+            return result
+
+        chat_request = MagicMock()
+        chat_request.model = GPT_IMAGE
+        with (
+            patch.object(image_generation, "_KEEPALIVE_INTERVAL_SECONDS", 0.01),
+            patch.object(
+                image_generation, "_run_image_generation", side_effect=slow_run
+            ),
+        ):
+            resp = image_generation.create_image_generation_streaming_response(
+                chat_request, b"request-bytes"
+            )
+            chunks = list(resp.response)
+
+        # Keepalive comment(s) flow first, while generation is still running.
+        self.assertIn(": keepalive\n\n", chunks)
+        data_frames = [c for c in chunks if c.startswith("data: ")]
+        self.assertLess(chunks.index(": keepalive\n\n"), chunks.index(data_frames[0]))
+        # The final frame and [DONE] marker are unchanged by the keepalives.
+        self.assertEqual(data_frames[-1], "data: [DONE]\n\n")
+        final = json.loads(data_frames[-2][len("data: ") :])
+        self.assertEqual(final["images"], ["data:image/png;base64,QUJD"])
+        self.assertEqual(final["tee_signature"], "sig")
+
+    def test_streaming_response_surfaces_error_frame(self):
+        chat_request = MagicMock()
+        chat_request.model = GPT_IMAGE
+        with (
+            patch.object(image_generation, "_KEEPALIVE_INTERVAL_SECONDS", 0.01),
+            patch.object(
+                image_generation,
+                "_run_image_generation",
+                side_effect=RuntimeError("boom"),
+            ),
+        ):
+            resp = image_generation.create_image_generation_streaming_response(
+                chat_request, b"request-bytes"
+            )
+            chunks = list(resp.response)
+
+        payload = json.loads(chunks[-1][len("data: ") :])
+        self.assertEqual(payload["error"], "boom")
+        self.assertEqual(payload["exception_type"], "RuntimeError")
 
 
 class TestPerImageBilling(unittest.TestCase):


### PR DESCRIPTION
## Summary

Image generation requests can block for 60-120 seconds with no bytes on the wire, causing intermediaries (OHTTP relay, load balancers, browser HTTP/2 sessions) to kill the connection as idle at ~60s. This change adds SSE keepalive comment streaming during long-running provider calls to keep the connection alive while maintaining full backward compatibility with existing response handling.

## Key Changes

- **New `run_with_sse_keepalive()` generator function** in `image_generation.py`:
  - Runs a blocking function in a worker thread via `ThreadPoolExecutor`
  - Yields SSE comment lines (`: keepalive\n\n`) at configurable intervals (default 10s) while the function executes
  - Returns the function's result value once complete
  - Propagates exceptions normally
  - Gracefully handles client disconnection (worker thread continues in background)

- **Updated image generation endpoints** to use keepalive streaming:
  - `create_image_generation_streaming_response()` now wraps `_run_image_generation()` with `run_with_sse_keepalive()`
  - `chat_controller.py` wraps image output model invocation with keepalive streaming

- **Comprehensive test coverage** in `TestSseKeepalive`:
  - Verifies keepalive comments are emitted during slow operations
  - Confirms fast operations skip keepalives entirely
  - Tests exception propagation
  - Validates streaming response format (keepalives before data frames, final frame unchanged)
  - Tests error frame delivery

## Implementation Details

- SSE keepalive comments are ignored by SSE parsers per spec, so they're transparent to clients
- 10-second interval balances wire activity against overhead, accounting for OHTTP controller's one-chunk look-ahead delay
- `ThreadPoolExecutor` with `wait=False` shutdown ensures background provider calls complete even if client disconnects
- All existing response structure and signing behavior is preserved—keepalives are purely transport-level

https://claude.ai/code/session_01Uhw2GhoEnxG98rmbgpHhhP