### PR TITLE
Add in-enclave content moderation gate

### DIFF
--- a/tee_gateway/__main__.py
+++ b/tee_gateway/__main__.py
@@ -22,6 +22,7 @@ from tee_gateway.config import (
     DEFAULT_HEARTBEAT_INTERVAL,
 )
 from tee_gateway.llm_backend import get_provider_config, set_provider_config
+from tee_gateway import moderation
 from tee_gateway.web_search import web_search_available
 from tee_gateway.heartbeat import create_heartbeat_service
 from tee_gateway.controllers.ohttp_controller import (
@@ -424,6 +425,25 @@ def set_provider_keys():
             exa_api_key=body.get("exa_api_key") or None,
         )
         set_provider_config(provider_config)
+
+        # Configure the in-enclave content-moderation gate. Defaults to ON when
+        # an OpenAI key is present (its free /moderations endpoint backs the
+        # gate) and fail-closed, so a screening outage rejects rather than leaks.
+        # Operators can override both via the key-injection body.
+        moderation_enabled = bool(
+            body.get("moderation_enabled", bool(provider_config.openai_api_key))
+        )
+        moderation_fail_closed = bool(body.get("moderation_fail_closed", True))
+        moderation_backend: moderation.ModerationBackend
+        if moderation_enabled and provider_config.openai_api_key:
+            moderation_backend = moderation.OpenAIModerationBackend()
+        else:
+            moderation_backend = moderation.StubBackend()
+        moderation.configure_moderation(
+            moderation_backend,
+            enabled=moderation_enabled,
+            fail_closed=moderation_fail_closed,
+        )
 
         facilitator_url = body.get("facilitator_url") or FACILITATOR_URL
 

--- a/tee_gateway/controllers/chat_controller.py
+++ b/tee_gateway/controllers/chat_controller.py
@@ -40,6 +40,7 @@ from tee_gateway.image_generation import (
 )
 from tee_gateway.model_registry import get_model_config
 from tee_gateway.pricing import compute_session_cost
+from tee_gateway import moderation
 
 logger = logging.getLogger(__name__)
 
@@ -96,6 +97,16 @@ def create_chat_completion(body):
         validate_attachments(chat_request.messages, chat_request.model)
     except AttachmentValidationError as e:
         return {"error": "Invalid attachment", "message": str(e)}, 400
+
+    # Screen client content before any provider call. Covers the chat and the
+    # image generation/edit paths alike (both dispatch below from here).
+    blocked = moderation.enforce(
+        moderation.texts_from_messages(chat_request.messages),
+        moderation.images_from_messages(chat_request.messages),
+        safety_identifier=moderation.payment_safety_identifier(),
+    )
+    if blocked:
+        return blocked
 
     if chat_request.stream:
         return _create_streaming_response(chat_request)

--- a/tee_gateway/controllers/completions_controller.py
+++ b/tee_gateway/controllers/completions_controller.py
@@ -18,8 +18,18 @@ from tee_gateway.llm_backend import (
     non_streaming_invoke_kwargs,
 )
 from tee_gateway.pricing import compute_session_cost
+from tee_gateway import moderation
 
 logger = logging.getLogger(__name__)
+
+
+def _prompt_texts(prompt: Any) -> list[str]:
+    """Flatten a completion ``prompt`` (str or list of str) into texts to screen."""
+    if isinstance(prompt, str):
+        return [prompt] if prompt else []
+    if isinstance(prompt, list):
+        return [p for p in prompt if isinstance(p, str) and p]
+    return []
 
 
 def create_completion(body):
@@ -28,6 +38,14 @@ def create_completion(body):
         body = CreateCompletionRequest.from_dict(connexion.request.get_json())
     else:
         return {"error": "Request must be application/json"}, 415
+
+    # Screen the prompt before any provider call.
+    blocked = moderation.enforce(
+        _prompt_texts(body.prompt),
+        safety_identifier=moderation.payment_safety_identifier(),
+    )
+    if blocked:
+        return blocked
 
     try:
         # The web_search flag is a deprecated no-op: search moved to the

--- a/tee_gateway/controllers/ohttp_controller.py
+++ b/tee_gateway/controllers/ohttp_controller.py
@@ -114,7 +114,19 @@ _INNER_ENDPOINT_PATHS = {
 
 # Response headers we propagate from the inner /v1/chat/completions response
 # back through the relay to the client.
-_FORWARDED_HEADER_PREFIXES = ("x-payment", "x-upto", "x-settlement", "x-tee")
+#
+# ``x-og-moderation`` carries the moderation gate's flag (see moderation.py):
+# on a policy hit the inner handler returns 403 with ``X-OG-Moderation-Flagged``
+# (and matched categories), which we surface to the relay so it can ban the
+# payer it bills. Only a policy-class label ever rides here, never client
+# content, and a blocked request is already a non-2xx forwarded as plaintext.
+_FORWARDED_HEADER_PREFIXES = (
+    "x-payment",
+    "x-upto",
+    "x-settlement",
+    "x-tee",
+    "x-og-moderation",
+)
 _FORWARDED_HEADER_NAMES = ("www-authenticate",)
 
 

--- a/tee_gateway/controllers/web_search_controller.py
+++ b/tee_gateway/controllers/web_search_controller.py
@@ -36,6 +36,7 @@ from tee_gateway.web_search import (
     execute_web_search_call,
     web_search_available,
 )
+from tee_gateway import moderation
 
 logger = logging.getLogger(__name__)
 
@@ -52,6 +53,14 @@ def create_web_search():
     query = body.get("query")
     if not isinstance(query, str) or not query.strip():
         return {"error": "A non-empty `query` string is required"}, 400
+
+    # Screen the search query before it reaches Exa.
+    blocked = moderation.enforce(
+        [query],
+        safety_identifier=moderation.payment_safety_identifier(),
+    )
+    if blocked:
+        return blocked
 
     # Hash the body exactly as the client sent it (canonicalized), so the
     # client can recompute the request hash from what it built. The `endpoint`

--- a/tee_gateway/moderation.py
+++ b/tee_gateway/moderation.py
@@ -1,0 +1,371 @@
+"""In-enclave content moderation gate.
+
+The gateway routes decrypted client content to seven upstream providers, some of
+which have weaker guardrails than others (notably on the image generation/edit
+paths). Enforcement by any single provider protects that provider's policy, not
+this operator's account — abusive *attempts* are still logged against our keys,
+and because the OHTTP layer strips end-user identity (see
+``ohttp_controller._IDENTIFYING_FIELDS``) the upstream provider cannot block the
+individual abuser and holds us responsible instead.
+
+This module adds one automated check that runs *inside the enclave*, before any
+provider call, uniformly across every endpoint and model. Because it is fully
+automated and never surfaces content to a human or the operator, it does not
+weaken the TEE confidentiality guarantee: the content is already decrypted here
+in order to be routed at all.
+
+Design notes:
+
+- The backend is pluggable (``ModerationBackend``). A concrete
+  ``OpenAIModerationBackend`` is provided (OpenAI ``/moderations`` is free, has
+  dedicated ``sexual/minors`` coverage, and is a single HTTP call, so it adds no
+  new dependency and has negligible effect on the enclave image / PCR). A
+  ``StubBackend`` placeholder is also provided for wiring the gate in before a
+  classifier is chosen.
+- ``fail_closed`` controls behavior when the backend is *unreachable* (a network
+  or provider error, distinct from a policy hit). Default is fail-closed: if the
+  gate cannot run, the request is rejected. Flip to fail-open only deliberately.
+- Nothing here is billed. A blocked or gate-unavailable request never reaches a
+  provider and never produces a cost block, so x402 settles nothing for it.
+"""
+
+from __future__ import annotations
+
+import logging
+from abc import ABC, abstractmethod
+from dataclasses import dataclass, field
+from typing import Any, Optional
+
+logger = logging.getLogger(__name__)
+
+# Cap the number of characters we send to the moderation backend per request.
+# Abusive prompts are short; this bounds latency and backend cost on pathological
+# inputs without meaningfully reducing detection.
+_MAX_MODERATION_CHARS = 40_000
+
+
+class ModerationUnavailable(Exception):
+    """The moderation backend could not produce a decision (network/provider error).
+
+    Distinct from a normal "flagged" decision — this means the gate itself failed
+    to run, and ``fail_closed`` decides whether that blocks the request.
+    """
+
+
+@dataclass(frozen=True)
+class ModerationDecision:
+    """Outcome of a moderation check.
+
+    ``allowed`` is the only field the call sites must consult. ``categories`` and
+    ``backend`` are for logging and metrics.
+    """
+
+    allowed: bool
+    categories: list[str] = field(default_factory=list)
+    backend: str = "none"
+
+
+class ModerationBackend(ABC):
+    """A pluggable content classifier."""
+
+    name: str = "abstract"
+
+    @abstractmethod
+    def check(
+        self, texts: list[str], image_data_uris: Optional[list[str]] = None
+    ) -> ModerationDecision:
+        """Classify the given text (and optional inline images).
+
+        Must raise ``ModerationUnavailable`` if it cannot reach a verdict, rather
+        than returning ``allowed=True`` on error — the fail-closed policy depends
+        on the two being distinguishable.
+        """
+        raise NotImplementedError
+
+
+class StubBackend(ModerationBackend):
+    """Placeholder backend that allows everything.
+
+    Used only to wire the gate into the call sites before a real classifier is
+    selected. It never raises, so with this backend the gate is effectively a
+    no-op regardless of ``fail_closed``. Replace before relying on the gate.
+    """
+
+    name = "stub"
+
+    def check(
+        self, texts: list[str], image_data_uris: Optional[list[str]] = None
+    ) -> ModerationDecision:
+        return ModerationDecision(allowed=True, backend=self.name)
+
+
+class OpenAIModerationBackend(ModerationBackend):
+    """Backend using OpenAI's free ``/moderations`` endpoint.
+
+    Reuses the shared OpenAI ``httpx`` client built at key injection
+    (``llm_backend.openai_http_client``), whose base URL is
+    ``https://api.openai.com/v1``, so this posts to ``/moderations``. A transport
+    error, non-2xx status, or unparseable body raises ``ModerationUnavailable``.
+    """
+
+    name = "openai"
+
+    def __init__(self, model: str = "omni-moderation-latest") -> None:
+        self.model = model
+
+    def check(
+        self, texts: list[str], image_data_uris: Optional[list[str]] = None
+    ) -> ModerationDecision:
+        # Imported lazily to avoid a circular import at module load
+        # (llm_backend imports nothing from here, but keep the edge one-way).
+        from tee_gateway import llm_backend
+
+        client = llm_backend.openai_http_client
+        if client is None:
+            raise ModerationUnavailable("OpenAI HTTP client not initialized")
+
+        joined = "\n\n".join(t for t in texts if t)[:_MAX_MODERATION_CHARS]
+
+        # The omni moderation model accepts multimodal input arrays; include any
+        # inline image references so the image gen/edit paths are covered too.
+        input_items: list[dict[str, Any]] = []
+        if joined:
+            input_items.append({"type": "text", "text": joined})
+        for uri in image_data_uris or []:
+            if isinstance(uri, str) and uri.startswith("data:"):
+                input_items.append({"type": "image_url", "image_url": {"url": uri}})
+
+        if not input_items:
+            # Nothing to classify (e.g. an empty request); treat as allowed.
+            return ModerationDecision(allowed=True, backend=self.name)
+
+        try:
+            resp = client.post(
+                "/moderations",
+                json={"model": self.model, "input": input_items},
+            )
+            resp.raise_for_status()
+            data = resp.json()
+        except Exception as exc:  # httpx errors, non-2xx, JSON decode
+            raise ModerationUnavailable(str(exc)) from exc
+
+        results = data.get("results") or []
+        flagged_categories: list[str] = []
+        any_flagged = False
+        for result in results:
+            if not isinstance(result, dict):
+                continue
+            if result.get("flagged"):
+                any_flagged = True
+            categories = result.get("categories") or {}
+            if isinstance(categories, dict):
+                flagged_categories.extend(
+                    name for name, hit in categories.items() if hit
+                )
+
+        return ModerationDecision(
+            allowed=not any_flagged,
+            categories=sorted(set(flagged_categories)),
+            backend=self.name,
+        )
+
+
+# --- Module state ----------------------------------------------------------
+
+_backend: ModerationBackend = StubBackend()
+_enabled: bool = False
+_fail_closed: bool = True
+
+
+def configure_moderation(
+    backend: Optional[ModerationBackend] = None,
+    *,
+    enabled: bool = False,
+    fail_closed: bool = True,
+) -> None:
+    """Configure the moderation gate. Call once at startup / key injection.
+
+    ``enabled=False`` (the default) leaves the gate off so behavior — and the PCR
+    measurement path — is unchanged until an operator opts in. When enabled with
+    the default ``StubBackend`` the gate still allows everything; supply a real
+    backend (e.g. ``OpenAIModerationBackend()``) to actually filter.
+    """
+    global _backend, _enabled, _fail_closed
+    if backend is not None:
+        _backend = backend
+    _enabled = enabled
+    _fail_closed = fail_closed
+    logger.info(
+        "Moderation configured: enabled=%s fail_closed=%s backend=%s",
+        _enabled,
+        _fail_closed,
+        _backend.name,
+    )
+
+
+def is_enabled() -> bool:
+    return _enabled
+
+
+def enforce(
+    texts: list[str],
+    image_data_uris: Optional[list[str]] = None,
+    *,
+    safety_identifier: Optional[str] = None,
+) -> Optional[tuple[dict, int]]:
+    """Run the gate. Return ``None`` to allow, or an ``(error_body, status)`` tuple to reject.
+
+    Call sites use it as::
+
+        blocked = moderation.enforce(texts, images)
+        if blocked:
+            return blocked
+
+    - Policy hit -> ``(403 body)``.
+    - Backend unavailable and ``fail_closed`` -> ``(503 body)``; otherwise allow.
+    ``safety_identifier`` (a stable, non-reversible per-payer id) is logged so a
+    flagged source can be attributed and blocked without de-anonymizing content.
+    """
+    if not _enabled:
+        return None
+
+    try:
+        decision = _backend.check(texts, image_data_uris)
+    except ModerationUnavailable as exc:
+        logger.error(
+            "Moderation backend unavailable (fail_closed=%s, id=%s): %s",
+            _fail_closed,
+            safety_identifier,
+            exc,
+        )
+        if _fail_closed:
+            return (
+                {
+                    "error": "moderation_unavailable",
+                    "message": "Request could not be screened and was not processed.",
+                },
+                503,
+            )
+        return None
+
+    if decision.allowed:
+        return None
+
+    logger.warning(
+        "Request blocked by moderation: categories=%s backend=%s id=%s",
+        decision.categories,
+        decision.backend,
+        safety_identifier,
+    )
+    return (
+        {
+            "error": "content_policy_violation",
+            "message": "This request was rejected by content moderation.",
+        },
+        403,
+    )
+
+
+def payment_safety_identifier() -> Optional[str]:
+    """Derive a stable, non-reversible identifier for the paying wallet, if any.
+
+    The OHTTP layer strips client identity, but x402 ties every paid request to a
+    payer address exposed on Flask's request-global ``g`` by the payment
+    middleware. We hash that address (never the content) so a flagged source can
+    be attributed, rate-limited, or blocked — and passed upstream as a provider
+    "safety identifier" — without de-anonymizing anyone. Returns ``None`` when no
+    payment context is present (e.g. unpaid/local calls).
+    """
+    try:
+        import hashlib
+
+        import x402.http.middleware.flask as x402_flask
+
+        payload = getattr(x402_flask.g, "payment_payload", None)
+        address = _extract_payer_address(payload)
+        if not address:
+            return None
+        return hashlib.sha256(address.lower().encode("utf-8")).hexdigest()[:16]
+    except Exception:
+        return None
+
+
+def _extract_payer_address(payload: Any) -> Optional[str]:
+    """Best-effort pull of the payer address from an x402 payment payload."""
+    if payload is None:
+        return None
+    # Payload shapes vary across x402 schemes; probe the common locations.
+    for getter in (
+        lambda p: getattr(p, "from_address", None),
+        lambda p: getattr(getattr(p, "payload", None), "from_address", None),
+        lambda p: p.get("from") if isinstance(p, dict) else None,
+        lambda p: (p.get("payload") or {}).get("from") if isinstance(p, dict) else None,
+    ):
+        try:
+            value = getter(payload)
+        except Exception:
+            value = None
+        if isinstance(value, str) and value:
+            return value
+    return None
+
+
+# --- Extraction helpers ----------------------------------------------------
+
+
+def texts_from_messages(messages: list) -> list[str]:
+    """Collect moderatable text from OpenAI-format chat messages (dicts or models).
+
+    Pulls the text of user, system, and tool turns (the client-authored content);
+    multimodal ``text`` parts are included, non-text parts are skipped here and
+    handled by ``images_from_messages``.
+    """
+    texts: list[str] = []
+    for msg in messages:
+        role = msg.get("role") if isinstance(msg, dict) else getattr(msg, "role", None)
+        if role not in ("user", "system", "tool", "function", None):
+            continue
+        content = (
+            msg.get("content")
+            if isinstance(msg, dict)
+            else getattr(msg, "content", None)
+        )
+        if isinstance(content, str):
+            if content:
+                texts.append(content)
+        elif isinstance(content, list):
+            for part in content:
+                if isinstance(part, dict) and part.get("type") == "text":
+                    text = part.get("text") or ""
+                    if text:
+                        texts.append(text)
+                elif isinstance(part, str) and part:
+                    texts.append(part)
+    return texts
+
+
+def images_from_messages(messages: list) -> list[str]:
+    """Collect inline ``data:`` image URIs from user turns for image moderation.
+
+    Only inline data URIs are returned; plain remote URLs are deliberately not
+    dereferenced inside the enclave (matching the image-generation path's policy
+    of never fetching client-supplied URLs).
+    """
+    images: list[str] = []
+    for msg in messages:
+        content = (
+            msg.get("content")
+            if isinstance(msg, dict)
+            else getattr(msg, "content", None)
+        )
+        if not isinstance(content, list):
+            continue
+        for part in content:
+            if not isinstance(part, dict):
+                continue
+            if part.get("type") in ("image_url", "image"):
+                image_url = part.get("image_url", part)
+                url = image_url.get("url") if isinstance(image_url, dict) else image_url
+                if isinstance(url, str) and url.startswith("data:"):
+                    images.append(url)
+    return images

--- a/tee_gateway/moderation.py
+++ b/tee_gateway/moderation.py
@@ -43,6 +43,16 @@ logger = logging.getLogger(__name__)
 # inputs without meaningfully reducing detection.
 _MAX_MODERATION_CHARS = 40_000
 
+# Outer-response headers the enclave emits on a policy hit. They ride the same
+# relay-visible channel as the cost headers (see
+# ``ohttp_controller._FORWARDED_HEADER_PREFIXES``), so the relay — which maps the
+# sealed request to the payer it bills — can ban or throttle that user without
+# any client content or identity ever entering the enclave. The gateway still
+# blocks the individual request; this flag is what enables persistent, per-user
+# enforcement at the layer that actually holds identity.
+MODERATION_FLAG_HEADER = "X-OG-Moderation-Flagged"
+MODERATION_CATEGORIES_HEADER = "X-OG-Moderation-Categories"
+
 
 class ModerationUnavailable(Exception):
     """The moderation backend could not produce a decision (network/provider error).
@@ -212,8 +222,8 @@ def enforce(
     image_data_uris: Optional[list[str]] = None,
     *,
     safety_identifier: Optional[str] = None,
-) -> Optional[tuple[dict, int]]:
-    """Run the gate. Return ``None`` to allow, or an ``(error_body, status)`` tuple to reject.
+) -> Optional[tuple[dict, int, dict[str, str]]]:
+    """Run the gate. Return ``None`` to allow, or a ``(body, status, headers)`` tuple to reject.
 
     Call sites use it as::
 
@@ -221,10 +231,17 @@ def enforce(
         if blocked:
             return blocked
 
-    - Policy hit -> ``(403 body)``.
-    - Backend unavailable and ``fail_closed`` -> ``(503 body)``; otherwise allow.
-    ``safety_identifier`` (a stable, non-reversible per-payer id) is logged so a
-    flagged source can be attributed and blocked without de-anonymizing content.
+    The tuple is a Flask/connexion response triple, so a controller returns it
+    directly. On a policy hit the ``headers`` carry ``X-OG-Moderation-Flagged``
+    (and the matched categories); in the OHTTP path these propagate to the relay
+    as outer headers so it can ban the payer it bills. On a screening *outage*
+    (fail-closed 503) **no** flag header is emitted — an unavailable classifier
+    is not evidence of abuse and must not trigger a ban.
+
+    - Policy hit -> ``403`` with flag headers.
+    - Backend unavailable and ``fail_closed`` -> ``503`` (no flag); otherwise allow.
+    ``safety_identifier`` is logged for enclave-side correlation only; the relay
+    uses its own billing identity to enforce.
     """
     if not _enabled:
         return None
@@ -245,6 +262,7 @@ def enforce(
                     "message": "Request could not be screened and was not processed.",
                 },
                 503,
+                {},
             )
         return None
 
@@ -257,12 +275,18 @@ def enforce(
         decision.backend,
         safety_identifier,
     )
+    headers = {MODERATION_FLAG_HEADER: "1"}
+    if decision.categories:
+        # A comma-joined list of policy-class labels (e.g. "sexual/minors") — a
+        # category name, never any client content — so the relay can prioritize.
+        headers[MODERATION_CATEGORIES_HEADER] = ",".join(decision.categories)
     return (
         {
             "error": "content_policy_violation",
             "message": "This request was rejected by content moderation.",
         },
         403,
+        headers,
     )
 
 

--- a/tee_gateway/test/test_moderation.py
+++ b/tee_gateway/test/test_moderation.py
@@ -1,0 +1,123 @@
+"""Unit tests for the in-enclave moderation gate (tee_gateway.moderation)."""
+
+import unittest
+
+from tee_gateway import moderation
+from tee_gateway.moderation import (
+    ModerationBackend,
+    ModerationDecision,
+    ModerationUnavailable,
+    StubBackend,
+)
+
+
+class _AllowBackend(ModerationBackend):
+    name = "allow"
+
+    def check(self, texts, image_data_uris=None):
+        return ModerationDecision(allowed=True, backend=self.name)
+
+
+class _BlockBackend(ModerationBackend):
+    name = "block"
+
+    def check(self, texts, image_data_uris=None):
+        return ModerationDecision(
+            allowed=False, categories=["sexual/minors"], backend=self.name
+        )
+
+
+class _BrokenBackend(ModerationBackend):
+    name = "broken"
+
+    def check(self, texts, image_data_uris=None):
+        raise ModerationUnavailable("upstream down")
+
+
+class ModerationEnforceTest(unittest.TestCase):
+    def tearDown(self):
+        # Reset module state so tests don't leak configuration into each other.
+        moderation.configure_moderation(StubBackend(), enabled=False, fail_closed=True)
+
+    def test_disabled_gate_allows(self):
+        moderation.configure_moderation(_BlockBackend(), enabled=False)
+        self.assertIsNone(moderation.enforce(["anything"]))
+
+    def test_allow_backend_passes(self):
+        moderation.configure_moderation(_AllowBackend(), enabled=True)
+        self.assertIsNone(moderation.enforce(["hello"]))
+
+    def test_block_returns_403(self):
+        moderation.configure_moderation(_BlockBackend(), enabled=True)
+        result = moderation.enforce(["bad content"])
+        self.assertIsNotNone(result)
+        assert result is not None
+        _body, status = result
+        self.assertEqual(status, 403)
+
+    def test_fail_closed_returns_503(self):
+        moderation.configure_moderation(
+            _BrokenBackend(), enabled=True, fail_closed=True
+        )
+        result = moderation.enforce(["x"])
+        self.assertIsNotNone(result)
+        assert result is not None
+        _body, status = result
+        self.assertEqual(status, 503)
+
+    def test_fail_open_allows_on_error(self):
+        moderation.configure_moderation(
+            _BrokenBackend(), enabled=True, fail_closed=False
+        )
+        self.assertIsNone(moderation.enforce(["x"]))
+
+
+class ExtractionTest(unittest.TestCase):
+    def test_texts_from_messages_dicts(self):
+        messages = [
+            {"role": "system", "content": "be nice"},
+            {"role": "user", "content": "hello"},
+            {"role": "assistant", "content": "should be ignored"},
+            {
+                "role": "user",
+                "content": [
+                    {"type": "text", "text": "part text"},
+                    {
+                        "type": "image_url",
+                        "image_url": {"url": "data:image/png;base64,AAAA"},
+                    },
+                ],
+            },
+        ]
+        texts = moderation.texts_from_messages(messages)
+        self.assertIn("be nice", texts)
+        self.assertIn("hello", texts)
+        self.assertIn("part text", texts)
+        self.assertNotIn("should be ignored", texts)
+
+    def test_images_from_messages_inline_only(self):
+        messages = [
+            {
+                "role": "user",
+                "content": [
+                    {
+                        "type": "image_url",
+                        "image_url": {"url": "data:image/png;base64,AAAA"},
+                    },
+                    {
+                        "type": "image_url",
+                        "image_url": {"url": "https://example.com/x.png"},
+                    },
+                ],
+            },
+        ]
+        images = moderation.images_from_messages(messages)
+        self.assertEqual(images, ["data:image/png;base64,AAAA"])
+
+    def test_payment_safety_identifier_no_context(self):
+        # Outside a request/payment context this must not raise, just return None.
+        self.assertIsNone(moderation.payment_safety_identifier())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tee_gateway/test/test_moderation.py
+++ b/tee_gateway/test/test_moderation.py
@@ -47,23 +47,31 @@ class ModerationEnforceTest(unittest.TestCase):
         moderation.configure_moderation(_AllowBackend(), enabled=True)
         self.assertIsNone(moderation.enforce(["hello"]))
 
-    def test_block_returns_403(self):
+    def test_block_returns_403_with_flag_header(self):
         moderation.configure_moderation(_BlockBackend(), enabled=True)
         result = moderation.enforce(["bad content"])
         self.assertIsNotNone(result)
         assert result is not None
-        _body, status = result
+        _body, status, headers = result
         self.assertEqual(status, 403)
+        # The relay bans off this header; the categories carry a policy-class
+        # label only, never client content.
+        self.assertEqual(headers.get(moderation.MODERATION_FLAG_HEADER), "1")
+        self.assertEqual(
+            headers.get(moderation.MODERATION_CATEGORIES_HEADER), "sexual/minors"
+        )
 
-    def test_fail_closed_returns_503(self):
+    def test_fail_closed_returns_503_without_flag(self):
         moderation.configure_moderation(
             _BrokenBackend(), enabled=True, fail_closed=True
         )
         result = moderation.enforce(["x"])
         self.assertIsNotNone(result)
         assert result is not None
-        _body, status = result
+        _body, status, headers = result
         self.assertEqual(status, 503)
+        # A screening outage is not a policy hit — must not flag the user.
+        self.assertNotIn(moderation.MODERATION_FLAG_HEADER, headers)
 
     def test_fail_open_allows_on_error(self):
         moderation.configure_moderation(
@@ -117,6 +125,14 @@ class ExtractionTest(unittest.TestCase):
     def test_payment_safety_identifier_no_context(self):
         # Outside a request/payment context this must not raise, just return None.
         self.assertIsNone(moderation.payment_safety_identifier())
+
+    def test_flag_header_is_forwarded_to_relay(self):
+        # The OHTTP layer must surface the moderation flag to the relay, or the
+        # per-user ban signal never leaves the enclave.
+        from tee_gateway.controllers.ohttp_controller import _should_forward_header
+
+        self.assertTrue(_should_forward_header(moderation.MODERATION_FLAG_HEADER))
+        self.assertTrue(_should_forward_header(moderation.MODERATION_CATEGORIES_HEADER))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Why

OpenAI flagged high-risk traffic (child-sexualization category) against the org's API key. Because the OHTTP layer strips end-user identity, the upstream provider can't block the individual abuser and holds the operator's account responsible instead. Relying on each downstream provider's own filter doesn't help: abusive *attempts* are still logged against our keys, provider filters vary in strength (especially on image gen/edit), and enforcement lands on us. This adds one automated screening layer we control, before any provider call.

## What

- **`moderation.py`** — a pluggable `ModerationBackend` gate:
  - `OpenAIModerationBackend` uses OpenAI's free `/moderations` endpoint (dedicated `sexual/minors` coverage, single HTTP call, no new dependency, negligible PCR impact). `StubBackend` is a placeholder for wiring the gate in before a classifier is chosen.
  - `enforce()` returns **403** on a policy hit and, when **fail-closed** (default), **503** if the backend is unreachable — distinguishing a policy hit from a screening outage. Blocked/unscreened requests never reach a provider and are never billed.
  - Text and inline-image extraction helpers; inline `data:` images are screened, remote URLs are not dereferenced in the enclave.
- **Entry-point wiring** — the gate runs in `create_chat_completion` (covers chat + the image generation/edit paths that dispatch from it), `create_completion`, and `create_web_search`.
- **Safety identifier** — derive a stable, non-reversible id from the x402 payer address so a flagged source can be attributed/blocked without de-anonymizing content (this is the abuse-resistant version of OpenAI's requested "safety identifiers").
- **Configuration at key injection** — on by default when an OpenAI key is present, fail-closed; both overridable via `moderation_enabled` / `moderation_fail_closed` in the key-injection body. Runtime config only, so **PCR measurements are unaffected**.

## Tests

`tee_gateway/test/test_moderation.py` — allow/block/fail-closed/fail-open enforcement paths and the extraction helpers. `make lint` (ruff + mypy) clean; existing controller/ohttp/web-search suites still pass.

## Notes / follow-ups (not in this PR)

- Rotate and re-inject the flagged OpenAI key.
- Passing the derived safety identifier *through* to each provider call (LangChain path) is left as a follow-up to avoid disturbing the signing/caching path in this change.
- CSAM specifically carries mandatory-reporting obligations (US: NCMEC CyberTipline) — a process concern for legal/T&S, out of scope for code here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VrqnR24nqPGQ6vJeWamoS3

---
_Generated by [Claude Code](https://claude.ai/code/session_01VrqnR24nqPGQ6vJeWamoS3)_