### PR TITLE
Share xAI non-streaming usage workaround with /v1/completions; drop redundant stream kwargs

### DIFF
--- a/tee_gateway/controllers/chat_controller.py
+++ b/tee_gateway/controllers/chat_controller.py
@@ -29,6 +29,7 @@ from tee_gateway.llm_backend import (
     get_chat_model_cached,
     convert_messages,
     extract_usage,
+    non_streaming_invoke_kwargs,
     validate_attachments,
     AttachmentValidationError,
     canonical_user_content,
@@ -287,11 +288,9 @@ def _create_non_streaming_response(chat_request: CreateChatCompletionRequest):
         if rf_dict and provider == "anthropic":
             response = _invoke_anthropic_structured(model, rf_dict, langchain_messages)
         else:
-            # ChatXAI is cached with streaming enabled for the streaming
-            # endpoint. Disable it here so stream=false gets one complete
-            # provider response with its authoritative usage object.
-            invoke_kwargs = {"stream": False} if provider == "x-ai" else {}
-            response = model.invoke(langchain_messages, **invoke_kwargs)
+            response = model.invoke(
+                langchain_messages, **non_streaming_invoke_kwargs(provider)
+            )
 
         # Normalize content (Gemini may return a list of content parts, and
         # image-generation models return image blocks alongside any text).
@@ -567,19 +566,10 @@ def _create_streaming_response(chat_request: CreateChatCompletionRequest):
                     yield f"data: {json.dumps(data)}\n\n"
                     chunks_iter = []
                 else:
-                    # xAI Chat Completions requires include_usage for the
-                    # terminal billing event. Its Responses API (used for web
-                    # search) includes terminal usage automatically and does
-                    # not accept the LangChain-only stream_usage argument.
-                    stream_kwargs = (
-                        {"stream_usage": True}
-                        if provider == "x-ai" and not chat_request.web_search
-                        else {}
-                    )
-                    chunks_iter = model.stream(  # type: ignore[assignment]
-                        langchain_messages,
-                        **stream_kwargs,
-                    )
+                    # Terminal usage needs no per-call opt-in: every provider
+                    # is constructed with stream_usage=True (see
+                    # get_chat_model_cached).
+                    chunks_iter = model.stream(langchain_messages)  # type: ignore[assignment]
 
                 for chunk in chunks_iter:
                     # --- Text content ---

--- a/tee_gateway/controllers/completions_controller.py
+++ b/tee_gateway/controllers/completions_controller.py
@@ -13,7 +13,9 @@ from tee_gateway.models.create_completion_request import CreateCompletionRequest
 from tee_gateway.tee_manager import get_tee_keys, compute_tee_msg_hash
 from tee_gateway.llm_backend import (
     get_chat_model_cached,
+    get_provider_from_model,
     extract_usage,
+    non_streaming_invoke_kwargs,
 )
 from tee_gateway.pricing import compute_session_cost
 
@@ -58,7 +60,8 @@ def create_completion(body):
         )
 
         messages = [HumanMessage(content=body.prompt)]
-        response = model.invoke(messages)
+        provider = get_provider_from_model(body.model)
+        response = model.invoke(messages, **non_streaming_invoke_kwargs(provider))
 
         # Some providers can return content as a list of blocks; flatten to the
         # text the caller expects.

--- a/tee_gateway/llm_backend.py
+++ b/tee_gateway/llm_backend.py
@@ -161,6 +161,18 @@ def get_provider_from_model(model: str) -> str:
     return cfg.provider
 
 
+def non_streaming_invoke_kwargs(provider: str) -> Dict[str, Any]:
+    """Kwargs for ``model.invoke()`` when a true non-streaming call is needed.
+
+    Chat models are cached with ``streaming=True`` for the streaming endpoint,
+    so ``invoke()`` streams internally and LangChain merges the chunks. xAI
+    reports cumulative usage snapshots on every chunk, which that merge sums
+    into inflated token counts — force a real non-streaming request so the
+    provider returns one authoritative usage object.
+    """
+    return {"stream": False} if provider == "x-ai" else {}
+
+
 @lru_cache(maxsize=64)
 def get_chat_model_cached(
     model: str,

--- a/tests/test_opengradient_field.py
+++ b/tests/test_opengradient_field.py
@@ -193,19 +193,29 @@ class TestChatStreamingOpengradient(unittest.TestCase):
         self.assertIn("opengradient", final)
         self.assertEqual(final["opengradient"]["cost_opg"], "12345")
 
-    def test_xai_stream_explicitly_requests_usage(self):
+    def test_xai_stream_keeps_latest_cumulative_usage_snapshot(self):
+        # xAI reports cumulative usage on every chunk; the final usage must be
+        # the last snapshot, not the sum of all snapshots.
         from tee_gateway.controllers import chat_controller
 
-        chunk = MagicMock()
-        chunk.content = "hello"
-        chunk.tool_call_chunks = []
-        chunk.usage_metadata = {
+        first = MagicMock()
+        first.content = "hel"
+        first.tool_call_chunks = []
+        first.usage_metadata = {
+            "input_tokens": 10,
+            "output_tokens": 5,
+            "total_tokens": 15,
+        }
+        second = MagicMock()
+        second.content = "lo"
+        second.tool_call_chunks = []
+        second.usage_metadata = {
             "input_tokens": 10,
             "output_tokens": 20,
             "total_tokens": 30,
         }
         fake_model = MagicMock()
-        fake_model.stream.return_value = iter([chunk])
+        fake_model.stream.return_value = iter([first, second])
 
         with (
             patch.object(
@@ -230,54 +240,18 @@ class TestChatStreamingOpengradient(unittest.TestCase):
             request.model = "grok-4.3"
             request.stream = True
             response = chat_controller._create_streaming_response(request)
-            list(response.response)
+            chunks = [
+                c.decode() if isinstance(c, bytes) else c for c in response.response
+            ]
 
-        fake_model.stream.assert_called_once()
-        self.assertTrue(fake_model.stream.call_args.kwargs["stream_usage"])
-
-    def test_xai_responses_stream_does_not_forward_stream_usage(self):
-        from tee_gateway.controllers import chat_controller
-
-        chunk = MagicMock()
-        chunk.content = "hello"
-        chunk.tool_call_chunks = []
-        chunk.usage_metadata = {
-            "input_tokens": 10,
-            "output_tokens": 20,
-            "total_tokens": 30,
-        }
-        fake_model = MagicMock()
-        fake_model.stream.return_value = iter([chunk])
-
-        with (
-            patch.object(
-                chat_controller, "get_chat_model_cached", return_value=fake_model
-            ),
-            patch.object(
-                chat_controller, "get_provider_from_model", return_value="x-ai"
-            ),
-            patch.object(chat_controller, "_build_tools_list", return_value=[]),
-            patch.object(
-                chat_controller, "compute_session_cost", return_value=_fake_cost()
-            ),
-            patch.object(
-                chat_controller, "get_tee_keys", return_value=_fake_tee_keys()
-            ),
-            patch.object(
-                chat_controller,
-                "compute_tee_msg_hash",
-                return_value=(b"h", "ih", "oh"),
-            ),
-        ):
-            request = _chat_request()
-            request.model = "grok-4.3"
-            request.stream = True
-            request.web_search = True
-            response = chat_controller._create_streaming_response(request)
-            list(response.response)
-
-        fake_model.stream.assert_called_once()
-        self.assertNotIn("stream_usage", fake_model.stream.call_args.kwargs)
+        data_events = [
+            c for c in chunks if c.startswith("data: ") and "[DONE]" not in c
+        ]
+        final = json.loads(data_events[-1][len("data: ") :].strip())
+        self.assertEqual(
+            final["usage"],
+            {"prompt_tokens": 10, "completion_tokens": 20, "total_tokens": 30},
+        )
 
 
 class TestCompletionsOpengradient(unittest.TestCase):
@@ -329,6 +303,54 @@ class TestCompletionsOpengradient(unittest.TestCase):
         self.assertIsInstance(resp, dict)
         self.assertIn("opengradient", resp)
         self.assertEqual(resp["opengradient"]["cost_opg"], "12345")
+
+    def test_xai_completion_disables_provider_streaming(self):
+        from tee_gateway.controllers import completions_controller
+
+        fake_response = MagicMock()
+        fake_response.content = "world"
+        fake_model = MagicMock()
+        fake_model.invoke.return_value = fake_response
+
+        fake_request = MagicMock()
+        fake_request.is_json = True
+        fake_request.get_json.return_value = {
+            "model": "grok-4-fast",
+            "prompt": "hi",
+        }
+
+        body = CreateCompletionRequest(model="grok-4-fast", prompt="hi")
+
+        with (
+            patch("connexion.request", fake_request),
+            patch.object(
+                completions_controller,
+                "get_chat_model_cached",
+                return_value=fake_model,
+            ),
+            patch.object(
+                completions_controller, "extract_usage", return_value=_FAKE_USAGE
+            ),
+            patch.object(
+                completions_controller,
+                "compute_session_cost",
+                return_value=_fake_cost(),
+            ),
+            patch.object(
+                completions_controller,
+                "get_tee_keys",
+                return_value=_fake_tee_keys(),
+            ),
+            patch.object(
+                completions_controller,
+                "compute_tee_msg_hash",
+                return_value=(b"h", "ih", "oh"),
+            ),
+        ):
+            completions_controller.create_completion(body)
+
+        fake_model.invoke.assert_called_once()
+        self.assertFalse(fake_model.invoke.call_args.kwargs["stream"])
 
 
 class TestSessionCostCalculatorMissingBlock(unittest.TestCase):


### PR DESCRIPTION
Follow-ups from review of #137, targeting `ani/missing-cost-fixes` so they land as part of that PR.

## 1. `/v1/completions` had the same xAI overbilling bug #137 fixes for chat

`completions_controller.create_completion` called `model.invoke(messages)` with no `stream=False`. Since every chat model is cached with `streaming=True`, `invoke()` streams internally and LangChain merges the chunks — for xAI that merge **sums the cumulative per-chunk usage snapshots**, inflating billed tokens on grok models exactly as it did on the chat endpoint.

The workaround is hoisted into a shared helper, `llm_backend.non_streaming_invoke_kwargs(provider)`, used by both `chat_controller._create_non_streaming_response` and `completions_controller.create_completion`, so the two endpoints can't drift apart again.

## 2. Removed the per-call `stream_usage=True` on `model.stream()`

The kwarg was a no-op: `ChatXAI` is already constructed with `stream_usage=True` in `get_chat_model_cached` (and langchain-xai 1.2.2 forces it on by default in its post-init validator). The `not chat_request.web_search` gate and its comment also implied the deprecated no-op `web_search` flag still routed xAI to the Responses API, which contradicts the flag's documented behavior. The real streaming fix — keeping the latest cumulative usage snapshot instead of summing — is untouched.

## Tests

- Replaced the two tests pinning the `stream_usage` kwarg with `test_xai_stream_keeps_latest_cumulative_usage_snapshot`, which covers the keep-latest behavior directly (final SSE usage equals the last snapshot, not the sum).
- Added `test_xai_completion_disables_provider_streaming` asserting the completions endpoint passes `stream=False` for grok models.
- `uv run --group test pytest tee_gateway/test/ tests/test_pricing.py tests/test_opengradient_field.py`: 349 passed, 4 skipped. `make lint` (ruff + mypy) clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013bcpZQZ8pAgHL6z4gBZrDM

---
_Generated by [Claude Code](https://claude.ai/code/session_013bcpZQZ8pAgHL6z4gBZrDM)_