### PR TITLE
Add seedance-5.0 image model; move glm-5.2 to BytePlus ModelArk

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -124,12 +124,12 @@ Model name prefixes determine routing:
 - **Anthropic**: claude-sonnet-4-0/4-5/4-6, claude-sonnet-5, claude-haiku-4-5, claude-opus-4-5/4-6/4-7/4-8, claude-opus-5, claude-fable-5, claude-3-7-sonnet, claude-3-5-haiku
 - **Google**: gemini-3.6-flash, gemini-3.5-flash-lite, gemini-2.5-flash, gemini-2.5-flash-lite, gemini-2.5-pro, gemini-3-pro-preview, gemini-3-flash-preview, gemini-3.1-pro-preview, gemini-3.5-flash; image generation: gemini-2.5-flash-image, gemini-3.1-flash-image
 - **xAI**: grok-2, grok-3, grok-3-mini, grok-4, grok-4.3, grok-4.5, grok-4-fast, grok-4-1-fast; image generation: grok-2-image
-- **ByteDance** (BytePlus ModelArk, OpenAI-compatible, ap-southeast): seed-1.6, seed-1.8, seed-2.0-lite, deepseek-v4-flash, deepseek-v4-pro; image generation: seedream-4.0, seedream-5.0-lite, seedance-4.5
+- **ByteDance** (BytePlus ModelArk, OpenAI-compatible, ap-southeast): seed-1.6, seed-1.8, seed-2.0-lite, deepseek-v4-flash, deepseek-v4-pro, glm-5.2 (Z.ai's model served via a ModelArk deployment endpoint); image generation: seedream-4.0, seedream-5.0-lite, seedance-4.5, seedance-5.0
 - **Nous Research** (Nous Portal, OpenAI-compatible): hermes-4-405b, hermes-4-70b
-- **Z.ai** (Model API, OpenAI-compatible): glm-5.2; image generation: glm-image
+- **Z.ai** (Model API, OpenAI-compatible): image generation: glm-image (glm-5.2 chat is routed through BytePlus ModelArk, see ByteDance above)
 
 Image generation via OpenAI (gpt-image-2), xAI (grok-2-image), ByteDance
-(seedream-4.0, seedream-5.0-lite, seedance-4.5), and Z.ai (glm-image) is served
+(seedream-4.0, seedream-5.0-lite, seedance-4.5, seedance-5.0), and Z.ai (glm-image) is served
 through a provider `/images/generations` endpoint rather than the chat path (see
 `image_generation.py`), but is surfaced on `/v1/chat/completions` exactly like
 Gemini's inline-image models (images returned out-of-band under the message

--- a/tee_gateway/model_registry.py
+++ b/tee_gateway/model_registry.py
@@ -532,6 +532,23 @@ class SupportedModel(Enum):
         image_supports_reference=True,
         image_extra_params=_BYTEDANCE_EP_IMAGE_PARAMS,
     )
+    # Seedance 5.0 image generation via a ModelArk deployment endpoint.
+    # Returns hosted URLs (fetched and inlined by the gateway) and takes the
+    # shared ep- deployment params. BytePlus bills it tiered by output size
+    # ($0.045/image at <=2.61MP, $0.09 above); the gateway pins size "2K"
+    # (~4.2MP), which always lands in the upper tier, so bill flat $0.09.
+    SEEDANCE_5_0 = ModelConfig(
+        provider="bytedance",
+        api_name="ep-20260803211347-hq9k8",
+        input_price_usd=Decimal("0"),
+        output_price_usd=Decimal("0"),
+        image_generation=True,
+        per_image_price_usd=Decimal("0.09"),
+        image_response_format="url",
+        image_send_n=False,
+        image_supports_reference=True,
+        image_extra_params=_BYTEDANCE_EP_IMAGE_PARAMS,
+    )
 
     # ── Nous Research (Nous Portal, OpenAI-compatible) ──────────────────
     # Hermes 4 family, served via Nous's OpenAI-compatible inference API.
@@ -555,10 +572,12 @@ class SupportedModel(Enum):
     )
 
     # ── Z.ai (Model API, OpenAI-compatible) ─────────────────────────────
-    # Z.ai publishes GLM-5.2 prices per 1M tokens: $1.40 input, $4.40 output.
+    # GLM-5.2 is served via a BytePlus ModelArk deployment endpoint (api_name
+    # "ep-…") rather than Z.ai's own API — same model, same per-1M-token
+    # pricing ($1.40 input, $4.40 output), routed through the bytedance client.
     GLM_5_2 = ModelConfig(
-        provider="zai",
-        api_name="glm-5.2",
+        provider="bytedance",
+        api_name="ep-20260803211658-fwpzs",
         input_price_usd=Decimal("0.0000014"),
         output_price_usd=Decimal("0.0000044"),
     )
@@ -675,11 +694,15 @@ _MODEL_LOOKUP: dict[str, SupportedModel] = {
     "ep-20260624042612-7dxcv": SupportedModel.SEEDANCE_4_5,
     "seedance-4.5": SupportedModel.SEEDANCE_4_5,
     "seedance-4-5": SupportedModel.SEEDANCE_4_5,
+    "ep-20260803211347-hq9k8": SupportedModel.SEEDANCE_5_0,
+    "seedance-5.0": SupportedModel.SEEDANCE_5_0,
+    "seedance-5-0": SupportedModel.SEEDANCE_5_0,
     # Nous Research
     "hermes-4-405b": SupportedModel.HERMES_4_405B,
     "hermes-4-70b": SupportedModel.HERMES_4_70B,
     # Z.ai
     "glm-5.2": SupportedModel.GLM_5_2,
+    "ep-20260803211658-fwpzs": SupportedModel.GLM_5_2,
     "glm-image": SupportedModel.GLM_IMAGE,
     # Legacy — not in current SDK, retained for older SDK versions
     "grok-3-mini-beta": SupportedModel.GROK_3_MINI,  # old beta alias

--- a/tee_gateway/test/test_image_generation.py
+++ b/tee_gateway/test/test_image_generation.py
@@ -27,6 +27,7 @@ GROK_IMAGE = "grok-2-image"
 SEEDREAM = "seedream-4.0"
 SEEDREAM_5_LITE = "seedream-5.0-lite"
 SEEDANCE = "seedance-4.5"
+SEEDANCE_5 = "seedance-5.0"
 GLM_IMAGE = "glm-image"
 GPT_IMAGE = "gpt-image-2"
 
@@ -714,7 +715,7 @@ class TestPerImageBilling(unittest.TestCase):
         return {"prompt_tokens": 0, "completion_tokens": 0, "total_tokens": 0}
 
     def test_single_image_charged_flat_price(self):
-        for model in (GROK_IMAGE, SEEDREAM, SEEDANCE, GLM_IMAGE, GPT_IMAGE):
+        for model in (GROK_IMAGE, SEEDREAM, SEEDANCE, SEEDANCE_5, GLM_IMAGE, GPT_IMAGE):
             with self.subTest(model=model):
                 cfg = get_model_config(model)
                 cost = compute_session_cost(model, self._zero_usage(), image_count=1)

--- a/tests/test_pricing.py
+++ b/tests/test_pricing.py
@@ -445,6 +445,23 @@ class TestModelRegistry(unittest.TestCase):
             get_model_config("seedream-5.0-lite"),
         )
 
+    def test_seedance_5_0_resolves(self):
+        cfg = get_model_config("seedance-5.0")
+        self.assertEqual(cfg.provider, "bytedance")
+        self.assertEqual(cfg.api_name, "ep-20260803211347-hq9k8")
+        self.assertTrue(cfg.image_generation)
+        self.assertEqual(cfg.per_image_price_usd, Decimal("0.09"))
+
+    def test_seedance_5_0_aliases_resolve(self):
+        self.assertEqual(
+            get_model_config("seedance-5-0"),
+            get_model_config("seedance-5.0"),
+        )
+        self.assertEqual(
+            get_model_config("ep-20260803211347-hq9k8"),
+            get_model_config("seedance-5.0"),
+        )
+
     # ── Nous Research (Nous Portal) ─────────────────────────────────────────
 
     def test_hermes_4_405b_resolves(self):
@@ -464,11 +481,19 @@ class TestModelRegistry(unittest.TestCase):
     # ── Z.ai (Model API) ───────────────────────────────────────────────────
 
     def test_glm_5_2_resolves(self):
+        # GLM-5.2 is served via a BytePlus ModelArk deployment endpoint, not
+        # Z.ai's own API; pricing is unchanged.
         cfg = get_model_config("glm-5.2")
-        self.assertEqual(cfg.provider, "zai")
-        self.assertEqual(cfg.api_name, "glm-5.2")
+        self.assertEqual(cfg.provider, "bytedance")
+        self.assertEqual(cfg.api_name, "ep-20260803211658-fwpzs")
         self.assertEqual(cfg.input_price_usd, Decimal("0.0000014"))
         self.assertEqual(cfg.output_price_usd, Decimal("0.0000044"))
+
+    def test_glm_5_2_ep_alias_resolves(self):
+        self.assertEqual(
+            get_model_config("ep-20260803211658-fwpzs"),
+            get_model_config("glm-5.2"),
+        )
 
     def test_glm_image_resolves(self):
         cfg = get_model_config("glm-image")


### PR DESCRIPTION
## Seedance 5.0 (new image model)

Registers `seedance-5.0`, served via a ByteDance ModelArk deployment endpoint (`ep-20260803211347-hq9k8`), configured exactly like `seedance-4.5`:

- URL response format (the gateway fetches the hosted URL and inlines the bytes)
- no `n` param, reference-image support for image-to-image edits
- shared `ep-` deployment params (`size: 2K`, `watermark: false`, `sequential_image_generation: disabled`, `stream: false`)
- aliases: `seedance-5.0`, `seedance-5-0`, and the raw `ep-` id

**Pricing**: BytePlus bills this model tiered by output size — $0.045/image at ≤2.61MP, $0.09/image above. Since the gateway pins `size: "2K"` (~4.2MP output), every image lands in the upper tier, so it is registered at a flat **$0.09/image**.

## GLM-5.2 backend switch

`glm-5.2` chat now routes through a BytePlus ModelArk deployment endpoint (`ep-20260803211658-fwpzs`) on the existing `bytedance` HTTP client instead of Z.ai's API. Same model, same per-token pricing ($1.40/$4.40 per 1M), same user-facing id — nothing changes for clients. `glm-image` stays on the Z.ai client.

## Tests

- `tests/test_pricing.py`: seedance-5.0 resolution + alias tests; glm-5.2 test updated to the new provider/endpoint plus an ep-alias test
- `tee_gateway/test/test_image_generation.py`: seedance-5.0 added to the flat per-image billing loop (the `ep-` payload-shaping path is already pinned by the seedance-4.5 tests, which share the same config)
- Full suite + `make lint` (ruff/mypy) pass; the only failures (`test_ohttp`/`test_server` needing pytest, one multimodal hash test) are pre-existing on `main`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EiijQyH7okLPEhkJd7hocv

---
_Generated by [Claude Code](https://claude.ai/code/session_01EiijQyH7okLPEhkJd7hocv)_