### PR TITLE
Add Claude Opus 5 model to the registry

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -115,7 +115,7 @@ Server configuration:
 
 Model name prefixes determine routing:
 - **OpenAI**: gpt-4.1, gpt-5, gpt-5-mini, gpt-5.2, gpt-5.6-sol/terra/luna, o4-mini; image generation: gpt-image-2
-- **Anthropic**: claude-sonnet-4-0/4-5/4-6, claude-sonnet-5, claude-haiku-4-5, claude-opus-4-5/4-6/4-7/4-8, claude-fable-5, claude-3-7-sonnet, claude-3-5-haiku
+- **Anthropic**: claude-sonnet-4-0/4-5/4-6, claude-sonnet-5, claude-haiku-4-5, claude-opus-4-5/4-6/4-7/4-8, claude-opus-5, claude-fable-5, claude-3-7-sonnet, claude-3-5-haiku
 - **Google**: gemini-3.6-flash, gemini-3.5-flash-lite, gemini-2.5-flash, gemini-2.5-flash-lite, gemini-2.5-pro, gemini-3-pro-preview, gemini-3-flash-preview, gemini-3.1-pro-preview, gemini-3.5-flash; image generation: gemini-2.5-flash-image, gemini-3.1-flash-image
 - **xAI**: grok-2, grok-3, grok-3-mini, grok-4, grok-4.3, grok-4.5, grok-4-fast, grok-4-1-fast; image generation: grok-2-image
 - **ByteDance** (BytePlus ModelArk, OpenAI-compatible, ap-southeast): seed-1.6, seed-1.8, seed-2.0-lite, deepseek-v4-flash, deepseek-v4-pro; image generation: seedream-4.0, seedream-5.0-lite, seedance-4.5

--- a/tee_gateway/model_registry.py
+++ b/tee_gateway/model_registry.py
@@ -287,6 +287,16 @@ class SupportedModel(Enum):
         output_price_usd=Decimal("0.000025"),
         supports_temperature=False,
     )
+    # Claude Opus 5 — the current Opus, a drop-in upgrade at Opus 4.8's pricing
+    # ($5/$25 per MTok). Adaptive-thinking-only; like Opus 4.7+ it rejects the
+    # `temperature` field (HTTP 400), so supports_temperature=False.
+    CLAUDE_OPUS_5 = ModelConfig(
+        provider="anthropic",
+        api_name="claude-opus-5",
+        input_price_usd=Decimal("0.000005"),
+        output_price_usd=Decimal("0.000025"),
+        supports_temperature=False,
+    )
     # Claude Fable 5 — Anthropic's most capable widely released model (GA on the
     # first-party API from 2026-06-09). Adaptive-thinking-only; like Opus 4.7+ it
     # rejects `temperature` (HTTP 400), so supports_temperature=False.
@@ -620,6 +630,7 @@ _MODEL_LOOKUP: dict[str, SupportedModel] = {
     "claude-opus-4-6": SupportedModel.CLAUDE_OPUS_4_6,
     "claude-opus-4-7": SupportedModel.CLAUDE_OPUS_4_7,
     "claude-opus-4-8": SupportedModel.CLAUDE_OPUS_4_8,
+    "claude-opus-5": SupportedModel.CLAUDE_OPUS_5,
     "claude-fable-5": SupportedModel.CLAUDE_FABLE_5,
     # Google
     "gemini-2.5-flash": SupportedModel.GEMINI_2_5_FLASH,

--- a/tests/test_pricing.py
+++ b/tests/test_pricing.py
@@ -127,6 +127,15 @@ class TestModelRegistry(unittest.TestCase):
         # Opus 4.7+ rejects the `temperature` field (HTTP 400)
         self.assertFalse(cfg.supports_temperature)
 
+    def test_claude_opus_5_resolves(self):
+        cfg = get_model_config("claude-opus-5")
+        self.assertEqual(cfg.provider, "anthropic")
+        self.assertEqual(cfg.api_name, "claude-opus-5")
+        self.assertEqual(cfg.input_price_usd, Decimal("0.000005"))
+        self.assertEqual(cfg.output_price_usd, Decimal("0.000025"))
+        # Adaptive-thinking-only; rejects the `temperature` field (HTTP 400)
+        self.assertFalse(cfg.supports_temperature)
+
     def test_claude_fable_5_resolves(self):
         cfg = get_model_config("claude-fable-5")
         self.assertEqual(cfg.provider, "anthropic")
@@ -627,6 +636,13 @@ class TestCalculateSessionCostOPG(unittest.TestCase):
         expected = _expected_cost_opg("claude-opus-4-7", 1000, 500)
         self.assertEqual(cost, expected)
         # Same price tier as opus-4-5/4-6: 1000*0.000005 + 500*0.000025 = 0.0175 USD
+        self.assertEqual(cost, 17_500_000_000_000_000)
+
+    def test_claude_opus_5_cost(self):
+        cost = self._calc("claude-opus-5", 1000, 500)
+        expected = _expected_cost_opg("claude-opus-5", 1000, 500)
+        self.assertEqual(cost, expected)
+        # Same price tier as opus-4-5/4-6/4-7/4-8: 1000*0.000005 + 500*0.000025 = 0.0175 USD
         self.assertEqual(cost, 17_500_000_000_000_000)
 
     # ── Google Gemini ────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

Registers the latest Anthropic Opus model, `claude-opus-5`, so the gateway can route requests to it.

## Changes

- **`tee_gateway/model_registry.py`**
  - New `SupportedModel.CLAUDE_OPUS_5` config: provider `anthropic`, api_name `claude-opus-5`, priced at `$5/$25` per MTok input/output (`input_price_usd=0.000005`, `output_price_usd=0.000025`) — the same tier as Opus 4.5/4.6/4.7/4.8.
  - `supports_temperature=False` — Opus 5 is adaptive-thinking-only and rejects the `temperature` field (HTTP 400), matching Opus 4.7/4.8.
  - New `_MODEL_LOOKUP` entry `"claude-opus-5"`.
- **`tests/test_pricing.py`** — registry-resolution and cost tests for `claude-opus-5` (verifies provider, api_name, pricing tier, and `supports_temperature=False`).
- **`CLAUDE.md`** — adds `claude-opus-5` to the supported Anthropic models list.

## Verification

- `python -m unittest tests.test_pricing` — 122 tests pass.
- `ruff format --check` and `ruff check` clean on the touched files.

No dependency changes, so `uv.lock` and the resulting PCR measurements are unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01VpwYNv9A7B7DPyLhuUQU1F)_