### PR TITLE
Retry hosted-image URL fetch on 404 and transient errors

### DIFF
--- a/tee_gateway/image_generation.py
+++ b/tee_gateway/image_generation.py
@@ -68,6 +68,15 @@ _ALLOWED_FETCH_SCHEMES = {"http", "https"}
 # Shared keyless client for fetching provider-hosted image URLs into the enclave.
 _image_fetch_client: Optional[httpx.Client] = None
 
+# Retry policy for the hosted-URL fetch. Some providers (notably Z.ai, whose
+# generations response points at mfile.z.ai) return the URL before the file is
+# visible on their CDN, so an immediate GET can 404 with "file not exist" even
+# though the image was generated — retrying shortly after succeeds. 404 covers
+# that visibility race; 5xx and transport errors are ordinary transient CDN
+# failures. Anything else (403, size-cap ValueError, …) fails fast.
+_FETCH_RETRY_STATUS_CODES = frozenset({404, 500, 502, 503, 504})
+_FETCH_RETRY_DELAYS_SECONDS = (1.0, 2.0, 4.0)
+
 # Cap on how much of a provider error body is copied into an exception message
 # (and from there into logs and the client-facing error payload).
 _MAX_ERROR_DETAIL_CHARS = 600
@@ -161,6 +170,10 @@ def _fetch_url_as_data_uri(url: str) -> str:
     identically to inline-byte ones: the bytes are pulled into the enclave and
     ride out inside the OHTTP/TEE envelope, so the client never sees a raw URL.
 
+    Retries 404s and transient failures per ``_FETCH_RETRY_STATUS_CODES`` — the
+    URL comes straight out of the provider's response, so a 404 means the CDN
+    hasn't caught up yet, not that the image doesn't exist.
+
     Hardened against egress abuse: http(s) only, non-public IP hosts rejected,
     redirects capped, and the body capped at ``_MAX_IMAGE_BYTES`` (streamed so an
     oversized response is aborted instead of buffered whole).
@@ -175,7 +188,23 @@ def _fetch_url_as_data_uri(url: str) -> str:
             max_redirects=_MAX_REDIRECTS,
         )
 
-    with _image_fetch_client.stream("GET", url) as resp:
+    for delay in _FETCH_RETRY_DELAYS_SECONDS:
+        try:
+            return _fetch_url_once(_image_fetch_client, url)
+        except httpx.HTTPStatusError as e:
+            if e.response.status_code not in _FETCH_RETRY_STATUS_CODES:
+                raise
+            reason: str = str(e)
+        except httpx.TransportError as e:
+            reason = str(e)
+        logger.warning("Image URL fetch failed, retrying in %.0fs: %s", delay, reason)
+        time.sleep(delay)
+    return _fetch_url_once(_image_fetch_client, url)  # last attempt: raise as-is
+
+
+def _fetch_url_once(client: httpx.Client, url: str) -> str:
+    """Single GET for ``_fetch_url_as_data_uri`` (see there for the contract)."""
+    with client.stream("GET", url) as resp:
         _raise_for_status_with_detail(resp)
         declared = resp.headers.get("content-length")
         if declared and declared.isdigit() and int(declared) > _MAX_IMAGE_BYTES:

--- a/tee_gateway/test/test_image_generation.py
+++ b/tee_gateway/test/test_image_generation.py
@@ -477,6 +477,126 @@ class TestFetchUrlAsDataUri(unittest.TestCase):
                 image_generation._fetch_url_as_data_uri("https://cdn/big.png")
 
 
+def _error_stream_ctx(status: int, body: bytes) -> MagicMock:
+    """A .stream(...) context manager yielding a real httpx error response."""
+    import httpx
+
+    resp = httpx.Response(
+        status, content=body, request=httpx.Request("GET", "https://cdn/x.png")
+    )
+    ctx = MagicMock()
+    ctx.__enter__.return_value = resp
+    ctx.__exit__.return_value = False
+    return ctx
+
+
+def _ok_stream_ctx(chunks: list[bytes]) -> MagicMock:
+    resp = MagicMock()
+    resp.raise_for_status.return_value = None
+    resp.headers = {"content-type": "image/png"}
+    resp.iter_bytes.return_value = chunks
+    ctx = MagicMock()
+    ctx.__enter__.return_value = resp
+    ctx.__exit__.return_value = False
+    return ctx
+
+
+class TestFetchUrlRetry(unittest.TestCase):
+    """The hosted-URL fetch retries CDN-visibility 404s and transient errors.
+
+    Z.ai's generations response can point at a file mfile.z.ai hasn't made
+    visible yet, so the immediate fetch 404s with "file not exist" even though
+    the image exists moments later. A 404 on a provider-returned URL is
+    therefore retried, not trusted.
+    """
+
+    def test_404_then_success_is_retried(self):
+        client = MagicMock()
+        client.stream.side_effect = [
+            _error_stream_ctx(404, b'{"RetCode":-148654, "ErrMsg":"file not exist"}'),
+            _ok_stream_ctx([b"hello"]),
+        ]
+        with (
+            patch.object(image_generation, "_image_fetch_client", client),
+            patch.object(image_generation.time, "sleep") as sleep,
+        ):
+            uri = image_generation._fetch_url_as_data_uri("https://cdn/x.png")
+
+        self.assertEqual(uri, "data:image/png;base64,aGVsbG8=")
+        self.assertEqual(client.stream.call_count, 2)
+        sleep.assert_called_once_with(image_generation._FETCH_RETRY_DELAYS_SECONDS[0])
+
+    def test_transport_error_then_success_is_retried(self):
+        import httpx
+
+        client = MagicMock()
+        client.stream.side_effect = [
+            httpx.ConnectError("connection reset"),
+            _ok_stream_ctx([b"hello"]),
+        ]
+        with (
+            patch.object(image_generation, "_image_fetch_client", client),
+            patch.object(image_generation.time, "sleep"),
+        ):
+            uri = image_generation._fetch_url_as_data_uri("https://cdn/x.png")
+
+        self.assertEqual(uri, "data:image/png;base64,aGVsbG8=")
+        self.assertEqual(client.stream.call_count, 2)
+
+    def test_non_retryable_status_fails_immediately(self):
+        import httpx
+
+        client = MagicMock()
+        client.stream.return_value = _error_stream_ctx(403, b"Access denied")
+        with (
+            patch.object(image_generation, "_image_fetch_client", client),
+            patch.object(image_generation.time, "sleep") as sleep,
+        ):
+            with self.assertRaises(httpx.HTTPStatusError):
+                image_generation._fetch_url_as_data_uri("https://cdn/x.png")
+
+        self.assertEqual(client.stream.call_count, 1)
+        sleep.assert_not_called()
+
+    def test_persistent_404_exhausts_retries_and_raises(self):
+        import httpx
+
+        attempts = 1 + len(image_generation._FETCH_RETRY_DELAYS_SECONDS)
+        client = MagicMock()
+        client.stream.side_effect = [
+            _error_stream_ctx(404, b'{"ErrMsg":"file not exist"}')
+            for _ in range(attempts)
+        ]
+        with (
+            patch.object(image_generation, "_image_fetch_client", client),
+            patch.object(image_generation.time, "sleep") as sleep,
+        ):
+            with self.assertRaises(httpx.HTTPStatusError) as ctx:
+                image_generation._fetch_url_as_data_uri("https://cdn/x.png")
+
+        self.assertIn("file not exist", str(ctx.exception))
+        self.assertEqual(client.stream.call_count, attempts)
+        self.assertEqual(
+            [c.args[0] for c in sleep.call_args_list],
+            list(image_generation._FETCH_RETRY_DELAYS_SECONDS),
+        )
+
+    def test_size_cap_violation_is_not_retried(self):
+        # An oversized body is a hard failure, not a transient one.
+        client = MagicMock()
+        client.stream.return_value = _ok_stream_ctx([b"x" * 4, b"x" * 4])
+        with (
+            patch.object(image_generation, "_image_fetch_client", client),
+            patch.object(image_generation, "_MAX_IMAGE_BYTES", 5),
+            patch.object(image_generation.time, "sleep") as sleep,
+        ):
+            with self.assertRaises(ValueError):
+                image_generation._fetch_url_as_data_uri("https://cdn/big.png")
+
+        self.assertEqual(client.stream.call_count, 1)
+        sleep.assert_not_called()
+
+
 class TestExtractImageInputs(unittest.TestCase):
     """Prompt + reference-image extraction from the user turns."""
 


### PR DESCRIPTION
## Problem

Image generations on chat.opengradient.ai were failing with:

```
HTTPStatusError: Client error '404 Not Found' for url 'https://mfile.z.ai/…watermark.png'
— provider response: {"RetCode":-148654, "ErrMsg":"file not exist"}
```

Z.ai's `/images/generations` endpoint returns a hosted URL on `mfile.z.ai`, and the gateway fetches it into the enclave immediately (`_fetch_url_as_data_uri`). When the CDN hasn't made the file visible yet, that single GET 404s and the entire generation fails — even though the image exists moments later. The fetch had no retry at all.

## Change

- `_fetch_url_as_data_uri` now retries with a short 1s/2s/4s backoff (4 attempts total) on:
  - **404** — the CDN-visibility race described above; the URL comes straight out of the provider's response, so a 404 means "not visible yet", not "doesn't exist"
  - **500/502/503/504** and httpx transport errors — ordinary transient CDN failures
- Everything else still fails fast: non-retryable statuses (e.g. 403), SSRF/scheme validation, and the 25 MiB size-cap guard.
- The single-GET body is extracted into `_fetch_url_once`; the retry loop wraps it. Each retry is logged with the failure detail.

Worst case this adds ~7s before surfacing the original error — negligible next to image-generation latency, and the existing streaming error path is unchanged.

## Testing

- New `TestFetchUrlRetry` covers: 404-then-success, transport-error-then-success, non-retryable 403 fails immediately with no sleep, persistent 404 exhausts all retries and surfaces the provider error body, and the size-cap violation is not retried.
- Full CI-style suite passes: `uv run --group test pytest tee_gateway/test/ tests/test_pricing.py tests/test_opengradient_field.py` → 338 passed, 3 skipped.
- `make lint` clean (ruff format, ruff check, mypy).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BtJgJDUNMpoaRvggVDjk5o

---
_Generated by [Claude Code](https://claude.ai/code/session_01BtJgJDUNMpoaRvggVDjk5o)_