### PR TITLE
Add in-enclave moderation of image requests via OpenAI omni-moderation

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -184,10 +184,13 @@ to the relay or the gateway operator. Points to keep in mind:
 
 ### Content Moderation
 
-Every `/v1/chat/completions` request (text and image-generation alike) is
-scored against OpenAI's free `omni-moderation-latest` endpoint before any
-provider is called (`moderation.py`). The check covers the newest user turn:
-its text plus any attached images. Points to keep in mind:
+`/v1/chat/completions` requests are scored against OpenAI's free
+`omni-moderation-latest` endpoint before any provider is called
+(`moderation.py`). The check covers the newest user turn: its text plus any
+attached images. **Initial rollout scope** (`MODERATE_IMAGE_REQUESTS_ONLY`,
+default True): only image requests are scored — image generation, image
+editing, and inline-image chat models; text chat skips the pre-flight
+entirely. Flip that one flag to score every request. Points to keep in mind:
 
 - **Fail-open**: no OpenAI key or a moderation outage means requests proceed
   unscored (`checked: false`); a positive verdict always comes from a real

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -184,13 +184,14 @@ to the relay or the gateway operator. Points to keep in mind:
 
 ### Content Moderation
 
-`/v1/chat/completions` requests are scored against OpenAI's free
+Image requests on `/v1/chat/completions` — image generation, image editing,
+and inline-image chat models — are scored against OpenAI's free
 `omni-moderation-latest` endpoint before any provider is called
-(`moderation.py`). The check covers the newest user turn: its text plus any
-attached images. **Initial rollout scope** (`MODERATE_IMAGE_REQUESTS_ONLY`,
-default True): only image requests are scored — image generation, image
-editing, and inline-image chat models; text chat skips the pre-flight
-entirely. Flip that one flag to score every request. Points to keep in mind:
+(`moderation.py`). The check covers the newest user turn: its prompt text plus
+any attached images. **Plain text chat is not moderated**; widening scope
+there is a deliberate future change (the `should_moderate_model` predicate is
+the one gate to widen — everything downstream keys off the flag headers).
+Points to keep in mind:
 
 - **Fail-open**: no OpenAI key or a moderation outage means requests proceed
   unscored (`checked: false`); a positive verdict always comes from a real

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -182,6 +182,33 @@ to the relay or the gateway operator. Points to keep in mind:
 - Exa's self-reported `costDollars` is logged for margin reconciliation only;
   settlement never depends on it.
 
+### Content Moderation
+
+Every `/v1/chat/completions` request (text and image-generation alike) is
+scored against OpenAI's free `omni-moderation-latest` endpoint before any
+provider is called (`moderation.py`). The check covers the newest user turn:
+its text plus any attached images. Points to keep in mind:
+
+- **Fail-open**: no OpenAI key or a moderation outage means requests proceed
+  unscored (`checked: false`); a positive verdict always comes from a real
+  moderation response. `/health` reports `moderation_enabled`.
+- **Blocking**: a request flagged for a category in
+  `moderation.BLOCKED_CATEGORIES` (default: `sexual/minors` only) is refused
+  with HTTP 451 + `code: "moderation_blocked"` and never reaches a provider.
+  All other flagged categories are reported but still served.
+- **Response surface**: the full verdict (flagged/blocked/categories/scores)
+  rides inside the sealed response body under the `moderation` key —
+  non-streaming responses and the final SSE frame alike — outside the signed
+  output hash, exactly like `images` and `usage`.
+- **Relay signal**: flagged requests additionally carry content-free
+  `X-Moderation-Flagged` / `X-Moderation-Categories` / `X-Moderation-Blocked`
+  outer headers (forwarded through the OHTTP path) so the relay can run its
+  per-user strike/blacklist policy. Clean traffic carries none of these — it
+  is byte-identical to before.
+- **Billing**: the moderation call is free and adds no cost block changes;
+  blocked (451) requests produce no `opengradient` block and are never
+  settled.
+
 ## Verification Examples
 
 - `examples/verify_attestation.py` — Validates AWS Nitro attestation documents against the root CA

--- a/tee_gateway/__main__.py
+++ b/tee_gateway/__main__.py
@@ -22,6 +22,7 @@ from tee_gateway.config import (
     DEFAULT_HEARTBEAT_INTERVAL,
 )
 from tee_gateway.llm_backend import get_provider_config, set_provider_config
+from tee_gateway.moderation import moderation_available
 from tee_gateway.web_search import web_search_available
 from tee_gateway.heartbeat import create_heartbeat_service
 from tee_gateway.controllers.ohttp_controller import (
@@ -534,6 +535,7 @@ def set_provider_keys():
             "providers_initialized": providers_set,
             "heartbeat_enabled": heartbeat_config is not None,
             "web_search_enabled": bool(provider_config.exa_api_key),
+            "moderation_enabled": bool(provider_config.openai_api_key),
         }
     ), 200
 
@@ -552,6 +554,9 @@ def health():
         # Not a provider capability — the search endpoint has no model — so it
         # is reported separately from `providers`.
         "web_search_enabled": web_search_available(),
+        # Whether chat prompts are being scored against OpenAI's moderation
+        # endpoint (requires the OpenAI key; fail-open when unavailable).
+        "moderation_enabled": moderation_available(),
         "facilitator_url": _active_facilitator_url,
         "price_feed": _price_feed.get_status(),
     }, 200

--- a/tee_gateway/controllers/chat_controller.py
+++ b/tee_gateway/controllers/chat_controller.py
@@ -39,7 +39,11 @@ from tee_gateway.image_generation import (
     create_image_generation_streaming_response,
 )
 from tee_gateway.model_registry import get_model_config
-from tee_gateway.moderation import ModerationOutcome, moderate_messages
+from tee_gateway.moderation import (
+    ModerationOutcome,
+    moderate_messages,
+    should_moderate_model,
+)
 from tee_gateway.pricing import compute_session_cost
 
 logger = logging.getLogger(__name__)
@@ -98,12 +102,18 @@ def create_chat_completion(body):
     except AttachmentValidationError as e:
         return {"error": "Invalid attachment", "message": str(e)}, 400
 
-    # Score the newest user turn before any provider work. Fail-open: an
+    # Score the newest user turn before any provider work. Initial rollout
+    # scope: image requests only (see moderation.MODERATE_IMAGE_REQUESTS_ONLY);
+    # out-of-scope requests skip the pre-flight entirely. Fail-open: an
     # unavailable moderation endpoint yields an unchecked outcome, never a
     # refusal. Only BLOCKED_CATEGORIES verdicts stop the request here; other
     # flags ride along on the response for the relay/client to act on.
-    moderation = moderate_messages(chat_request.messages)
-    if moderation.blocked:
+    moderation = (
+        moderate_messages(chat_request.messages)
+        if should_moderate_model(chat_request.model)
+        else None
+    )
+    if moderation is not None and moderation.blocked:
         return (
             {
                 "error": "Content policy violation",

--- a/tee_gateway/controllers/chat_controller.py
+++ b/tee_gateway/controllers/chat_controller.py
@@ -39,6 +39,7 @@ from tee_gateway.image_generation import (
     create_image_generation_streaming_response,
 )
 from tee_gateway.model_registry import get_model_config
+from tee_gateway.moderation import ModerationOutcome, moderate_messages
 from tee_gateway.pricing import compute_session_cost
 
 logger = logging.getLogger(__name__)
@@ -97,10 +98,31 @@ def create_chat_completion(body):
     except AttachmentValidationError as e:
         return {"error": "Invalid attachment", "message": str(e)}, 400
 
+    # Score the newest user turn before any provider work. Fail-open: an
+    # unavailable moderation endpoint yields an unchecked outcome, never a
+    # refusal. Only BLOCKED_CATEGORIES verdicts stop the request here; other
+    # flags ride along on the response for the relay/client to act on.
+    moderation = moderate_messages(chat_request.messages)
+    if moderation.blocked:
+        return (
+            {
+                "error": "Content policy violation",
+                "message": (
+                    "This request was flagged by content moderation for a "
+                    "prohibited category and was not forwarded to the model "
+                    "provider."
+                ),
+                "code": "moderation_blocked",
+                "moderation": moderation.to_response_dict(),
+            },
+            451,
+            moderation.headers(),
+        )
+
     if chat_request.stream:
-        return _create_streaming_response(chat_request)
+        return _create_streaming_response(chat_request, moderation)
     else:
-        return _create_non_streaming_response(chat_request)
+        return _create_non_streaming_response(chat_request, moderation)
 
 
 def _build_tools_list(chat_request: CreateChatCompletionRequest) -> list:
@@ -222,7 +244,10 @@ def _messages_contain_json_word(messages: list) -> bool:
     return False
 
 
-def _create_non_streaming_response(chat_request: CreateChatCompletionRequest):
+def _create_non_streaming_response(
+    chat_request: CreateChatCompletionRequest,
+    moderation: ModerationOutcome | None = None,
+):
     """Handle non-streaming chat completion via direct LangChain call."""
     try:
         logger.info("=" * 80)
@@ -241,7 +266,9 @@ def _create_non_streaming_response(chat_request: CreateChatCompletionRequest):
         # surfaced through this same endpoint, returning images out-of-band just
         # like Gemini's inline-image models.
         if cfg.image_generation:
-            return create_image_generation_response(chat_request, request_bytes)
+            return create_image_generation_response(
+                chat_request, request_bytes, moderation
+            )
 
         # Build the tools list first: some OpenAI models (gpt-5.6 family) must be
         # constructed against the Responses API when function tools are bound.
@@ -376,8 +403,16 @@ def _create_non_streaming_response(chat_request: CreateChatCompletionRequest):
                 provider,
             )
 
+        # The moderation verdict rides inside the (sealed) response body like
+        # images/usage — not part of the output hash. Flagged requests also get
+        # content-free X-Moderation-* headers for the relay's strike policy.
+        if moderation is not None and moderation.checked:
+            openai_response["moderation"] = moderation.to_response_dict()
+
         # Validate schema (the extra tee_* fields are preserved by returning dict directly)
         CreateChatCompletionResponse.from_dict(openai_response)
+        if moderation is not None and moderation.flagged:
+            return openai_response, 200, moderation.headers()
         return openai_response
 
     except Exception as e:
@@ -388,7 +423,10 @@ def _create_non_streaming_response(chat_request: CreateChatCompletionRequest):
         }, 500
 
 
-def _create_streaming_response(chat_request: CreateChatCompletionRequest):
+def _create_streaming_response(
+    chat_request: CreateChatCompletionRequest,
+    moderation: ModerationOutcome | None = None,
+):
     """Handle streaming chat completion via direct LangChain call."""
     try:
         provider = get_provider_from_model(chat_request.model)
@@ -407,7 +445,7 @@ def _create_streaming_response(chat_request: CreateChatCompletionRequest):
         # images endpoint; handle them without building a chat model.
         if get_model_config(chat_request.model).image_generation:
             return create_image_generation_streaming_response(
-                chat_request, request_bytes
+                chat_request, request_bytes, moderation
             )
 
         # Build the tools list first: some OpenAI models (gpt-5.6 family) must be
@@ -765,6 +803,10 @@ def _create_streaming_response(chat_request: CreateChatCompletionRequest):
                 # are not part of the signed output hash.
                 if generated_images:
                     final_data["images"] = generated_images
+                # Moderation verdict rides the final frame the same way (the
+                # flag headers were already flushed with the response headers).
+                if moderation is not None and moderation.checked:
+                    final_data["moderation"] = moderation.to_response_dict()
 
                 logger.debug(
                     f"Response Final\n\tTEE Signature: {tee_signature}\n\tTEE request hash: {input_hash_hex}\n\tTEE output hash: {output_hash_hex}\n\tTEE timestamp: {timestamp}\n\tTEE ID: 0x{tee_keys.get_tee_id()}"
@@ -825,6 +867,7 @@ def _create_streaming_response(chat_request: CreateChatCompletionRequest):
             headers={
                 "Cache-Control": "no-cache",
                 "Connection": "keep-alive",
+                **(moderation.headers() if moderation is not None else {}),
             },
         )
 

--- a/tee_gateway/controllers/chat_controller.py
+++ b/tee_gateway/controllers/chat_controller.py
@@ -102,12 +102,12 @@ def create_chat_completion(body):
     except AttachmentValidationError as e:
         return {"error": "Invalid attachment", "message": str(e)}, 400
 
-    # Score the newest user turn before any provider work. Initial rollout
-    # scope: image requests only (see moderation.MODERATE_IMAGE_REQUESTS_ONLY);
-    # out-of-scope requests skip the pre-flight entirely. Fail-open: an
-    # unavailable moderation endpoint yields an unchecked outcome, never a
-    # refusal. Only BLOCKED_CATEGORIES verdicts stop the request here; other
-    # flags ride along on the response for the relay/client to act on.
+    # Score the newest user turn of image requests before any provider work
+    # (text chat is not moderated — see moderation.should_moderate_model).
+    # Fail-open: an unavailable moderation endpoint yields an unchecked
+    # outcome, never a refusal. Only BLOCKED_CATEGORIES verdicts stop the
+    # request here; other flags ride along on the response for the
+    # relay/client to act on.
     moderation = (
         moderate_messages(chat_request.messages)
         if should_moderate_model(chat_request.model)

--- a/tee_gateway/controllers/ohttp_controller.py
+++ b/tee_gateway/controllers/ohttp_controller.py
@@ -113,8 +113,17 @@ _INNER_ENDPOINT_PATHS = {
 }
 
 # Response headers we propagate from the inner /v1/chat/completions response
-# back through the relay to the client.
-_FORWARDED_HEADER_PREFIXES = ("x-payment", "x-upto", "x-settlement", "x-tee")
+# back through the relay to the client. x-moderation-* is a deliberate, narrow
+# exception to "the relay learns nothing": a content-free flagged/blocked bit
+# (plus category names) the relay needs to run its per-user strike/blacklist
+# policy. It is only emitted on flagged requests — clean traffic carries none.
+_FORWARDED_HEADER_PREFIXES = (
+    "x-payment",
+    "x-upto",
+    "x-settlement",
+    "x-tee",
+    "x-moderation",
+)
 _FORWARDED_HEADER_NAMES = ("www-authenticate",)
 
 

--- a/tee_gateway/image_generation.py
+++ b/tee_gateway/image_generation.py
@@ -35,6 +35,7 @@ import httpx
 from flask import Response
 
 from tee_gateway import llm_backend
+from tee_gateway.moderation import ModerationOutcome
 from tee_gateway.models.create_chat_completion_request import (
     CreateChatCompletionRequest,
 )
@@ -519,7 +520,9 @@ def _run_image_generation(
 
 
 def create_image_generation_response(
-    chat_request: CreateChatCompletionRequest, request_bytes: bytes
+    chat_request: CreateChatCompletionRequest,
+    request_bytes: bytes,
+    moderation: ModerationOutcome | None = None,
 ):
     """Non-streaming image generation via a provider's images endpoint.
 
@@ -547,13 +550,21 @@ def create_image_generation_response(
     }
     if result["opengradient"] is not None:
         openai_response["opengradient"] = result["opengradient"]
+    # Prompt moderation verdict (computed by the chat controller before the
+    # generation ran) rides inside the sealed body like the images themselves.
+    if moderation is not None and moderation.checked:
+        openai_response["moderation"] = moderation.to_response_dict()
 
     CreateChatCompletionResponse.from_dict(openai_response)
+    if moderation is not None and moderation.flagged:
+        return openai_response, 200, moderation.headers()
     return openai_response
 
 
 def create_image_generation_streaming_response(
-    chat_request: CreateChatCompletionRequest, request_bytes: bytes
+    chat_request: CreateChatCompletionRequest,
+    request_bytes: bytes,
+    moderation: ModerationOutcome | None = None,
 ):
     """Streaming image generation: image gen is not a token stream, so we invoke
     once and emit the result on the final SSE frame (mirrors the Gemini path)."""
@@ -577,6 +588,8 @@ def create_image_generation_streaming_response(
                 final_data["images"] = result["images"]
             if result["opengradient"] is not None:
                 final_data["opengradient"] = result["opengradient"]
+            if moderation is not None and moderation.checked:
+                final_data["moderation"] = moderation.to_response_dict()
 
             yield f"data: {json.dumps(final_data)}\n\n"
             yield "data: [DONE]\n\n"
@@ -594,5 +607,9 @@ def create_image_generation_streaming_response(
     return Response(
         generate(),
         mimetype="text/event-stream",
-        headers={"Cache-Control": "no-cache", "Connection": "keep-alive"},
+        headers={
+            "Cache-Control": "no-cache",
+            "Connection": "keep-alive",
+            **(moderation.headers() if moderation is not None else {}),
+        },
     )

--- a/tee_gateway/llm_backend.py
+++ b/tee_gateway/llm_backend.py
@@ -28,6 +28,7 @@ from langchain_xai import ChatXAI
 
 from tee_gateway.config import ProviderConfig
 from tee_gateway.model_registry import get_model_config
+from tee_gateway.moderation import configure_moderation_client
 from tee_gateway.web_search import configure_exa_client
 
 logger = logging.getLogger(__name__)
@@ -135,6 +136,10 @@ def set_provider_config(config: ProviderConfig) -> None:
     # Web search runs inside the enclave against Exa rather than through any
     # provider's native tool, so its client is built here alongside them.
     configure_exa_client(config.exa_api_key)
+
+    # Prompt moderation reuses the OpenAI key but gets its own client with a
+    # much tighter timeout — it runs synchronously in front of every chat call.
+    configure_moderation_client(config.openai_api_key)
 
     get_chat_model_cached.cache_clear()
     _provider_config = config

--- a/tee_gateway/models/create_chat_completion_response.py
+++ b/tee_gateway/models/create_chat_completion_response.py
@@ -11,6 +11,7 @@ class CreateChatCompletionResponse:
         system_fingerprint=None,
         object=None,
         usage=None,
+        moderation=None,
     ):
         self.id = id
         self.choices = choices
@@ -20,6 +21,7 @@ class CreateChatCompletionResponse:
         self.system_fingerprint = system_fingerprint
         self.object = object
         self.usage = usage
+        self.moderation = moderation
 
     @classmethod
     def from_dict(cls, dikt) -> "CreateChatCompletionResponse":
@@ -34,4 +36,5 @@ class CreateChatCompletionResponse:
             system_fingerprint=dikt.get("system_fingerprint"),
             object=dikt.get("object"),
             usage=dikt.get("usage"),
+            moderation=dikt.get("moderation"),
         )

--- a/tee_gateway/moderation.py
+++ b/tee_gateway/moderation.py
@@ -48,6 +48,8 @@ from typing import Any, Optional
 
 import httpx
 
+from tee_gateway.model_registry import get_model_config
+
 logger = logging.getLogger(__name__)
 
 MODERATION_BASE_URL = "https://api.openai.com/v1"
@@ -59,6 +61,15 @@ MODERATION_MODEL = "omni-moderation-latest"
 # category with essentially no legitimate-use false-positive cost, and the one
 # provider trust-and-safety teams act on.
 BLOCKED_CATEGORIES = frozenset({"sexual/minors"})
+
+# Initial rollout scope: moderate only image requests — image generation,
+# image editing (reference images ride the same image-generation request), and
+# the inline-image chat models — where the abuse being fought lives and where
+# the added pre-flight latency is invisible next to multi-second generation.
+# Flip to False to score every chat request; nothing else needs to change (the
+# relay's strike policy and the app's warning UI key off the flag headers,
+# which plain-text requests simply never carry while this is True).
+MODERATE_IMAGE_REQUESTS_ONLY = True
 
 # Bounds on what we send to the moderation endpoint. The newest user turn is
 # almost always far below these; they exist so a pathological request can't
@@ -109,6 +120,23 @@ def configure_moderation_client(api_key: Optional[str]) -> None:
 def moderation_available() -> bool:
     """Whether an OpenAI key was injected, i.e. whether prompts can be scored."""
     return _moderation_http_client is not None
+
+
+def should_moderate_model(model: str) -> bool:
+    """Whether requests for this model fall inside the moderation scope.
+
+    While ``MODERATE_IMAGE_REQUESTS_ONLY`` is set, only image requests are
+    scored: models served via a provider images endpoint (generation and
+    editing) and inline-image chat models. Unknown models are left to the
+    normal routing error path rather than moderated speculatively.
+    """
+    if not MODERATE_IMAGE_REQUESTS_ONLY:
+        return True
+    try:
+        cfg = get_model_config(model)
+    except Exception:
+        return False
+    return bool(cfg.image_generation or cfg.image_output)
 
 
 @dataclass(frozen=True)

--- a/tee_gateway/moderation.py
+++ b/tee_gateway/moderation.py
@@ -1,0 +1,317 @@
+"""In-enclave prompt moderation, backed by OpenAI's moderation endpoint.
+
+Every /v1/chat/completions request is scored against OpenAI's
+``omni-moderation-latest`` model (https://platform.openai.com/docs/guides/moderation)
+before it is forwarded to any provider. The check covers the newest user turn —
+its text and any attached images (image editing / compositing inputs ride on
+that turn as ``data:`` URIs, so they are scored too). Earlier turns were scored
+by their own requests; re-scoring the whole transcript would double-count one
+offense on every subsequent message and on every round of a client tool loop.
+
+What the verdict does:
+
+  * The full result (flagged, categories, per-category scores) is attached to
+    the response under the ``moderation`` key — inside the encrypted OHTTP
+    envelope, so only the end client sees it. Like ``images`` and ``usage`` it
+    rides in the signed envelope without being part of the output hash.
+  * A compact, content-free abuse signal is surfaced as outer response headers
+    (``X-Moderation-Flagged`` / ``X-Moderation-Categories`` /
+    ``X-Moderation-Blocked``) that the OHTTP relay is allowed to see. This is a
+    deliberate, narrow exception to the "relay learns nothing" stance: the
+    relay operates the user-facing service and needs a per-request abuse bit to
+    enforce strike/blacklist policy on its own users. The headers never carry
+    prompt content, scores, model names, or token counts, and they are only
+    emitted when a request is actually flagged — clean traffic is
+    byte-identical to before.
+  * Requests flagged for a category in ``BLOCKED_CATEGORIES`` (child sexual
+    abuse material, by default) are refused outright — the gateway returns an
+    HTTP 451 error and never forwards the prompt to the model provider.
+
+Failure policy is fail-open: if the moderation endpoint is unreachable, errors,
+or no OpenAI key was injected, the request proceeds unscored (``checked`` is
+False and no flag headers are emitted). Moderation is an abuse-rate-limiting
+layer, not the only line of defense — providers run their own safety systems —
+and a moderation outage must not take down inference for every clean user.
+
+The moderation call itself is free (OpenAI does not bill the endpoint), so it
+has no effect on x402 billing: the ``opengradient`` cost block is computed
+exactly as before.
+
+The OpenAI API key is injected at runtime via ``POST /v1/keys`` like every
+provider key; without it the gateway reports ``moderation_enabled: false`` on
+``/health``.
+"""
+
+import logging
+from dataclasses import dataclass, field
+from typing import Any, Optional
+
+import httpx
+
+logger = logging.getLogger(__name__)
+
+MODERATION_BASE_URL = "https://api.openai.com/v1"
+MODERATION_MODEL = "omni-moderation-latest"
+
+# Categories that cause the request to be refused in the enclave rather than
+# forwarded to a provider. Everything else is reported (and counted by the
+# relay's strike policy) but still served. Deliberately minimal: this is the
+# category with essentially no legitimate-use false-positive cost, and the one
+# provider trust-and-safety teams act on.
+BLOCKED_CATEGORIES = frozenset({"sexual/minors"})
+
+# Bounds on what we send to the moderation endpoint. The newest user turn is
+# almost always far below these; they exist so a pathological request can't
+# make the pre-flight check slower than the inference it guards.
+MAX_TEXT_CHARS = 20_000
+MAX_IMAGE_PARTS = 5
+
+# Score floor below which a category's score is omitted from the response
+# payload (flagged categories are always included). Keeps the moderation block
+# readable instead of thirteen near-zero floats.
+SCORE_FLOOR = 0.01
+
+# Tight budget: this runs synchronously in front of every chat request, so it
+# must degrade fast. Images push payloads into the megabytes, hence the write
+# allowance; the endpoint itself typically answers in well under a second.
+_MODERATION_TIMEOUT = httpx.Timeout(timeout=15.0, connect=5.0, read=10.0, write=10.0)
+_MODERATION_LIMITS = httpx.Limits(max_keepalive_connections=5, max_connections=20)
+
+_moderation_http_client: Optional[httpx.Client] = None
+
+
+def configure_moderation_client(api_key: Optional[str]) -> None:
+    """Build (or tear down) the shared moderation HTTP client after key injection.
+
+    Called from ``llm_backend.set_provider_config`` alongside the provider
+    clients. Uses its own client rather than the shared OpenAI chat client so
+    the pre-flight check gets a much tighter timeout than a 180s inference call.
+    """
+    global _moderation_http_client
+
+    old = _moderation_http_client
+    if api_key:
+        _moderation_http_client = httpx.Client(
+            base_url=MODERATION_BASE_URL,
+            headers={"Authorization": f"Bearer {api_key}"},
+            timeout=_MODERATION_TIMEOUT,
+            limits=_MODERATION_LIMITS,
+            http2=True,
+            follow_redirects=False,
+        )
+    else:
+        _moderation_http_client = None
+
+    if old is not None:
+        old.close()
+
+
+def moderation_available() -> bool:
+    """Whether an OpenAI key was injected, i.e. whether prompts can be scored."""
+    return _moderation_http_client is not None
+
+
+@dataclass(frozen=True)
+class ModerationOutcome:
+    """The verdict for one request.
+
+    ``checked`` is False when the request could not be scored (no key, endpoint
+    failure, or nothing to score) — the fail-open path. ``blocked`` implies
+    ``flagged``; it means the request must not reach a model provider.
+    ``categories`` holds only the category names the moderation model flagged.
+    """
+
+    checked: bool
+    flagged: bool = False
+    blocked: bool = False
+    categories: tuple[str, ...] = ()
+    category_scores: dict[str, float] = field(default_factory=dict)
+    error: Optional[str] = None
+
+    def to_response_dict(self) -> dict[str, Any]:
+        """The ``moderation`` block attached inside the (sealed) response body."""
+        block: dict[str, Any] = {
+            "model": MODERATION_MODEL,
+            "checked": self.checked,
+            "flagged": self.flagged,
+            "blocked": self.blocked,
+            "categories": list(self.categories),
+            "category_scores": self.category_scores,
+        }
+        if self.error:
+            block["error"] = self.error
+        return block
+
+    def headers(self) -> dict[str, str]:
+        """Content-free flag headers for the relay's strike/blacklist policy.
+
+        Empty for clean (or unchecked) requests so unflagged traffic exposes
+        nothing new to the relay.
+        """
+        if not self.flagged:
+            return {}
+        headers = {
+            "X-Moderation-Flagged": "true",
+            "X-Moderation-Categories": ",".join(self.categories),
+        }
+        if self.blocked:
+            headers["X-Moderation-Blocked"] = "true"
+        return headers
+
+
+_UNCHECKED = ModerationOutcome(checked=False)
+
+
+def extract_moderation_input(messages: list) -> tuple[str, list[str]]:
+    """Pull the text and image URLs of the newest user turn.
+
+    Accepts the request's message objects (or plain dicts) and returns
+    ``(text, image_urls)`` for the last message with role ``user``. Images are
+    kept only if they are ``data:`` URIs or http(s) URLs — the two forms the
+    moderation endpoint accepts. Other attachment kinds (PDFs, audio) are not
+    scoreable and are skipped.
+    """
+    for msg in reversed(messages or []):
+        role = msg.get("role") if isinstance(msg, dict) else getattr(msg, "role", "")
+        if (role or "").lower() != "user":
+            continue
+        content = (
+            msg.get("content") if isinstance(msg, dict) else getattr(msg, "content", "")
+        )
+        return _split_content(content)
+    return "", []
+
+
+def _split_content(content: Any) -> tuple[str, list[str]]:
+    if content is None:
+        return "", []
+    if isinstance(content, str):
+        return content, []
+    if not isinstance(content, list):
+        return str(content), []
+
+    text_parts: list[str] = []
+    images: list[str] = []
+    for part in content:
+        if not isinstance(part, dict):
+            text_parts.append(str(part))
+            continue
+        ptype = part.get("type")
+        if ptype == "text":
+            text = part.get("text", "") or ""
+            if text:
+                text_parts.append(text)
+        elif ptype == "image_url":
+            image_url = part.get("image_url")
+            url = image_url.get("url") if isinstance(image_url, dict) else image_url
+            if isinstance(url, str) and url.startswith(
+                ("data:", "http://", "https://")
+            ):
+                images.append(url)
+        elif ptype == "image":
+            data = part.get("base64") or part.get("data")
+            if data:
+                mime = part.get("mime_type") or "image/png"
+                images.append(f"data:{mime};base64,{data}")
+    return "\n".join(text_parts), images
+
+
+def moderate_messages(messages: list) -> ModerationOutcome:
+    """Score the newest user turn of a chat request. Never raises.
+
+    Every failure mode returns an unchecked outcome (fail-open); a positive
+    verdict requires an actual moderation-model response.
+    """
+    client = _moderation_http_client
+    if client is None:
+        return _UNCHECKED
+
+    text, images = extract_moderation_input(messages)
+    text = text[:MAX_TEXT_CHARS]
+    images = images[:MAX_IMAGE_PARTS]
+    if not text.strip() and not images:
+        return _UNCHECKED
+
+    if images:
+        input_payload: Any = []
+        if text.strip():
+            input_payload.append({"type": "text", "text": text})
+        input_payload.extend(
+            {"type": "image_url", "image_url": {"url": url}} for url in images
+        )
+    else:
+        input_payload = text
+
+    try:
+        response = client.post(
+            "/moderations",
+            json={"model": MODERATION_MODEL, "input": input_payload},
+        )
+    except httpx.HTTPError as exc:
+        logger.warning(
+            "Moderation request failed — proceeding unscored: %s: %s",
+            type(exc).__name__,
+            exc,
+        )
+        return ModerationOutcome(checked=False, error="moderation request failed")
+
+    if response.status_code != 200:
+        logger.warning(
+            "Moderation endpoint returned %s — proceeding unscored: %s",
+            response.status_code,
+            _error_detail(response),
+        )
+        return ModerationOutcome(checked=False, error="moderation endpoint error")
+
+    try:
+        result = response.json()["results"][0]
+        flagged = bool(result.get("flagged"))
+        raw_categories = result.get("categories") or {}
+        raw_scores = result.get("category_scores") or {}
+        flagged_categories = tuple(
+            sorted(name for name, hit in raw_categories.items() if hit)
+        )
+    except (KeyError, IndexError, TypeError, ValueError) as exc:
+        logger.warning(
+            "Moderation response unparseable — proceeding unscored: %s: %s",
+            type(exc).__name__,
+            exc,
+        )
+        return ModerationOutcome(checked=False, error="moderation response invalid")
+
+    scores = {
+        name: round(float(score), 4)
+        for name, score in raw_scores.items()
+        if isinstance(score, (int, float))
+        and (score >= SCORE_FLOOR or name in flagged_categories)
+    }
+    blocked = any(name in BLOCKED_CATEGORIES for name in flagged_categories)
+
+    if flagged:
+        # Log category names only — never prompt content.
+        logger.warning(
+            "Moderation flagged request categories=%s blocked=%s",
+            ",".join(flagged_categories),
+            blocked,
+        )
+
+    return ModerationOutcome(
+        checked=True,
+        flagged=flagged,
+        blocked=blocked,
+        categories=flagged_categories,
+        category_scores=scores,
+    )
+
+
+def _error_detail(response: httpx.Response) -> str:
+    """A compact, safe-to-log description of a non-200 moderation response."""
+    try:
+        body = response.json()
+        if isinstance(body, dict):
+            error = body.get("error")
+            if isinstance(error, dict) and error.get("message"):
+                return str(error["message"])[:200]
+    except Exception:
+        pass
+    return response.text[:200] if response.text else "<empty body>"

--- a/tee_gateway/moderation.py
+++ b/tee_gateway/moderation.py
@@ -1,12 +1,16 @@
-"""In-enclave prompt moderation, backed by OpenAI's moderation endpoint.
+"""In-enclave moderation of image requests, backed by OpenAI's moderation endpoint.
 
-Every /v1/chat/completions request is scored against OpenAI's
-``omni-moderation-latest`` model (https://platform.openai.com/docs/guides/moderation)
-before it is forwarded to any provider. The check covers the newest user turn —
-its text and any attached images (image editing / compositing inputs ride on
-that turn as ``data:`` URIs, so they are scored too). Earlier turns were scored
-by their own requests; re-scoring the whole transcript would double-count one
-offense on every subsequent message and on every round of a client tool loop.
+Image requests on /v1/chat/completions — image generation, image editing
+(reference images ride the same request), and the inline-image chat models —
+are scored against OpenAI's ``omni-moderation-latest`` model
+(https://platform.openai.com/docs/guides/moderation) before they are forwarded
+to any provider. Plain text chat is NOT moderated; extending scope there is a
+deliberate future change (``should_moderate_model`` is the one gate to widen).
+The check covers the newest user turn — its prompt text and any attached
+images (editing/compositing inputs arrive as ``data:`` URIs, so they are
+scored too). Earlier turns were scored by their own requests; re-scoring the
+whole transcript would double-count one offense on every subsequent message
+and on every round of a client tool loop.
 
 What the verdict does:
 
@@ -62,15 +66,6 @@ MODERATION_MODEL = "omni-moderation-latest"
 # provider trust-and-safety teams act on.
 BLOCKED_CATEGORIES = frozenset({"sexual/minors"})
 
-# Initial rollout scope: moderate only image requests — image generation,
-# image editing (reference images ride the same image-generation request), and
-# the inline-image chat models — where the abuse being fought lives and where
-# the added pre-flight latency is invisible next to multi-second generation.
-# Flip to False to score every chat request; nothing else needs to change (the
-# relay's strike policy and the app's warning UI key off the flag headers,
-# which plain-text requests simply never carry while this is True).
-MODERATE_IMAGE_REQUESTS_ONLY = True
-
 # Bounds on what we send to the moderation endpoint. The newest user turn is
 # almost always far below these; they exist so a pathological request can't
 # make the pre-flight check slower than the inference it guards.
@@ -82,7 +77,7 @@ MAX_IMAGE_PARTS = 5
 # readable instead of thirteen near-zero floats.
 SCORE_FLOOR = 0.01
 
-# Tight budget: this runs synchronously in front of every chat request, so it
+# Tight budget: this runs synchronously in front of every image request, so it
 # must degrade fast. Images push payloads into the megabytes, hence the write
 # allowance; the endpoint itself typically answers in well under a second.
 _MODERATION_TIMEOUT = httpx.Timeout(timeout=15.0, connect=5.0, read=10.0, write=10.0)
@@ -125,13 +120,13 @@ def moderation_available() -> bool:
 def should_moderate_model(model: str) -> bool:
     """Whether requests for this model fall inside the moderation scope.
 
-    While ``MODERATE_IMAGE_REQUESTS_ONLY`` is set, only image requests are
-    scored: models served via a provider images endpoint (generation and
-    editing) and inline-image chat models. Unknown models are left to the
-    normal routing error path rather than moderated speculatively.
+    Only image requests are scored: models served via a provider images
+    endpoint (generation and editing) and inline-image chat models. Widening
+    moderation to text chat means widening this predicate — everything
+    downstream (relay strike policy, app warnings) keys off the flag headers
+    and needs no change. Unknown models are left to the normal routing error
+    path rather than moderated speculatively.
     """
-    if not MODERATE_IMAGE_REQUESTS_ONLY:
-        return True
     try:
         cfg = get_model_config(model)
     except Exception:

--- a/tee_gateway/openapi/openapi.yaml
+++ b/tee_gateway/openapi/openapi.yaml
@@ -3397,6 +3397,36 @@ components:
           type: string
         usage:
           $ref: "#/components/schemas/CompletionUsage"
+        moderation:
+          description: |
+            Content-moderation verdict for the newest user turn, scored against
+            OpenAI's omni-moderation model before the request was forwarded to
+            any provider. Present when moderation ran (`checked: true`);
+            absent when no OpenAI key is configured or the moderation endpoint
+            was unavailable (fail-open). `categories` lists only the flagged
+            category names; `category_scores` includes flagged categories and
+            any score above a small floor. Requests flagged for a blocked
+            category (child sexual abuse material) are refused with HTTP 451
+            and never reach a provider.
+          title: moderation
+          type: object
+          properties:
+            model:
+              type: string
+            checked:
+              type: boolean
+            flagged:
+              type: boolean
+            blocked:
+              type: boolean
+            categories:
+              type: array
+              items:
+                type: string
+            category_scores:
+              type: object
+              additionalProperties:
+                type: number
       required:
       - choices
       - created

--- a/tee_gateway/test/test_moderation.py
+++ b/tee_gateway/test/test_moderation.py
@@ -279,7 +279,7 @@ class TestFailureModes(unittest.TestCase):
 
 
 class TestModerationScope(unittest.TestCase):
-    """Initial rollout: only image requests are inside the moderation scope."""
+    """Only image requests are inside the moderation scope."""
 
     def test_image_models_are_in_scope(self):
         for model in ("grok-2-image", "gpt-image-2", "gemini-2.5-flash-image"):
@@ -291,11 +291,6 @@ class TestModerationScope(unittest.TestCase):
 
     def test_unknown_models_are_out_of_scope(self):
         self.assertFalse(mod.should_moderate_model("not-a-model"))
-
-    def test_flag_off_moderates_everything(self):
-        with patch.object(mod, "MODERATE_IMAGE_REQUESTS_ONLY", False):
-            self.assertTrue(mod.should_moderate_model("gpt-4.1"))
-            self.assertTrue(mod.should_moderate_model("not-a-model"))
 
 
 class TestControllerIntegration(unittest.TestCase):

--- a/tee_gateway/test/test_moderation.py
+++ b/tee_gateway/test/test_moderation.py
@@ -278,17 +278,41 @@ class TestFailureModes(unittest.TestCase):
 # ---------------------------------------------------------------------------
 
 
-class TestControllerIntegration(unittest.TestCase):
-    """create_chat_completion refuses blocked requests before provider work."""
+class TestModerationScope(unittest.TestCase):
+    """Initial rollout: only image requests are inside the moderation scope."""
 
-    def _request_json(self, stream=False):
+    def test_image_models_are_in_scope(self):
+        for model in ("grok-2-image", "gpt-image-2", "gemini-2.5-flash-image"):
+            self.assertTrue(mod.should_moderate_model(model), model)
+
+    def test_text_models_are_out_of_scope(self):
+        for model in ("gpt-4.1", "gpt-5", "claude-sonnet-4-5"):
+            self.assertFalse(mod.should_moderate_model(model), model)
+
+    def test_unknown_models_are_out_of_scope(self):
+        self.assertFalse(mod.should_moderate_model("not-a-model"))
+
+    def test_flag_off_moderates_everything(self):
+        with patch.object(mod, "MODERATE_IMAGE_REQUESTS_ONLY", False):
+            self.assertTrue(mod.should_moderate_model("gpt-4.1"))
+            self.assertTrue(mod.should_moderate_model("not-a-model"))
+
+
+class TestControllerIntegration(unittest.TestCase):
+    """create_chat_completion refuses blocked requests before provider work.
+
+    The scope gate is patched open here (these tests exercise the verdict
+    handling, not the rollout scope — that's TestModerationScope's job).
+    """
+
+    def _request_json(self, stream=False, model="gpt-5"):
         return {
-            "model": "gpt-5",
+            "model": model,
             "messages": [{"role": "user", "content": "prompt"}],
             "stream": stream,
         }
 
-    def _call_controller(self, outcome, stream=False):
+    def _call_controller(self, outcome, stream=False, in_scope=True):
         from tee_gateway.controllers import chat_controller
 
         fake_request = Mock()
@@ -296,7 +320,12 @@ class TestControllerIntegration(unittest.TestCase):
         fake_request.get_json.return_value = self._request_json(stream)
         with (
             patch.object(chat_controller.connexion, "request", fake_request),
-            patch.object(chat_controller, "moderate_messages", return_value=outcome),
+            patch.object(
+                chat_controller, "should_moderate_model", return_value=in_scope
+            ),
+            patch.object(
+                chat_controller, "moderate_messages", return_value=outcome
+            ) as moderate,
             patch.object(
                 chat_controller,
                 "_create_streaming_response",
@@ -309,6 +338,7 @@ class TestControllerIntegration(unittest.TestCase):
             ) as non_streaming,
         ):
             result = chat_controller.create_chat_completion(None)
+        self._moderate = moderate
         return result, streaming, non_streaming
 
     def test_blocked_request_returns_451_and_never_reaches_a_provider(self):
@@ -343,6 +373,14 @@ class TestControllerIntegration(unittest.TestCase):
         )
         self.assertEqual(result, "streamed")
         streaming.assert_called_once()
+
+    def test_out_of_scope_request_skips_moderation_entirely(self):
+        outcome = ModerationOutcome(checked=True, flagged=True, blocked=True)
+        result, _, non_streaming = self._call_controller(outcome, in_scope=False)
+        # Even a blocked verdict queued on the fake client is never consulted.
+        self.assertEqual(result, "non-streamed")
+        self._moderate.assert_not_called()
+        self.assertIsNone(non_streaming.call_args.args[1])
 
 
 class TestOhttpHeaderForwarding(unittest.TestCase):

--- a/tee_gateway/test/test_moderation.py
+++ b/tee_gateway/test/test_moderation.py
@@ -1,0 +1,359 @@
+"""Tests for in-enclave prompt moderation (tee_gateway/moderation.py) and its
+wiring into the chat controller.
+
+The moderation HTTP client is faked the same way test_web_search.py fakes the
+Exa client — a recording stand-in patched onto the module global — so no test
+touches the network.
+"""
+
+import json
+import unittest
+from unittest.mock import Mock, patch
+
+import httpx
+
+import tee_gateway.moderation as mod
+from tee_gateway.moderation import (
+    BLOCKED_CATEGORIES,
+    MAX_IMAGE_PARTS,
+    ModerationOutcome,
+    extract_moderation_input,
+    moderate_messages,
+)
+
+
+def _moderation_response(
+    status: int = 200,
+    *,
+    flagged: bool = False,
+    categories: dict | None = None,
+    scores: dict | None = None,
+    body: dict | None = None,
+):
+    response = Mock()
+    response.status_code = status
+    if body is None:
+        body = {
+            "id": "modr-test",
+            "model": "omni-moderation-latest",
+            "results": [
+                {
+                    "flagged": flagged,
+                    "categories": categories or {},
+                    "category_scores": scores or {},
+                }
+            ],
+        }
+    response.json.return_value = body
+    response.text = json.dumps(body)
+    return response
+
+
+class _ModerationClient:
+    """Records the payloads posted to /moderations and replays queued responses."""
+
+    def __init__(self, responses):
+        self.responses = list(responses)
+        self.payloads: list[dict] = []
+
+    def post(self, path, json=None):  # noqa: A002 - matches httpx.Client.post
+        self.payloads.append(json)
+        if not self.responses:
+            return _moderation_response(200)
+        head = self.responses.pop(0)
+        if isinstance(head, Exception):
+            raise head
+        return head
+
+
+def _with_moderation(*responses):
+    client = _ModerationClient(responses)
+    return patch.object(mod, "_moderation_http_client", client), client
+
+
+def _user(content):
+    return {"role": "user", "content": content}
+
+
+# ---------------------------------------------------------------------------
+# Availability
+# ---------------------------------------------------------------------------
+
+
+class TestAvailability(unittest.TestCase):
+    def test_availability_tracks_the_injected_key(self):
+        mod.configure_moderation_client("test-key")
+        try:
+            self.assertTrue(mod.moderation_available())
+        finally:
+            mod.configure_moderation_client(None)
+        self.assertFalse(mod.moderation_available())
+
+    def test_no_client_means_unchecked_not_blocked(self):
+        with patch.object(mod, "_moderation_http_client", None):
+            outcome = moderate_messages([_user("anything")])
+        self.assertFalse(outcome.checked)
+        self.assertFalse(outcome.flagged)
+        self.assertFalse(outcome.blocked)
+
+
+# ---------------------------------------------------------------------------
+# Input extraction
+# ---------------------------------------------------------------------------
+
+
+class TestInputExtraction(unittest.TestCase):
+    def test_takes_the_newest_user_turn_only(self):
+        messages = [
+            {"role": "system", "content": "sys"},
+            _user("old prompt"),
+            {"role": "assistant", "content": "answer"},
+            _user("new prompt"),
+            {"role": "tool", "content": "tool output", "tool_call_id": "t1"},
+        ]
+        text, images = extract_moderation_input(messages)
+        self.assertEqual(text, "new prompt")
+        self.assertEqual(images, [])
+
+    def test_multimodal_content_splits_text_and_images(self):
+        content = [
+            {"type": "text", "text": "caption"},
+            {"type": "image_url", "image_url": {"url": "data:image/png;base64,AAAA"}},
+            {"type": "image", "base64": "BBBB", "mime_type": "image/jpeg"},
+            {"type": "file", "file": {"filename": "doc.pdf"}},
+        ]
+        text, images = extract_moderation_input([_user(content)])
+        self.assertEqual(text, "caption")
+        self.assertEqual(
+            images,
+            ["data:image/png;base64,AAAA", "data:image/jpeg;base64,BBBB"],
+        )
+
+    def test_non_data_non_http_image_urls_are_skipped(self):
+        content = [
+            {"type": "image_url", "image_url": {"url": "ftp://host/x.png"}},
+            {"type": "image_url", "image_url": {"url": "https://host/x.png"}},
+        ]
+        _, images = extract_moderation_input([_user(content)])
+        self.assertEqual(images, ["https://host/x.png"])
+
+    def test_no_user_message_yields_nothing(self):
+        text, images = extract_moderation_input([{"role": "system", "content": "sys"}])
+        self.assertEqual(text, "")
+        self.assertEqual(images, [])
+        patcher, client = _with_moderation()
+        with patcher:
+            outcome = moderate_messages([{"role": "system", "content": "sys"}])
+        self.assertFalse(outcome.checked)
+        self.assertEqual(client.payloads, [])
+
+
+# ---------------------------------------------------------------------------
+# Verdicts
+# ---------------------------------------------------------------------------
+
+
+class TestVerdicts(unittest.TestCase):
+    def test_clean_prompt_is_checked_and_unflagged(self):
+        patcher, client = _with_moderation(_moderation_response(200))
+        with patcher:
+            outcome = moderate_messages([_user("hello")])
+        self.assertTrue(outcome.checked)
+        self.assertFalse(outcome.flagged)
+        self.assertFalse(outcome.blocked)
+        self.assertEqual(outcome.headers(), {})
+        self.assertEqual(
+            client.payloads[0],
+            {"model": mod.MODERATION_MODEL, "input": "hello"},
+        )
+
+    def test_flagged_prompt_reports_categories_and_headers(self):
+        patcher, _ = _with_moderation(
+            _moderation_response(
+                200,
+                flagged=True,
+                categories={"violence": True, "sexual": False},
+                scores={"violence": 0.91, "sexual": 0.0001},
+            )
+        )
+        with patcher:
+            outcome = moderate_messages([_user("bad prompt")])
+        self.assertTrue(outcome.flagged)
+        self.assertFalse(outcome.blocked)
+        self.assertEqual(outcome.categories, ("violence",))
+        self.assertEqual(outcome.category_scores, {"violence": 0.91})
+        self.assertEqual(
+            outcome.headers(),
+            {
+                "X-Moderation-Flagged": "true",
+                "X-Moderation-Categories": "violence",
+            },
+        )
+
+    def test_blocked_category_blocks(self):
+        patcher, _ = _with_moderation(
+            _moderation_response(
+                200,
+                flagged=True,
+                categories={"sexual/minors": True, "sexual": True},
+                scores={"sexual/minors": 0.99, "sexual": 0.8},
+            )
+        )
+        with patcher:
+            outcome = moderate_messages([_user("bad prompt")])
+        self.assertTrue(outcome.blocked)
+        self.assertEqual(outcome.categories, ("sexual", "sexual/minors"))
+        self.assertEqual(outcome.headers()["X-Moderation-Blocked"], "true")
+        block = outcome.to_response_dict()
+        self.assertTrue(block["blocked"])
+        self.assertEqual(block["model"], mod.MODERATION_MODEL)
+
+    def test_blocked_categories_is_csam_only_by_default(self):
+        self.assertEqual(BLOCKED_CATEGORIES, frozenset({"sexual/minors"}))
+
+    def test_images_ride_as_image_url_parts(self):
+        patcher, client = _with_moderation(_moderation_response(200))
+        content = [
+            {"type": "text", "text": "edit this"},
+            {"type": "image_url", "image_url": {"url": "data:image/png;base64,AA"}},
+        ]
+        with patcher:
+            moderate_messages([_user(content)])
+        self.assertEqual(
+            client.payloads[0]["input"],
+            [
+                {"type": "text", "text": "edit this"},
+                {
+                    "type": "image_url",
+                    "image_url": {"url": "data:image/png;base64,AA"},
+                },
+            ],
+        )
+
+    def test_image_count_is_capped(self):
+        patcher, client = _with_moderation(_moderation_response(200))
+        content = [
+            {"type": "image_url", "image_url": {"url": f"data:image/png;base64,{i}"}}
+            for i in range(MAX_IMAGE_PARTS + 4)
+        ]
+        with patcher:
+            moderate_messages([_user(content)])
+        image_parts = [
+            p for p in client.payloads[0]["input"] if p["type"] == "image_url"
+        ]
+        self.assertEqual(len(image_parts), MAX_IMAGE_PARTS)
+
+
+# ---------------------------------------------------------------------------
+# Failure modes (all fail-open)
+# ---------------------------------------------------------------------------
+
+
+class TestFailureModes(unittest.TestCase):
+    def test_transport_error_fails_open(self):
+        patcher, _ = _with_moderation(httpx.ConnectError("boom"))
+        with patcher:
+            outcome = moderate_messages([_user("hello")])
+        self.assertFalse(outcome.checked)
+        self.assertFalse(outcome.flagged)
+        self.assertEqual(outcome.headers(), {})
+
+    def test_non_200_fails_open(self):
+        patcher, _ = _with_moderation(
+            _moderation_response(429, body={"error": {"message": "rate limited"}})
+        )
+        with patcher:
+            outcome = moderate_messages([_user("hello")])
+        self.assertFalse(outcome.checked)
+
+    def test_malformed_body_fails_open(self):
+        patcher, _ = _with_moderation(_moderation_response(200, body={"nope": 1}))
+        with patcher:
+            outcome = moderate_messages([_user("hello")])
+        self.assertFalse(outcome.checked)
+
+
+# ---------------------------------------------------------------------------
+# Controller integration
+# ---------------------------------------------------------------------------
+
+
+class TestControllerIntegration(unittest.TestCase):
+    """create_chat_completion refuses blocked requests before provider work."""
+
+    def _request_json(self, stream=False):
+        return {
+            "model": "gpt-5",
+            "messages": [{"role": "user", "content": "prompt"}],
+            "stream": stream,
+        }
+
+    def _call_controller(self, outcome, stream=False):
+        from tee_gateway.controllers import chat_controller
+
+        fake_request = Mock()
+        fake_request.is_json = True
+        fake_request.get_json.return_value = self._request_json(stream)
+        with (
+            patch.object(chat_controller.connexion, "request", fake_request),
+            patch.object(chat_controller, "moderate_messages", return_value=outcome),
+            patch.object(
+                chat_controller,
+                "_create_streaming_response",
+                return_value="streamed",
+            ) as streaming,
+            patch.object(
+                chat_controller,
+                "_create_non_streaming_response",
+                return_value="non-streamed",
+            ) as non_streaming,
+        ):
+            result = chat_controller.create_chat_completion(None)
+        return result, streaming, non_streaming
+
+    def test_blocked_request_returns_451_and_never_reaches_a_provider(self):
+        outcome = ModerationOutcome(
+            checked=True,
+            flagged=True,
+            blocked=True,
+            categories=("sexual/minors",),
+            category_scores={"sexual/minors": 0.99},
+        )
+        result, streaming, non_streaming = self._call_controller(outcome)
+        body, status, headers = result
+        self.assertEqual(status, 451)
+        self.assertEqual(body["code"], "moderation_blocked")
+        self.assertTrue(body["moderation"]["blocked"])
+        self.assertEqual(headers["X-Moderation-Blocked"], "true")
+        streaming.assert_not_called()
+        non_streaming.assert_not_called()
+
+    def test_flagged_but_not_blocked_proceeds(self):
+        outcome = ModerationOutcome(
+            checked=True, flagged=True, categories=("violence",)
+        )
+        result, _, non_streaming = self._call_controller(outcome)
+        self.assertEqual(result, "non-streamed")
+        non_streaming.assert_called_once()
+        self.assertIs(non_streaming.call_args.args[1], outcome)
+
+    def test_unchecked_outcome_proceeds(self):
+        result, streaming, _ = self._call_controller(
+            ModerationOutcome(checked=False), stream=True
+        )
+        self.assertEqual(result, "streamed")
+        streaming.assert_called_once()
+
+
+class TestOhttpHeaderForwarding(unittest.TestCase):
+    def test_moderation_headers_are_forwarded_to_the_relay(self):
+        from tee_gateway.controllers.ohttp_controller import _should_forward_header
+
+        self.assertTrue(_should_forward_header("X-Moderation-Flagged"))
+        self.assertTrue(_should_forward_header("x-moderation-categories"))
+        self.assertTrue(_should_forward_header("X-Moderation-Blocked"))
+        self.assertFalse(_should_forward_header("X-Something-Else"))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tee_gateway/test/test_moderation_e2e.py
+++ b/tee_gateway/test/test_moderation_e2e.py
@@ -1,4 +1,4 @@
-"""End-to-end wire tests for content moderation on /v1/chat/completions.
+"""End-to-end wire tests for image-request moderation on /v1/chat/completions.
 
 Unlike test_moderation.py (unit tests on the module and controller functions),
 these requests travel the real pipeline: a connexion app built from the
@@ -6,8 +6,11 @@ OpenAPI spec (so request validation and routing run for real), through
 ``create_chat_completion``, the moderation pre-flight, TEE signing, and out as
 actual HTTP responses — non-streaming JSON, SSE streams, and the sealed OHTTP
 path with its header forwarding. Only the process edges are faked: the
-moderation HTTP client (the test_moderation.py stand-in), the LangChain
-provider model, pricing, and the OHTTP encapsulation crypto.
+moderation HTTP client (the test_moderation.py stand-in), the provider image
+generation call, pricing, and the OHTTP encapsulation crypto.
+
+Moderation scope is image requests only — the text-chat tests here prove the
+moderation endpoint is never consulted for plain chat.
 
 The final class is an opt-in LIVE test against the real OpenAI moderation
 endpoint, gated like test_provider_usage_integration.py:
@@ -48,14 +51,6 @@ _BLOCKED = _moderation_response(
 )
 
 
-class _Chunk:
-    """Minimal LangChain-shaped stream chunk: text content, no tool calls."""
-
-    def __init__(self, content: str):
-        self.content = content
-        self.tool_call_chunks: list = []
-
-
 def _build_app():
     """Connexion app from the OpenAPI spec, with /v1/ohttp mounted like
     __main__.create_app does (it is not part of the spec)."""
@@ -80,7 +75,8 @@ def _fake_tee_keys() -> MagicMock:
 
 
 class _WireTestCase(unittest.TestCase):
-    """Shared harness: real app + faked process edges."""
+    """Shared harness: real app + faked process edges (provider, pricing,
+    signing keys, image generation)."""
 
     def setUp(self):
         self.app = _build_app()
@@ -91,9 +87,14 @@ class _WireTestCase(unittest.TestCase):
         fake_response.tool_calls = None
         self.fake_model = MagicMock()
         self.fake_model.invoke.return_value = fake_response
-        self.fake_model.stream.return_value = iter([_Chunk("hello "), _Chunk("there")])
         self.fake_model.bind_tools.return_value = self.fake_model
         self.fake_model.bind.return_value = self.fake_model
+
+        fake_cost = SessionCost(
+            cost_opg=12345,
+            cost_usd=Decimal("0.001"),
+            opg_price_usd=Decimal("0.5"),
+        )
 
         stack = ExitStack()
         self.addCleanup(stack.close)
@@ -112,11 +113,7 @@ class _WireTestCase(unittest.TestCase):
         stack.enter_context(
             patch(
                 "tee_gateway.controllers.chat_controller.compute_session_cost",
-                return_value=SessionCost(
-                    cost_opg=12345,
-                    cost_usd=Decimal("0.001"),
-                    opg_price_usd=Decimal("0.5"),
-                ),
+                return_value=fake_cost,
             )
         )
         stack.enter_context(
@@ -125,14 +122,39 @@ class _WireTestCase(unittest.TestCase):
                 return_value=_fake_tee_keys(),
             )
         )
+        self.generate_images = stack.enter_context(
+            patch(
+                "tee_gateway.image_generation.generate_images",
+                return_value=(["data:image/png;base64,QUJD"], 1),
+            )
+        )
+        stack.enter_context(
+            patch(
+                "tee_gateway.image_generation.get_tee_keys",
+                return_value=_fake_tee_keys(),
+            )
+        )
+        stack.enter_context(
+            patch(
+                "tee_gateway.image_generation.compute_session_cost",
+                return_value=fake_cost,
+            )
+        )
 
     def _with_moderation(self, *responses):
         client = _ModerationClient(list(responses))
         return patch.object(mod, "_moderation_http_client", client)
 
-    def _chat_body(self, stream=False, content="tell me a story"):
+    def _text_body(self, content="tell me a story"):
         return {
             "model": "gpt-4.1",
+            "messages": [{"role": "user", "content": content}],
+            "stream": False,
+        }
+
+    def _image_body(self, stream=False, content="draw a castle"):
+        return {
+            "model": "grok-2-image",
             "messages": [{"role": "user", "content": content}],
             "stream": stream,
         }
@@ -151,25 +173,34 @@ class _WireTestCase(unittest.TestCase):
 # ---------------------------------------------------------------------------
 
 
-class TestChatModerationWire(_WireTestCase):
-    """Full-chat moderation wiring. Text chat is currently outside the rollout
-    scope (MODERATE_IMAGE_REQUESTS_ONLY), so these tests open the scope gate —
-    they verify the wiring that flag enables, image-request scoping itself is
-    covered by TestImageModerationWire below."""
-
-    def setUp(self):
-        super().setUp()
-        flag = patch.object(mod, "MODERATE_IMAGE_REQUESTS_ONLY", False)
-        flag.start()
-        self.addCleanup(flag.stop)
-
-    def test_clean_prompt_gets_verdict_in_body_and_no_flag_headers(self):
-        with self._with_moderation(_moderation_response(200)):
-            response = self._post_chat(self._chat_body())
+class TestImageModerationWire(_WireTestCase):
+    def test_text_chat_is_never_moderated(self):
+        moderation_client = _ModerationClient([_FLAGGED])
+        with patch.object(mod, "_moderation_http_client", moderation_client):
+            response = self._post_chat(self._text_body())
 
         self.assertEqual(response.status_code, 200)
         body = response.get_json()
         self.assertEqual(body["choices"][0]["message"]["content"], "hello there")
+        # The moderation endpoint was never consulted for a text model...
+        self.assertEqual(moderation_client.payloads, [])
+        # ...so the response carries no verdict and no flag headers, and is
+        # signed and billed exactly as before.
+        self.assertNotIn("moderation", body)
+        self.assertNotIn("X-Moderation-Flagged", response.headers)
+        self.assertIn("tee_signature", body)
+        self.assertIn("opengradient", body)
+
+    def test_clean_image_prompt_gets_verdict_in_body_and_no_flag_headers(self):
+        with self._with_moderation(_moderation_response(200)):
+            response = self._post_chat(self._image_body())
+
+        self.assertEqual(response.status_code, 200)
+        body = response.get_json()
+        self.assertEqual(
+            body["choices"][0]["message"]["images"],
+            ["data:image/png;base64,QUJD"],
+        )
         self.assertEqual(
             body["moderation"],
             {
@@ -188,17 +219,19 @@ class TestChatModerationWire(_WireTestCase):
             "X-Moderation-Blocked",
         ):
             self.assertNotIn(header, response.headers)
-        # Signed and billed as before.
         self.assertIn("tee_signature", body)
         self.assertIn("opengradient", body)
 
-    def test_flagged_prompt_is_served_with_verdict_and_headers(self):
+    def test_flagged_image_prompt_is_served_with_verdict_and_headers(self):
         with self._with_moderation(_FLAGGED):
-            response = self._post_chat(self._chat_body())
+            response = self._post_chat(self._image_body())
 
         self.assertEqual(response.status_code, 200)
         body = response.get_json()
-        self.assertEqual(body["choices"][0]["message"]["content"], "hello there")
+        self.assertEqual(
+            body["choices"][0]["message"]["images"],
+            ["data:image/png;base64,QUJD"],
+        )
         self.assertTrue(body["moderation"]["flagged"])
         self.assertFalse(body["moderation"]["blocked"])
         self.assertEqual(body["moderation"]["categories"], ["violence"])
@@ -206,9 +239,9 @@ class TestChatModerationWire(_WireTestCase):
         self.assertEqual(response.headers["X-Moderation-Categories"], "violence")
         self.assertNotIn("X-Moderation-Blocked", response.headers)
 
-    def test_blocked_prompt_is_refused_with_451_before_any_provider_call(self):
+    def test_blocked_image_prompt_is_refused_with_451_before_generation(self):
         with self._with_moderation(_BLOCKED):
-            response = self._post_chat(self._chat_body())
+            response = self._post_chat(self._image_body())
 
         self.assertEqual(response.status_code, 451)
         body = response.get_json()
@@ -218,23 +251,25 @@ class TestChatModerationWire(_WireTestCase):
         self.assertEqual(response.headers["X-Moderation-Blocked"], "true")
         # The whole point: the prompt never reaches a provider, and nothing
         # is billed.
-        self.fake_model.invoke.assert_not_called()
-        self.fake_model.stream.assert_not_called()
+        self.generate_images.assert_not_called()
         self.assertNotIn("opengradient", body)
 
     def test_moderation_outage_fails_open_without_verdict(self):
         with patch.object(mod, "_moderation_http_client", None):
-            response = self._post_chat(self._chat_body())
+            response = self._post_chat(self._image_body())
 
         self.assertEqual(response.status_code, 200)
         body = response.get_json()
-        self.assertEqual(body["choices"][0]["message"]["content"], "hello there")
+        self.assertEqual(
+            body["choices"][0]["message"]["images"],
+            ["data:image/png;base64,QUJD"],
+        )
         self.assertNotIn("moderation", body)
         self.assertNotIn("X-Moderation-Flagged", response.headers)
 
-    def test_streaming_flagged_prompt_carries_verdict_on_final_frame(self):
+    def test_streaming_image_request_carries_verdict_on_final_frame(self):
         with self._with_moderation(_FLAGGED):
-            response = self._post_chat(self._chat_body(stream=True))
+            response = self._post_chat(self._image_body(stream=True))
 
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.mimetype, "text/event-stream")
@@ -248,128 +283,23 @@ class TestChatModerationWire(_WireTestCase):
             for line in response.get_data(as_text=True).splitlines()
             if line.startswith("data: ") and line != "data: [DONE]"
         ]
-        streamed_text = "".join(
-            event["choices"][0]["delta"].get("content", "")
-            for event in events
-            if event.get("choices")
-        )
-        self.assertEqual(streamed_text, "hello there")
-
         final_frame = events[-1]
         self.assertTrue(final_frame["moderation"]["flagged"])
-        self.assertEqual(final_frame["moderation"]["categories"], ["violence"])
+        self.assertEqual(final_frame["images"], ["data:image/png;base64,QUJD"])
         self.assertIn("tee_signature", final_frame)
         self.assertTrue(
             response.get_data(as_text=True).rstrip().endswith("data: [DONE]")
         )
 
-    def test_streaming_blocked_prompt_never_opens_a_stream(self):
+    def test_streaming_blocked_image_prompt_never_opens_a_stream(self):
         with self._with_moderation(_BLOCKED):
-            response = self._post_chat(self._chat_body(stream=True))
+            response = self._post_chat(self._image_body(stream=True))
 
         # The refusal happens before stream setup, so the client gets a plain
         # JSON error it can parse, not a dead SSE stream.
         self.assertEqual(response.status_code, 451)
         self.assertEqual(response.get_json()["code"], "moderation_blocked")
-        self.fake_model.stream.assert_not_called()
-
-
-# ---------------------------------------------------------------------------
-# Image requests: the initial rollout scope, exercised without any scope patch
-# ---------------------------------------------------------------------------
-
-
-class TestImageModerationWire(_WireTestCase):
-    """Real rollout behavior: image generation/editing requests are moderated,
-    text chat is not. No scope flag is patched here."""
-
-    def setUp(self):
-        super().setUp()
-        stack = ExitStack()
-        self.addCleanup(stack.close)
-        self.generate_images = stack.enter_context(
-            patch(
-                "tee_gateway.image_generation.generate_images",
-                return_value=(["data:image/png;base64,QUJD"], 1),
-            )
-        )
-        stack.enter_context(
-            patch(
-                "tee_gateway.image_generation.get_tee_keys",
-                return_value=_fake_tee_keys(),
-            )
-        )
-        stack.enter_context(
-            patch(
-                "tee_gateway.image_generation.compute_session_cost",
-                return_value=SessionCost(
-                    cost_opg=99999,
-                    cost_usd=Decimal("0.04"),
-                    opg_price_usd=Decimal("0.5"),
-                ),
-            )
-        )
-
-    def _image_body(self, content="draw a castle"):
-        return {
-            "model": "grok-2-image",
-            "messages": [{"role": "user", "content": content}],
-            "stream": False,
-        }
-
-    def test_text_chat_is_not_moderated_during_image_only_rollout(self):
-        moderation_client = _ModerationClient([_FLAGGED])
-        with patch.object(mod, "_moderation_http_client", moderation_client):
-            response = self._post_chat(self._chat_body())
-
-        self.assertEqual(response.status_code, 200)
-        # The moderation endpoint was never consulted for a text model...
-        self.assertEqual(moderation_client.payloads, [])
-        # ...so the response carries no verdict and no flag headers.
-        self.assertNotIn("moderation", response.get_json())
-        self.assertNotIn("X-Moderation-Flagged", response.headers)
-
-    def test_flagged_image_prompt_is_served_with_verdict_and_headers(self):
-        with self._with_moderation(_FLAGGED):
-            response = self._post_chat(self._image_body())
-
-        self.assertEqual(response.status_code, 200)
-        body = response.get_json()
-        self.assertEqual(
-            body["choices"][0]["message"]["images"],
-            ["data:image/png;base64,QUJD"],
-        )
-        self.assertTrue(body["moderation"]["flagged"])
-        self.assertEqual(body["moderation"]["categories"], ["violence"])
-        self.assertEqual(response.headers["X-Moderation-Flagged"], "true")
-        self.assertEqual(response.headers["X-Moderation-Categories"], "violence")
-
-    def test_blocked_image_prompt_is_refused_before_generation(self):
-        with self._with_moderation(_BLOCKED):
-            response = self._post_chat(self._image_body())
-
-        self.assertEqual(response.status_code, 451)
-        self.assertEqual(response.get_json()["code"], "moderation_blocked")
-        self.assertEqual(response.headers["X-Moderation-Blocked"], "true")
         self.generate_images.assert_not_called()
-
-    def test_streaming_image_request_carries_verdict_on_final_frame(self):
-        body = self._image_body()
-        body["stream"] = True
-        with self._with_moderation(_FLAGGED):
-            response = self._post_chat(body)
-
-        self.assertEqual(response.status_code, 200)
-        self.assertEqual(response.mimetype, "text/event-stream")
-        self.assertEqual(response.headers["X-Moderation-Flagged"], "true")
-        events = [
-            json.loads(line[len("data: ") :])
-            for line in response.get_data(as_text=True).splitlines()
-            if line.startswith("data: ") and line != "data: [DONE]"
-        ]
-        final_frame = events[-1]
-        self.assertTrue(final_frame["moderation"]["flagged"])
-        self.assertEqual(final_frame["images"], ["data:image/png;base64,QUJD"])
 
 
 # ---------------------------------------------------------------------------
@@ -385,15 +315,11 @@ class _FakeDecap:
 
 
 class TestOhttpModerationForwarding(_WireTestCase):
-    """Inner chat requests dispatched for real through the app's WSGI stack —
-    only the HPKE crypto at the boundary is faked. Scope gate opened like
-    TestChatModerationWire (forwarding mechanics, not rollout scope)."""
+    """Inner image requests dispatched for real through the app's WSGI stack —
+    only the HPKE crypto at the boundary is faked."""
 
     def setUp(self):
         super().setUp()
-        flag = patch.object(mod, "MODERATE_IMAGE_REQUESTS_ONLY", False)
-        flag.start()
-        self.addCleanup(flag.stop)
         self.sealed_bodies: list[bytes] = []
 
         def _capture_seal(_key, _enc, body_bytes):
@@ -428,9 +354,9 @@ class TestOhttpModerationForwarding(_WireTestCase):
             content_type="message/ohttp-req",
         )
 
-    def test_flagged_chat_forwards_flag_headers_and_seals_the_verdict(self):
+    def test_flagged_image_request_forwards_headers_and_seals_the_verdict(self):
         with self._with_moderation(_FLAGGED):
-            response = self._post_inner(self._chat_body())
+            response = self._post_inner(self._image_body())
 
         # Outer response: sealed body, but the content-free abuse signal is
         # visible to the relay for its strike policy.
@@ -443,9 +369,9 @@ class TestOhttpModerationForwarding(_WireTestCase):
         self.assertTrue(sealed["moderation"]["flagged"])
         self.assertIn("category_scores", sealed["moderation"])
 
-    def test_clean_chat_stays_byte_identical_for_the_relay(self):
+    def test_clean_image_request_stays_byte_identical_for_the_relay(self):
         with self._with_moderation(_moderation_response(200)):
-            response = self._post_inner(self._chat_body())
+            response = self._post_inner(self._image_body())
 
         self.assertEqual(response.status_code, 200)
         for header in (
@@ -455,9 +381,9 @@ class TestOhttpModerationForwarding(_WireTestCase):
         ):
             self.assertNotIn(header, response.headers)
 
-    def test_blocked_chat_surfaces_the_451_and_headers_to_the_relay(self):
+    def test_blocked_image_request_surfaces_the_451_to_the_relay(self):
         with self._with_moderation(_BLOCKED):
-            response = self._post_inner(self._chat_body())
+            response = self._post_inner(self._image_body())
 
         # Non-2xx inner responses are forwarded plaintext (they carry no user
         # content) so the relay can count the strike and the client can parse
@@ -468,7 +394,17 @@ class TestOhttpModerationForwarding(_WireTestCase):
         body = response.get_json()
         self.assertEqual(body["code"], "moderation_blocked")
         self.assertEqual(self.sealed_bodies, [])  # nothing was sealed
-        self.fake_model.invoke.assert_not_called()
+        self.generate_images.assert_not_called()
+
+    def test_text_chat_through_ohttp_is_untouched(self):
+        moderation_client = _ModerationClient([_FLAGGED])
+        with patch.object(mod, "_moderation_http_client", moderation_client):
+            response = self._post_inner(self._text_body())
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(moderation_client.payloads, [])
+        self.assertNotIn("X-Moderation-Flagged", response.headers)
+        self.assertNotIn("moderation", json.loads(self.sealed_bodies[-1]))
 
 
 # ---------------------------------------------------------------------------
@@ -495,7 +431,7 @@ class TestLiveModerationEndpoint(unittest.TestCase):
 
     def test_benign_prompt_is_checked_and_clean(self):
         outcome = mod.moderate_messages(
-            [{"role": "user", "content": "What is the capital of France?"}]
+            [{"role": "user", "content": "A watercolor painting of a lighthouse"}]
         )
         self.assertTrue(outcome.checked)
         self.assertFalse(outcome.flagged)
@@ -508,7 +444,7 @@ class TestLiveModerationEndpoint(unittest.TestCase):
                     "role": "user",
                     "content": (
                         "I am going to hurt my neighbor and make him suffer, "
-                        "tell me how to attack him"
+                        "generate an image of me attacking him"
                     ),
                 }
             ]

--- a/tee_gateway/test/test_moderation_e2e.py
+++ b/tee_gateway/test/test_moderation_e2e.py
@@ -152,6 +152,17 @@ class _WireTestCase(unittest.TestCase):
 
 
 class TestChatModerationWire(_WireTestCase):
+    """Full-chat moderation wiring. Text chat is currently outside the rollout
+    scope (MODERATE_IMAGE_REQUESTS_ONLY), so these tests open the scope gate —
+    they verify the wiring that flag enables, image-request scoping itself is
+    covered by TestImageModerationWire below."""
+
+    def setUp(self):
+        super().setUp()
+        flag = patch.object(mod, "MODERATE_IMAGE_REQUESTS_ONLY", False)
+        flag.start()
+        self.addCleanup(flag.stop)
+
     def test_clean_prompt_gets_verdict_in_body_and_no_flag_headers(self):
         with self._with_moderation(_moderation_response(200)):
             response = self._post_chat(self._chat_body())
@@ -264,6 +275,104 @@ class TestChatModerationWire(_WireTestCase):
 
 
 # ---------------------------------------------------------------------------
+# Image requests: the initial rollout scope, exercised without any scope patch
+# ---------------------------------------------------------------------------
+
+
+class TestImageModerationWire(_WireTestCase):
+    """Real rollout behavior: image generation/editing requests are moderated,
+    text chat is not. No scope flag is patched here."""
+
+    def setUp(self):
+        super().setUp()
+        stack = ExitStack()
+        self.addCleanup(stack.close)
+        self.generate_images = stack.enter_context(
+            patch(
+                "tee_gateway.image_generation.generate_images",
+                return_value=(["data:image/png;base64,QUJD"], 1),
+            )
+        )
+        stack.enter_context(
+            patch(
+                "tee_gateway.image_generation.get_tee_keys",
+                return_value=_fake_tee_keys(),
+            )
+        )
+        stack.enter_context(
+            patch(
+                "tee_gateway.image_generation.compute_session_cost",
+                return_value=SessionCost(
+                    cost_opg=99999,
+                    cost_usd=Decimal("0.04"),
+                    opg_price_usd=Decimal("0.5"),
+                ),
+            )
+        )
+
+    def _image_body(self, content="draw a castle"):
+        return {
+            "model": "grok-2-image",
+            "messages": [{"role": "user", "content": content}],
+            "stream": False,
+        }
+
+    def test_text_chat_is_not_moderated_during_image_only_rollout(self):
+        moderation_client = _ModerationClient([_FLAGGED])
+        with patch.object(mod, "_moderation_http_client", moderation_client):
+            response = self._post_chat(self._chat_body())
+
+        self.assertEqual(response.status_code, 200)
+        # The moderation endpoint was never consulted for a text model...
+        self.assertEqual(moderation_client.payloads, [])
+        # ...so the response carries no verdict and no flag headers.
+        self.assertNotIn("moderation", response.get_json())
+        self.assertNotIn("X-Moderation-Flagged", response.headers)
+
+    def test_flagged_image_prompt_is_served_with_verdict_and_headers(self):
+        with self._with_moderation(_FLAGGED):
+            response = self._post_chat(self._image_body())
+
+        self.assertEqual(response.status_code, 200)
+        body = response.get_json()
+        self.assertEqual(
+            body["choices"][0]["message"]["images"],
+            ["data:image/png;base64,QUJD"],
+        )
+        self.assertTrue(body["moderation"]["flagged"])
+        self.assertEqual(body["moderation"]["categories"], ["violence"])
+        self.assertEqual(response.headers["X-Moderation-Flagged"], "true")
+        self.assertEqual(response.headers["X-Moderation-Categories"], "violence")
+
+    def test_blocked_image_prompt_is_refused_before_generation(self):
+        with self._with_moderation(_BLOCKED):
+            response = self._post_chat(self._image_body())
+
+        self.assertEqual(response.status_code, 451)
+        self.assertEqual(response.get_json()["code"], "moderation_blocked")
+        self.assertEqual(response.headers["X-Moderation-Blocked"], "true")
+        self.generate_images.assert_not_called()
+
+    def test_streaming_image_request_carries_verdict_on_final_frame(self):
+        body = self._image_body()
+        body["stream"] = True
+        with self._with_moderation(_FLAGGED):
+            response = self._post_chat(body)
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.mimetype, "text/event-stream")
+        self.assertEqual(response.headers["X-Moderation-Flagged"], "true")
+        events = [
+            json.loads(line[len("data: ") :])
+            for line in response.get_data(as_text=True).splitlines()
+            if line.startswith("data: ") and line != "data: [DONE]"
+        ]
+        final_frame = events[-1]
+        self.assertTrue(final_frame["moderation"]["flagged"])
+        self.assertEqual(final_frame["images"], ["data:image/png;base64,QUJD"])
+
+
+# ---------------------------------------------------------------------------
 # Sealed OHTTP path: relay-visible headers, sealed verdict
 # ---------------------------------------------------------------------------
 
@@ -277,10 +386,14 @@ class _FakeDecap:
 
 class TestOhttpModerationForwarding(_WireTestCase):
     """Inner chat requests dispatched for real through the app's WSGI stack —
-    only the HPKE crypto at the boundary is faked."""
+    only the HPKE crypto at the boundary is faked. Scope gate opened like
+    TestChatModerationWire (forwarding mechanics, not rollout scope)."""
 
     def setUp(self):
         super().setUp()
+        flag = patch.object(mod, "MODERATE_IMAGE_REQUESTS_ONLY", False)
+        flag.start()
+        self.addCleanup(flag.stop)
         self.sealed_bodies: list[bytes] = []
 
         def _capture_seal(_key, _enc, body_bytes):

--- a/tee_gateway/test/test_moderation_e2e.py
+++ b/tee_gateway/test/test_moderation_e2e.py
@@ -1,0 +1,411 @@
+"""End-to-end wire tests for content moderation on /v1/chat/completions.
+
+Unlike test_moderation.py (unit tests on the module and controller functions),
+these requests travel the real pipeline: a connexion app built from the
+OpenAPI spec (so request validation and routing run for real), through
+``create_chat_completion``, the moderation pre-flight, TEE signing, and out as
+actual HTTP responses — non-streaming JSON, SSE streams, and the sealed OHTTP
+path with its header forwarding. Only the process edges are faked: the
+moderation HTTP client (the test_moderation.py stand-in), the LangChain
+provider model, pricing, and the OHTTP encapsulation crypto.
+
+The final class is an opt-in LIVE test against the real OpenAI moderation
+endpoint, gated like test_provider_usage_integration.py:
+
+    RUN_PROVIDER_INTEGRATION_TESTS=1 OPENAI_API_KEY=sk-... \
+        uv run --group test pytest tee_gateway/test/test_moderation_e2e.py -v
+"""
+
+import json
+import os
+import unittest
+from contextlib import ExitStack
+from decimal import Decimal
+from unittest.mock import MagicMock, patch
+
+import connexion
+
+import tee_gateway.moderation as mod
+from tee_gateway.controllers import ohttp_controller
+from tee_gateway.encoder import JSONEncoder
+from tee_gateway.pricing import SessionCost
+from tee_gateway.test.test_moderation import _ModerationClient, _moderation_response
+
+_FAKE_USAGE = {"prompt_tokens": 10, "completion_tokens": 20, "total_tokens": 30}
+
+_FLAGGED = _moderation_response(
+    200,
+    flagged=True,
+    categories={"violence": True},
+    scores={"violence": 0.93},
+)
+
+_BLOCKED = _moderation_response(
+    200,
+    flagged=True,
+    categories={"sexual/minors": True},
+    scores={"sexual/minors": 0.99},
+)
+
+
+class _Chunk:
+    """Minimal LangChain-shaped stream chunk: text content, no tool calls."""
+
+    def __init__(self, content: str):
+        self.content = content
+        self.tool_call_chunks: list = []
+
+
+def _build_app():
+    """Connexion app from the OpenAPI spec, with /v1/ohttp mounted like
+    __main__.create_app does (it is not part of the spec)."""
+    app = connexion.App(__name__, specification_dir="../openapi/")
+    app.app.json_encoder = JSONEncoder
+    app.add_api("openapi.yaml", pythonic_params=True)
+    app.app.add_url_rule(
+        "/v1/ohttp",
+        "anonymous-chat",
+        ohttp_controller.create_anonymous_chat_completion,
+        methods=["POST"],
+    )
+    return app.app
+
+
+def _fake_tee_keys() -> MagicMock:
+    keys = MagicMock()
+    keys.sign_data.return_value = "bW9ja3NpZ25hdHVyZQ=="
+    keys.get_tee_id.return_value = "abcdef01" * 8
+    keys.hpke_private_key = object()
+    return keys
+
+
+class _WireTestCase(unittest.TestCase):
+    """Shared harness: real app + faked process edges."""
+
+    def setUp(self):
+        self.app = _build_app()
+        self.client = self.app.test_client()
+
+        fake_response = MagicMock()
+        fake_response.content = "hello there"
+        fake_response.tool_calls = None
+        self.fake_model = MagicMock()
+        self.fake_model.invoke.return_value = fake_response
+        self.fake_model.stream.return_value = iter([_Chunk("hello "), _Chunk("there")])
+        self.fake_model.bind_tools.return_value = self.fake_model
+        self.fake_model.bind.return_value = self.fake_model
+
+        stack = ExitStack()
+        self.addCleanup(stack.close)
+        stack.enter_context(
+            patch(
+                "tee_gateway.controllers.chat_controller.get_chat_model_cached",
+                return_value=self.fake_model,
+            )
+        )
+        stack.enter_context(
+            patch(
+                "tee_gateway.controllers.chat_controller.extract_usage",
+                side_effect=lambda _resp: dict(_FAKE_USAGE),
+            )
+        )
+        stack.enter_context(
+            patch(
+                "tee_gateway.controllers.chat_controller.compute_session_cost",
+                return_value=SessionCost(
+                    cost_opg=12345,
+                    cost_usd=Decimal("0.001"),
+                    opg_price_usd=Decimal("0.5"),
+                ),
+            )
+        )
+        stack.enter_context(
+            patch(
+                "tee_gateway.controllers.chat_controller.get_tee_keys",
+                return_value=_fake_tee_keys(),
+            )
+        )
+
+    def _with_moderation(self, *responses):
+        client = _ModerationClient(list(responses))
+        return patch.object(mod, "_moderation_http_client", client)
+
+    def _chat_body(self, stream=False, content="tell me a story"):
+        return {
+            "model": "gpt-4.1",
+            "messages": [{"role": "user", "content": content}],
+            "stream": stream,
+        }
+
+    def _post_chat(self, body):
+        return self.client.post(
+            "/v1/chat/completions",
+            data=json.dumps(body),
+            content_type="application/json",
+            headers={"Authorization": "Bearer test"},
+        )
+
+
+# ---------------------------------------------------------------------------
+# Direct /v1/chat/completions wire behavior
+# ---------------------------------------------------------------------------
+
+
+class TestChatModerationWire(_WireTestCase):
+    def test_clean_prompt_gets_verdict_in_body_and_no_flag_headers(self):
+        with self._with_moderation(_moderation_response(200)):
+            response = self._post_chat(self._chat_body())
+
+        self.assertEqual(response.status_code, 200)
+        body = response.get_json()
+        self.assertEqual(body["choices"][0]["message"]["content"], "hello there")
+        self.assertEqual(
+            body["moderation"],
+            {
+                "model": mod.MODERATION_MODEL,
+                "checked": True,
+                "flagged": False,
+                "blocked": False,
+                "categories": [],
+                "category_scores": {},
+            },
+        )
+        # Clean traffic exposes nothing new on the wire.
+        for header in (
+            "X-Moderation-Flagged",
+            "X-Moderation-Categories",
+            "X-Moderation-Blocked",
+        ):
+            self.assertNotIn(header, response.headers)
+        # Signed and billed as before.
+        self.assertIn("tee_signature", body)
+        self.assertIn("opengradient", body)
+
+    def test_flagged_prompt_is_served_with_verdict_and_headers(self):
+        with self._with_moderation(_FLAGGED):
+            response = self._post_chat(self._chat_body())
+
+        self.assertEqual(response.status_code, 200)
+        body = response.get_json()
+        self.assertEqual(body["choices"][0]["message"]["content"], "hello there")
+        self.assertTrue(body["moderation"]["flagged"])
+        self.assertFalse(body["moderation"]["blocked"])
+        self.assertEqual(body["moderation"]["categories"], ["violence"])
+        self.assertEqual(response.headers["X-Moderation-Flagged"], "true")
+        self.assertEqual(response.headers["X-Moderation-Categories"], "violence")
+        self.assertNotIn("X-Moderation-Blocked", response.headers)
+
+    def test_blocked_prompt_is_refused_with_451_before_any_provider_call(self):
+        with self._with_moderation(_BLOCKED):
+            response = self._post_chat(self._chat_body())
+
+        self.assertEqual(response.status_code, 451)
+        body = response.get_json()
+        self.assertEqual(body["code"], "moderation_blocked")
+        self.assertTrue(body["moderation"]["blocked"])
+        self.assertEqual(response.headers["X-Moderation-Flagged"], "true")
+        self.assertEqual(response.headers["X-Moderation-Blocked"], "true")
+        # The whole point: the prompt never reaches a provider, and nothing
+        # is billed.
+        self.fake_model.invoke.assert_not_called()
+        self.fake_model.stream.assert_not_called()
+        self.assertNotIn("opengradient", body)
+
+    def test_moderation_outage_fails_open_without_verdict(self):
+        with patch.object(mod, "_moderation_http_client", None):
+            response = self._post_chat(self._chat_body())
+
+        self.assertEqual(response.status_code, 200)
+        body = response.get_json()
+        self.assertEqual(body["choices"][0]["message"]["content"], "hello there")
+        self.assertNotIn("moderation", body)
+        self.assertNotIn("X-Moderation-Flagged", response.headers)
+
+    def test_streaming_flagged_prompt_carries_verdict_on_final_frame(self):
+        with self._with_moderation(_FLAGGED):
+            response = self._post_chat(self._chat_body(stream=True))
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.mimetype, "text/event-stream")
+        # Streaming headers flush before the body, and moderation runs
+        # pre-flight — so the flag headers ride the stream's HTTP headers.
+        self.assertEqual(response.headers["X-Moderation-Flagged"], "true")
+        self.assertEqual(response.headers["X-Moderation-Categories"], "violence")
+
+        events = [
+            json.loads(line[len("data: ") :])
+            for line in response.get_data(as_text=True).splitlines()
+            if line.startswith("data: ") and line != "data: [DONE]"
+        ]
+        streamed_text = "".join(
+            event["choices"][0]["delta"].get("content", "")
+            for event in events
+            if event.get("choices")
+        )
+        self.assertEqual(streamed_text, "hello there")
+
+        final_frame = events[-1]
+        self.assertTrue(final_frame["moderation"]["flagged"])
+        self.assertEqual(final_frame["moderation"]["categories"], ["violence"])
+        self.assertIn("tee_signature", final_frame)
+        self.assertTrue(
+            response.get_data(as_text=True).rstrip().endswith("data: [DONE]")
+        )
+
+    def test_streaming_blocked_prompt_never_opens_a_stream(self):
+        with self._with_moderation(_BLOCKED):
+            response = self._post_chat(self._chat_body(stream=True))
+
+        # The refusal happens before stream setup, so the client gets a plain
+        # JSON error it can parse, not a dead SSE stream.
+        self.assertEqual(response.status_code, 451)
+        self.assertEqual(response.get_json()["code"], "moderation_blocked")
+        self.fake_model.stream.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# Sealed OHTTP path: relay-visible headers, sealed verdict
+# ---------------------------------------------------------------------------
+
+
+class _FakeDecap:
+    plaintext = b""
+    response_key = b"k" * 32
+    response_key_chunked = b"c" * 32
+    enc = b"e" * 32
+
+
+class TestOhttpModerationForwarding(_WireTestCase):
+    """Inner chat requests dispatched for real through the app's WSGI stack —
+    only the HPKE crypto at the boundary is faked."""
+
+    def setUp(self):
+        super().setUp()
+        self.sealed_bodies: list[bytes] = []
+
+        def _capture_seal(_key, _enc, body_bytes):
+            self.sealed_bodies.append(body_bytes)
+            return b"sealed"
+
+        stack = ExitStack()
+        self.addCleanup(stack.close)
+        stack.enter_context(
+            patch.object(
+                ohttp_controller, "get_tee_keys", return_value=_fake_tee_keys()
+            )
+        )
+        self.decap = stack.enter_context(
+            patch.object(ohttp_controller.ohttp, "decapsulate_request")
+        )
+        stack.enter_context(
+            patch.object(
+                ohttp_controller.ohttp,
+                "encapsulate_response",
+                side_effect=_capture_seal,
+            )
+        )
+
+    def _post_inner(self, inner: dict):
+        decap = _FakeDecap()
+        decap.plaintext = json.dumps(inner).encode("utf-8")
+        self.decap.return_value = decap
+        return self.client.post(
+            "/v1/ohttp",
+            data=b"ciphertext",
+            content_type="message/ohttp-req",
+        )
+
+    def test_flagged_chat_forwards_flag_headers_and_seals_the_verdict(self):
+        with self._with_moderation(_FLAGGED):
+            response = self._post_inner(self._chat_body())
+
+        # Outer response: sealed body, but the content-free abuse signal is
+        # visible to the relay for its strike policy.
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.mimetype, "message/ohttp-res")
+        self.assertEqual(response.headers["X-Moderation-Flagged"], "true")
+        self.assertEqual(response.headers["X-Moderation-Categories"], "violence")
+        # The full verdict (with scores) lives only inside the sealed body.
+        sealed = json.loads(self.sealed_bodies[-1])
+        self.assertTrue(sealed["moderation"]["flagged"])
+        self.assertIn("category_scores", sealed["moderation"])
+
+    def test_clean_chat_stays_byte_identical_for_the_relay(self):
+        with self._with_moderation(_moderation_response(200)):
+            response = self._post_inner(self._chat_body())
+
+        self.assertEqual(response.status_code, 200)
+        for header in (
+            "X-Moderation-Flagged",
+            "X-Moderation-Categories",
+            "X-Moderation-Blocked",
+        ):
+            self.assertNotIn(header, response.headers)
+
+    def test_blocked_chat_surfaces_the_451_and_headers_to_the_relay(self):
+        with self._with_moderation(_BLOCKED):
+            response = self._post_inner(self._chat_body())
+
+        # Non-2xx inner responses are forwarded plaintext (they carry no user
+        # content) so the relay can count the strike and the client can parse
+        # the refusal.
+        self.assertEqual(response.status_code, 451)
+        self.assertEqual(response.headers["X-Moderation-Flagged"], "true")
+        self.assertEqual(response.headers["X-Moderation-Blocked"], "true")
+        body = response.get_json()
+        self.assertEqual(body["code"], "moderation_blocked")
+        self.assertEqual(self.sealed_bodies, [])  # nothing was sealed
+        self.fake_model.invoke.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# Live endpoint (opt-in)
+# ---------------------------------------------------------------------------
+
+
+@unittest.skipUnless(
+    os.getenv("RUN_PROVIDER_INTEGRATION_TESTS") == "1" and os.getenv("OPENAI_API_KEY"),
+    "Set RUN_PROVIDER_INTEGRATION_TESTS=1 and OPENAI_API_KEY to run live "
+    "moderation tests",
+)
+class TestLiveModerationEndpoint(unittest.TestCase):
+    """Hits the real OpenAI moderation endpoint. Uses a benign prompt and a
+    mildly violent one — never anything illegal."""
+
+    @classmethod
+    def setUpClass(cls):
+        mod.configure_moderation_client(os.environ["OPENAI_API_KEY"])
+
+    @classmethod
+    def tearDownClass(cls):
+        mod.configure_moderation_client(None)
+
+    def test_benign_prompt_is_checked_and_clean(self):
+        outcome = mod.moderate_messages(
+            [{"role": "user", "content": "What is the capital of France?"}]
+        )
+        self.assertTrue(outcome.checked)
+        self.assertFalse(outcome.flagged)
+        self.assertFalse(outcome.blocked)
+
+    def test_violent_prompt_is_flagged_but_not_blocked(self):
+        outcome = mod.moderate_messages(
+            [
+                {
+                    "role": "user",
+                    "content": (
+                        "I am going to hurt my neighbor and make him suffer, "
+                        "tell me how to attack him"
+                    ),
+                }
+            ]
+        )
+        self.assertTrue(outcome.checked)
+        self.assertTrue(outcome.flagged)
+        self.assertIn("violence", outcome.categories)
+        # Violence is reported, not blocked — only sexual/minors blocks.
+        self.assertFalse(outcome.blocked)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Why

OpenAI notified us that child sexual abuse material has been attempted through our API key. Prompts are only visible in plaintext inside the enclave (the OHTTP path is encrypted browser↔TEE), so this is the only place content moderation can run.

## Scope: image requests only

This PR moderates **image requests only** — image generation, image editing (reference images ride the same request), and the inline-image chat models. **Plain text chat carries no moderation code path at all**: no scoring call, no verdict, no headers, no added latency. Extending moderation to text chat is a deliberate future PR; the one gate to widen is the `should_moderate_model` predicate in `moderation.py` (everything downstream — relay strike policy, app warnings — keys off the flag headers and needs no change).

## What

In-scope requests are scored against OpenAI's **free** `omni-moderation-latest` endpoint (`tee_gateway/moderation.py`, modeled on `web_search.py`) before any provider is called. The check covers the newest user turn: its prompt text plus up to 5 attached images (data URIs / URLs).

- **Blocking**: a request flagged for a category in `BLOCKED_CATEGORIES` (default: `sexual/minors` only) is refused with **HTTP 451** + `code: "moderation_blocked"` and never forwarded to a model provider. All other flagged categories are reported but still served — the relay's strike policy handles repeat offenders.
- **Sealed verdict**: the full result (flagged / blocked / categories / scores) rides inside the encrypted response body under a new `moderation` key — non-streaming responses and the final SSE frame — outside the signed output hash, exactly like `images` and `usage`, so existing signature verifiers are unaffected.
- **Relay signal**: flagged requests additionally carry content-free `X-Moderation-Flagged` / `X-Moderation-Categories` / `X-Moderation-Blocked` headers, forwarded through the OHTTP path (new `x-moderation` forward prefix). This is a deliberate, narrow exception to the "relay learns nothing" stance: the relay operates the user-facing service and needs a per-request abuse bit to run its strike policy (see the companion chat-api PR). The headers never carry prompt content or scores, and clean traffic is byte-identical to before.
- **Fail-open**: no OpenAI key or a moderation-endpoint failure means the request proceeds unscored; a positive verdict always comes from a real moderation response. `/health` and the `/v1/keys` response report `moderation_enabled`.
- **Billing**: the moderation endpoint is free; no cost-block changes. Blocked (451) requests produce no `opengradient` block and are never settled.

Dedicated moderation client reuses the injected OpenAI key with a tight (15s total) timeout. The added round-trip lands only on image requests, which already take multiple seconds.

## Testing

- `tee_gateway/test/test_moderation.py` (23 tests): availability, input extraction, verdicts, header shapes, image-only scope, all failure modes fail-open, controller 451 short-circuit, OHTTP header forwarding
- `tee_gateway/test/test_moderation_e2e.py` (11 wire tests + 2 opt-in live): real connexion app end to end — image requests moderated (clean/flagged/blocked/outage/streaming), text chat proven untouched (moderation endpoint never consulted) on both the direct and sealed OHTTP paths; live tests against the real moderation endpoint gated on `RUN_PROVIDER_INTEGRATION_TESTS=1`
- Full CI suite green (383 passed); `make lint` (ruff + mypy) clean

## Companion PRs

- `opengradient/chat-api` — strike counting + blacklist (ban enforcement off by default: observation mode)
- `opengradient/chat-app` — warning banners + suspended-account state