### PR TITLE
Drop sequential_image_generation from Seedance 5.0 requests

### DIFF
--- a/tee_gateway/model_registry.py
+++ b/tee_gateway/model_registry.py
@@ -105,6 +105,15 @@ _BYTEDANCE_EP_IMAGE_PARAMS: dict[str, Any] = {
     "stream": False,
 }
 
+# Seedance 5.0's deployment endpoint rejects ``sequential_image_generation``
+# ("not supported by the current model" -> HTTP 400), so it takes the shared
+# params minus that field.
+_SEEDANCE_5_IMAGE_PARAMS: dict[str, Any] = {
+    "watermark": False,
+    "size": "2K",
+    "stream": False,
+}
+
 
 @unique
 class SupportedModel(Enum):
@@ -533,10 +542,11 @@ class SupportedModel(Enum):
         image_extra_params=_BYTEDANCE_EP_IMAGE_PARAMS,
     )
     # Seedance 5.0 image generation via a ModelArk deployment endpoint.
-    # Returns hosted URLs (fetched and inlined by the gateway) and takes the
-    # shared ep- deployment params. BytePlus bills it tiered by output size
-    # ($0.045/image at <=2.61MP, $0.09 above); the gateway pins size "2K"
-    # (~4.2MP), which always lands in the upper tier, so bill flat $0.09.
+    # Returns hosted URLs (fetched and inlined by the gateway). Unlike the
+    # other ep- models it rejects sequential_image_generation, so it takes its
+    # own param set. BytePlus bills it tiered by output size ($0.045/image at
+    # <=2.61MP, $0.09 above); the gateway pins size "2K" (~4.2MP), which
+    # always lands in the upper tier, so bill flat $0.09.
     SEEDANCE_5_0 = ModelConfig(
         provider="bytedance",
         api_name="ep-20260803211347-hq9k8",
@@ -547,7 +557,7 @@ class SupportedModel(Enum):
         image_response_format="url",
         image_send_n=False,
         image_supports_reference=True,
-        image_extra_params=_BYTEDANCE_EP_IMAGE_PARAMS,
+        image_extra_params=_SEEDANCE_5_IMAGE_PARAMS,
     )
 
     # ── Nous Research (Nous Portal, OpenAI-compatible) ──────────────────

--- a/tee_gateway/test/test_image_generation.py
+++ b/tee_gateway/test/test_image_generation.py
@@ -185,6 +185,33 @@ class TestGenerateImages(unittest.TestCase):
         self.assertFalse(payload["stream"])
         self.assertNotIn("n", payload)
 
+    def test_seedance_5_omits_sequential_image_generation(self):
+        # The Seedance 5.0 deployment endpoint rejects sequential_image_generation
+        # with HTTP 400 ("not supported by the current model"), so its payload is
+        # the shared ep- shape minus that field.
+        client = MagicMock()
+        client.post.return_value = _mock_response([{"url": "https://cdn/img.jpg"}])
+        with (
+            patch.object(llm_backend, "bytedance_http_client", client),
+            patch.object(
+                image_generation,
+                "_fetch_url_as_data_uri",
+                return_value="data:image/jpeg;base64,RkVUQ0hFRA==",
+            ),
+        ):
+            images, count = generate_images(SEEDANCE_5, "a black hole", n=1)
+
+        self.assertEqual(count, 1)
+        self.assertEqual(images, ["data:image/jpeg;base64,RkVUQ0hFRA=="])
+        payload = client.post.call_args.kwargs["json"]
+        self.assertEqual(payload["model"], get_model_config(SEEDANCE_5).api_name)
+        self.assertEqual(payload["response_format"], "url")
+        self.assertNotIn("sequential_image_generation", payload)
+        self.assertFalse(payload["watermark"])
+        self.assertEqual(payload["size"], "2K")
+        self.assertFalse(payload["stream"])
+        self.assertNotIn("n", payload)
+
     def test_seedance_forwards_single_reference_image(self):
         client = MagicMock()
         client.post.return_value = _mock_response([{"url": "https://cdn/edited.jpg"}])


### PR DESCRIPTION
Fixes the production 400 on `seedance-5.0` image generation:

```
InvalidParameter: The parameter `sequential_image_generation` specified in the request are not valid:
the parameter `sequential_image_generation` is not supported by the current model.
```

Unlike the other ByteDance `ep-` image endpoints (seedance-4.5, seedream-5.0-lite), the Seedance 5.0 deployment endpoint rejects `sequential_image_generation` outright, so the model now takes its own `image_extra_params` set — the shared ep- params minus that field (`size: 2K`, `watermark: false`, `stream: false`, matching the verified working curl).

Added `test_seedance_5_omits_sequential_image_generation` pinning the payload shape. Registry/pricing are otherwise unchanged. Full affected suites and `make lint` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EiijQyH7okLPEhkJd7hocv

---
_Generated by [Claude Code](https://claude.ai/code/session_01EiijQyH7okLPEhkJd7hocv)_