### PR TITLE
Set store=false on OpenAI chat calls to opt out of prompt retention

### DIFF
--- a/tee_gateway/llm_backend.py
+++ b/tee_gateway/llm_backend.py
@@ -256,6 +256,10 @@ def get_chat_model_cached(
             api_key=SecretStr(config.openai_api_key),
             streaming=True,
             stream_usage=True,
+            # OpenAI retains request/response logs when `store` is unset (the
+            # Responses API defaults it to true). Explicitly opt out so
+            # prompts never persist outside the enclave.
+            store=False,
             **openai_kwargs,
         )  # type: ignore [call-arg]
 


### PR DESCRIPTION
## Summary

Prompts routed through the gateway to OpenAI were being persisted as logs on OpenAI's side: the `store` flag was never sent, and OpenAI's Responses API (which the gpt-5.6 family is forced onto via `use_responses_api`) defaults `store` to **true**. Chat Completions can also retain logs when the flag is unset.

This sets `store=False` explicitly on the OpenAI `ChatOpenAI` client in `llm_backend.py`. `store` is a first-class field in the installed `langchain-openai` (1.3.4), and it propagates into the outgoing request payload on **both** the Chat Completions and Responses API paths (verified against `_get_request_payload`).

Other OpenAI-compatible providers (xAI, ByteDance, Nous, Z.ai) are left untouched since `store` is an OpenAI-specific parameter that those backends may reject.

## Testing

- `make lint` — ruff + mypy clean
- `pytest tee_gateway/test` — 216 passed, 4 skipped

---
_Generated by [Claude Code](https://claude.ai/code/session_01BFvvsXNE6NvVxWDSqfbTJf)_