### PR TITLE
Route Claude through GCP Vertex AI when a service account is injected

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -10,6 +10,18 @@ ANTHROPIC_API_KEY=
 XAI_API_KEY=
 ARK_API_KEY=
 
+# GCP Vertex AI routing (optional). When the service-account key is set,
+# Anthropic (Claude) and Google (Gemini) models are served through Vertex AI
+# so usage draws on GCP credits; GOOGLE_API_KEY / ANTHROPIC_API_KEY are then
+# only a fallback for operators not routing through GCP. Base64-encode the
+# whole key file so the multi-line JSON fits one .env line:
+#   base64 -w0 service-account.json
+# GCP_PROJECT_ID defaults to the service account's own project;
+# GCP_LOCATION defaults to "global" (recommended — no 10% regional premium).
+GCP_SERVICE_ACCOUNT_JSON_B64=
+GCP_PROJECT_ID=
+GCP_LOCATION=
+
 # Blockchain heartbeat configuration (optional).
 # If HEARTBEAT_CONTRACT_ADDRESS and HEARTBEAT_FACILITATOR_URL are set, the enclave
 # signs heartbeat payloads and the facilitator relays on-chain txs.

--- a/.env.example
+++ b/.env.example
@@ -11,10 +11,11 @@ XAI_API_KEY=
 ARK_API_KEY=
 
 # GCP Vertex AI routing (optional). When the service-account key is set,
-# Anthropic (Claude) and Google (Gemini) models are served through Vertex AI
-# so usage draws on GCP credits; GOOGLE_API_KEY / ANTHROPIC_API_KEY are then
-# only a fallback for operators not routing through GCP. Base64-encode the
-# whole key file so the multi-line JSON fits one .env line:
+# Anthropic (Claude) models are served through Vertex AI so usage draws on
+# GCP credits; ANTHROPIC_API_KEY is then only a fallback for operators not
+# routing through GCP. Gemini stays on GOOGLE_API_KEY — a paid-tier Gemini
+# key already bills to its GCP project. Base64-encode the whole key file so
+# the multi-line JSON fits one .env line:
 #   base64 -w0 service-account.json
 # GCP_PROJECT_ID defaults to the service account's own project;
 # GCP_LOCATION defaults to "global" (recommended — no 10% regional premium).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -73,6 +73,12 @@ API keys (injected at runtime via POST /v1/keys — do NOT bake into the image):
 - `EXA_API_KEY` (Exa search; injected as `exa_api_key`) — backs the in-enclave
   `/v1/web_search` endpoint, not an LLM provider. Without it the endpoint
   returns 503 and `/health` reports `web_search_enabled: false`.
+- `GCP_SERVICE_ACCOUNT_JSON_B64` (base64-encoded GCP service-account key JSON;
+  injected as `gcp_service_account_json`) — when set, Anthropic and Google
+  models are routed through GCP Vertex AI instead of the vendors' direct APIs
+  (see "GCP Vertex AI routing" below). Optional companions: `GCP_PROJECT_ID`
+  (defaults to the service account's own project) and `GCP_LOCATION` (defaults
+  to Vertex's `global` endpoint).
 
 Server configuration:
 - `API_SERVER_PORT` (default: 8000)
@@ -116,6 +122,35 @@ Server configuration:
 - **Nitriding daemon** runs on localhost:8080, provides TLS termination (port 443 externally)
 - Endpoints `/enclave/ready` and `/enclave/hash` used for nitriding registration
 - PCR measurements in `measurements.txt` fingerprint the exact enclave image
+
+### GCP Vertex AI routing
+
+When a GCP service-account key is injected (`gcp_service_account_json`, plus
+optional `gcp_project_id`/`gcp_location`), **Anthropic (Claude) and Google
+(Gemini) models are served through GCP Vertex AI** so usage draws on GCP
+credits/commitments; without it, both fall back to the vendors' direct APIs
+via their per-vendor keys. Key points:
+
+- **Same model names, same billing**: user-facing model names, providers
+  (`anthropic`/`google`), pricing, request hashing, and signing are all
+  unchanged — Vertex is a transport, not a new provider. Claude's dated
+  snapshots use Vertex's `@`-form IDs (`vertex_api_name` in
+  `model_registry.py`, e.g. `claude-opus-4-5@20251101`); every other ID is
+  identical on both surfaces.
+- **How it's wired** (`llm_backend.py`): Claude runs through
+  `ChatAnthropicVertex`, a thin `ChatAnthropic` subclass that swaps the SDK
+  client for `anthropic.AnthropicVertex` (OAuth via the injected service
+  account, `/v1/messages` rewritten to Vertex `rawPredict`). Gemini uses the
+  same `ChatGoogleGenerativeAI` class with `vertexai=True` — the google-genai
+  SDK serves both backends natively.
+- **Location**: defaults to Vertex's `global` endpoint (recommended: dynamic
+  capacity routing, no 10% regional premium, and the only endpoint type
+  serving the newest Claude models). Inject `gcp_location` (`us`, `eu`, or a
+  specific region) only for data-residency needs.
+- **Non-migratable providers**: OpenAI, xAI, ByteDance, Nous, and Z.ai have no
+  Vertex presence and always use their direct APIs. Moderation also stays on
+  OpenAI's free endpoint.
+- `/health` and the `/v1/keys` response report `vertex_enabled`.
 
 ### Supported Providers
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -74,8 +74,8 @@ API keys (injected at runtime via POST /v1/keys — do NOT bake into the image):
   `/v1/web_search` endpoint, not an LLM provider. Without it the endpoint
   returns 503 and `/health` reports `web_search_enabled: false`.
 - `GCP_SERVICE_ACCOUNT_JSON_B64` (base64-encoded GCP service-account key JSON;
-  injected as `gcp_service_account_json`) — when set, Anthropic and Google
-  models are routed through GCP Vertex AI instead of the vendors' direct APIs
+  injected as `gcp_service_account_json`) — when set, Anthropic (Claude)
+  models are routed through GCP Vertex AI instead of Anthropic's direct API
   (see "GCP Vertex AI routing" below). Optional companions: `GCP_PROJECT_ID`
   (defaults to the service account's own project) and `GCP_LOCATION` (defaults
   to Vertex's `global` endpoint).
@@ -126,23 +126,24 @@ Server configuration:
 ### GCP Vertex AI routing
 
 When a GCP service-account key is injected (`gcp_service_account_json`, plus
-optional `gcp_project_id`/`gcp_location`), **Anthropic (Claude) and Google
-(Gemini) models are served through GCP Vertex AI** so usage draws on GCP
-credits/commitments; without it, both fall back to the vendors' direct APIs
-via their per-vendor keys. Key points:
+optional `gcp_project_id`/`gcp_location`), **Anthropic (Claude) models are
+served through GCP Vertex AI** so their usage draws on GCP
+credits/commitments; without it, Claude falls back to Anthropic's direct API
+via `anthropic_api_key`. Key points:
 
-- **Same model names, same billing**: user-facing model names, providers
-  (`anthropic`/`google`), pricing, request hashing, and signing are all
+- **Same model names, same billing**: user-facing model names, the
+  `anthropic` provider, pricing, request hashing, and signing are all
   unchanged — Vertex is a transport, not a new provider. Claude's dated
   snapshots use Vertex's `@`-form IDs (`vertex_api_name` in
-  `model_registry.py`, e.g. `claude-opus-4-5@20251101`); every other ID is
-  identical on both surfaces.
+  `model_registry.py`, e.g. `claude-opus-4-5@20251101`); current-generation
+  IDs are identical on both surfaces.
 - **How it's wired** (`llm_backend.py`): Claude runs through
   `ChatAnthropicVertex`, a thin `ChatAnthropic` subclass that swaps the SDK
   client for `anthropic.AnthropicVertex` (OAuth via the injected service
-  account, `/v1/messages` rewritten to Vertex `rawPredict`). Gemini uses the
-  same `ChatGoogleGenerativeAI` class with `vertexai=True` — the google-genai
-  SDK serves both backends natively.
+  account, `/v1/messages` rewritten to Vertex `rawPredict`).
+- **Gemini stays on the direct API**: a paid-tier Gemini API key already
+  bills to the GCP project it belongs to, so Vertex routing buys nothing —
+  keep `GOOGLE_API_KEY` on a project under the credited billing account.
 - **Location**: defaults to Vertex's `global` endpoint (recommended: dynamic
   capacity routing, no 10% regional premium, and the only endpoint type
   serving the newest Claude models). Inject `gcp_location` (`us`, `eu`, or a

--- a/README.md
+++ b/README.md
@@ -407,7 +407,7 @@ Clients use an x402-compatible client (e.g., the [x402 SDK](https://github.com/o
 | `ARK_API_KEY` | - | BytePlus / ByteDance ModelArk API key (injected as `bytedance_api_key`) |
 | `NOUS_API_KEY` | - | Nous Research / Nous Portal API key (injected as `nous_api_key`) |
 | `ZAI_API_KEY` | - | Z.ai Model API key (injected as `zai_api_key`) |
-| `GCP_SERVICE_ACCOUNT_JSON_B64` | - | Base64-encoded GCP service-account key JSON (injected as `gcp_service_account_json`). When set, Anthropic and Google models are served through GCP Vertex AI instead of the vendors' direct APIs |
+| `GCP_SERVICE_ACCOUNT_JSON_B64` | - | Base64-encoded GCP service-account key JSON (injected as `gcp_service_account_json`). When set, Anthropic (Claude) models are served through GCP Vertex AI instead of Anthropic's direct API |
 | `GCP_PROJECT_ID` | service account's own project | GCP project for Vertex AI (injected as `gcp_project_id`) |
 | `GCP_LOCATION` | `global` | Vertex AI endpoint: `global` (recommended, no regional premium), a multi-region (`us`/`eu`), or a specific region (injected as `gcp_location`) |
 | `EVM_PAYMENT_ADDRESS` | - | Wallet address to receive x402 payments |

--- a/README.md
+++ b/README.md
@@ -407,6 +407,9 @@ Clients use an x402-compatible client (e.g., the [x402 SDK](https://github.com/o
 | `ARK_API_KEY` | - | BytePlus / ByteDance ModelArk API key (injected as `bytedance_api_key`) |
 | `NOUS_API_KEY` | - | Nous Research / Nous Portal API key (injected as `nous_api_key`) |
 | `ZAI_API_KEY` | - | Z.ai Model API key (injected as `zai_api_key`) |
+| `GCP_SERVICE_ACCOUNT_JSON_B64` | - | Base64-encoded GCP service-account key JSON (injected as `gcp_service_account_json`). When set, Anthropic and Google models are served through GCP Vertex AI instead of the vendors' direct APIs |
+| `GCP_PROJECT_ID` | service account's own project | GCP project for Vertex AI (injected as `gcp_project_id`) |
+| `GCP_LOCATION` | `global` | Vertex AI endpoint: `global` (recommended, no regional premium), a multi-region (`us`/`eu`), or a specific region (injected as `gcp_location`) |
 | `EVM_PAYMENT_ADDRESS` | - | Wallet address to receive x402 payments |
 | `FACILITATOR_URL` | see `tee_gateway/__main__.py` | x402 payment facilitator endpoint |
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,8 @@ dependencies = [
     "langchain-google-genai>=4.2.1",
     "langchain-xai>=1.2.2",
     "openai>=2.15.0",
-    "anthropic>=0.76.0",
+    # [vertex] pulls google-auth for AnthropicVertex (Claude via GCP Vertex AI)
+    "anthropic[vertex]>=0.76.0",
     "google-generativeai>=0.8.6",
     "cryptography>=46.0.5",
     "eth-hash[pycryptodome]>=0.7.0",

--- a/scripts/run-enclave.sh
+++ b/scripts/run-enclave.sh
@@ -94,6 +94,16 @@ if [ -f "$ENV_FILE" ]; then
         ZAI_API_KEY="$(grep -E '^ZAI_API_KEY=' "$ENV_FILE" | cut -d'=' -f2-)"
         # Backs the in-enclave `web_search` tool (Exa), not an LLM provider.
         EXA_API_KEY="$(grep -E '^EXA_API_KEY=' "$ENV_FILE" | cut -d'=' -f2-)"
+        # GCP service-account key for Vertex AI routing (Anthropic + Google
+        # models). Base64-encoded in the .env so the multi-line JSON key
+        # survives the one-line KEY=VALUE format; decoded before injection.
+        GCP_SERVICE_ACCOUNT_JSON_B64="$(grep -E '^GCP_SERVICE_ACCOUNT_JSON_B64=' "$ENV_FILE" | cut -d'=' -f2-)"
+        GCP_SERVICE_ACCOUNT_JSON=""
+        if [ -n "$GCP_SERVICE_ACCOUNT_JSON_B64" ]; then
+            GCP_SERVICE_ACCOUNT_JSON="$(printf '%s' "$GCP_SERVICE_ACCOUNT_JSON_B64" | base64 -d)"
+        fi
+        GCP_PROJECT_ID="$(grep -E '^GCP_PROJECT_ID=' "$ENV_FILE" | cut -d'=' -f2-)"
+        GCP_LOCATION="$(grep -E '^GCP_LOCATION=' "$ENV_FILE" | cut -d'=' -f2-)"
 
         # FACILITATOR_URL is used for both x402 payment verification and the heartbeat relay.
         # HEARTBEAT_CONTRACT_ADDRESS and TEE_HEARTBEAT_INTERVAL are optional heartbeat parameters.
@@ -113,6 +123,9 @@ if [ -f "$ENV_FILE" ]; then
             --arg nous "$NOUS_API_KEY" \
             --arg zai "$ZAI_API_KEY" \
             --arg exa "$EXA_API_KEY" \
+            --arg gcp_sa "$GCP_SERVICE_ACCOUNT_JSON" \
+            --arg gcp_project "$GCP_PROJECT_ID" \
+            --arg gcp_location "$GCP_LOCATION" \
             --arg hb_contract "$HEARTBEAT_CONTRACT_ADDRESS" \
             --arg facilitator "$FACILITATOR_URL" \
             --arg hb_interval "$TEE_HEARTBEAT_INTERVAL" \
@@ -126,6 +139,9 @@ if [ -f "$ENV_FILE" ]; then
                 zai_api_key: $zai,
                 exa_api_key: $exa
             }
+            + if $gcp_sa != "" then {gcp_service_account_json: $gcp_sa} else {} end
+            + if $gcp_project != "" then {gcp_project_id: $gcp_project} else {} end
+            + if $gcp_location != "" then {gcp_location: $gcp_location} else {} end
             + if $hb_contract != "" then {heartbeat_contract_address: $hb_contract} else {} end
             + if $facilitator != "" then {facilitator_url: $facilitator} else {} end
             + if $hb_interval != "" then {tee_heartbeat_interval: $hb_interval} else {} end
@@ -156,6 +172,7 @@ if [ -f "$ENV_FILE" ]; then
         # Clear key variables from this shell immediately after use
         unset OPENAI_API_KEY GOOGLE_API_KEY ANTHROPIC_API_KEY XAI_API_KEY ARK_API_KEY
         unset NOUS_API_KEY ZAI_API_KEY EXA_API_KEY
+        unset GCP_SERVICE_ACCOUNT_JSON_B64 GCP_SERVICE_ACCOUNT_JSON GCP_PROJECT_ID GCP_LOCATION
         unset HEARTBEAT_CONTRACT_ADDRESS FACILITATOR_URL TEE_HEARTBEAT_INTERVAL
     fi
 else

--- a/scripts/run-enclave.sh
+++ b/scripts/run-enclave.sh
@@ -94,8 +94,8 @@ if [ -f "$ENV_FILE" ]; then
         ZAI_API_KEY="$(grep -E '^ZAI_API_KEY=' "$ENV_FILE" | cut -d'=' -f2-)"
         # Backs the in-enclave `web_search` tool (Exa), not an LLM provider.
         EXA_API_KEY="$(grep -E '^EXA_API_KEY=' "$ENV_FILE" | cut -d'=' -f2-)"
-        # GCP service-account key for Vertex AI routing (Anthropic + Google
-        # models). Base64-encoded in the .env so the multi-line JSON key
+        # GCP service-account key for Vertex AI routing of Anthropic (Claude)
+        # models. Base64-encoded in the .env so the multi-line JSON key
         # survives the one-line KEY=VALUE format; decoded before injection.
         GCP_SERVICE_ACCOUNT_JSON_B64="$(grep -E '^GCP_SERVICE_ACCOUNT_JSON_B64=' "$ENV_FILE" | cut -d'=' -f2-)"
         GCP_SERVICE_ACCOUNT_JSON=""

--- a/tee_gateway/__main__.py
+++ b/tee_gateway/__main__.py
@@ -423,8 +423,18 @@ def set_provider_keys():
             nous_api_key=body.get("nous_api_key") or None,
             zai_api_key=body.get("zai_api_key") or None,
             exa_api_key=body.get("exa_api_key") or None,
+            gcp_service_account_json=body.get("gcp_service_account_json") or None,
+            gcp_project_id=body.get("gcp_project_id") or None,
+            gcp_location=body.get("gcp_location") or None,
         )
-        set_provider_config(provider_config)
+        try:
+            set_provider_config(provider_config)
+        except ValueError as e:
+            # Malformed GCP service-account key: reject the injection outright
+            # (keys can be re-injected) instead of silently running without
+            # Vertex routing.
+            logger.error("Provider config rejected: %s", e)
+            return jsonify({"error": str(e)}), 400
 
         facilitator_url = body.get("facilitator_url") or FACILITATOR_URL
 
@@ -491,6 +501,10 @@ def set_provider_keys():
         logger.info(
             "  exa_api_key (web search)    : %s", _set(provider_config.exa_api_key)
         )
+        logger.info(
+            "  gcp_service_account (vertex): %s",
+            _set(provider_config.gcp_service_account_json),
+        )
         logger.info("  facilitator_url             : %s", facilitator_url)
         logger.info(
             "  heartbeat_contract_address  : %s",
@@ -515,27 +529,17 @@ def set_provider_keys():
         _active_facilitator_url = facilitator_url
         _keys_initialized = True
 
-    providers_set = [
-        p
-        for p, k in {
-            "openai": provider_config.openai_api_key,
-            "google": provider_config.google_api_key,
-            "anthropic": provider_config.anthropic_api_key,
-            "xai": provider_config.xai_api_key,
-            "bytedance": provider_config.bytedance_api_key,
-            "nous": provider_config.nous_api_key,
-            "zai": provider_config.zai_api_key,
-        }.items()
-        if k
-    ]
-
     return jsonify(
         {
             "status": "ok",
-            "providers_initialized": providers_set,
+            "providers_initialized": provider_config.initialized_providers(),
             "heartbeat_enabled": heartbeat_config is not None,
             "web_search_enabled": bool(provider_config.exa_api_key),
             "moderation_enabled": bool(provider_config.openai_api_key),
+            # Whether Anthropic/Google models are routed through GCP Vertex AI
+            # (a GCP service-account key was injected) instead of the vendors'
+            # direct APIs.
+            "vertex_enabled": provider_config.vertex_enabled(),
         }
     ), 200
 
@@ -557,6 +561,8 @@ def health():
         # Whether chat prompts are being scored against OpenAI's moderation
         # endpoint (requires the OpenAI key; fail-open when unavailable).
         "moderation_enabled": moderation_available(),
+        # Whether Anthropic/Google models are routed through GCP Vertex AI.
+        "vertex_enabled": cfg.vertex_enabled() if cfg else False,
         "facilitator_url": _active_facilitator_url,
         "price_feed": _price_feed.get_status(),
     }, 200

--- a/tee_gateway/__main__.py
+++ b/tee_gateway/__main__.py
@@ -543,9 +543,9 @@ def set_provider_keys():
             "heartbeat_enabled": heartbeat_config is not None,
             "web_search_enabled": bool(provider_config.exa_api_key),
             "moderation_enabled": bool(provider_config.openai_api_key),
-            # Whether Anthropic/Google models are routed through GCP Vertex AI
-            # (a GCP service-account key was injected) instead of the vendors'
-            # direct APIs.
+            # Whether Anthropic (Claude) models are routed through GCP Vertex
+            # AI (a GCP service-account key was injected) instead of
+            # Anthropic's direct API.
             "vertex_enabled": provider_config.vertex_enabled(),
         }
     ), 200
@@ -568,7 +568,7 @@ def health():
         # Whether chat prompts are being scored against OpenAI's moderation
         # endpoint (requires the OpenAI key; fail-open when unavailable).
         "moderation_enabled": moderation_available(),
-        # Whether Anthropic/Google models are routed through GCP Vertex AI.
+        # Whether Anthropic (Claude) models are routed through GCP Vertex AI.
         "vertex_enabled": cfg.vertex_enabled() if cfg else False,
         "facilitator_url": _active_facilitator_url,
         "price_feed": _price_feed.get_status(),

--- a/tee_gateway/__main__.py
+++ b/tee_gateway/__main__.py
@@ -429,12 +429,19 @@ def set_provider_keys():
         )
         try:
             set_provider_config(provider_config)
-        except ValueError as e:
+        except ValueError:
             # Malformed GCP service-account key: reject the injection outright
             # (keys can be re-injected) instead of silently running without
-            # Vertex routing.
-            logger.error("Provider config rejected: %s", e)
-            return jsonify({"error": str(e)}), 400
+            # Vertex routing. The exception text can carry parser internals,
+            # so it goes to the enclave log only — never the HTTP response.
+            logger.exception("Provider config rejected")
+            return jsonify(
+                {
+                    "error": "Invalid GCP configuration "
+                    "(gcp_service_account_json / gcp_project_id); "
+                    "see enclave logs for details"
+                }
+            ), 400
 
         facilitator_url = body.get("facilitator_url") or FACILITATOR_URL
 

--- a/tee_gateway/config.py
+++ b/tee_gateway/config.py
@@ -35,17 +35,19 @@ class ProviderConfig:
     # deliberately absent from initialized_providers() — /health reports it
     # separately as `web_search_enabled`.
     exa_api_key: Optional[str] = None
-    # GCP service-account key (full JSON, as a string). When set, Anthropic and
-    # Google models are served through Vertex AI instead of the vendors' direct
-    # APIs — the per-vendor API keys above then act as an optional fallback for
-    # operators that don't route through GCP. project defaults to the service
-    # account's own project_id; location defaults to Vertex's "global" endpoint.
+    # GCP service-account key (full JSON, as a string). When set, Anthropic
+    # (Claude) models are served through GCP Vertex AI instead of Anthropic's
+    # direct API — anthropic_api_key then acts as an optional fallback for
+    # operators that don't route through GCP. Gemini deliberately stays on the
+    # direct API (a paid-tier Gemini key already bills to its GCP project).
+    # project defaults to the service account's own project_id; location
+    # defaults to Vertex's "global" endpoint.
     gcp_service_account_json: Optional[str] = None
     gcp_project_id: Optional[str] = None
     gcp_location: Optional[str] = None
 
     def vertex_enabled(self) -> bool:
-        """Whether Anthropic/Google traffic is routed through GCP Vertex AI."""
+        """Whether Anthropic (Claude) traffic is routed through GCP Vertex AI."""
         return bool(self.gcp_service_account_json)
 
     def initialized_providers(self) -> list[str]:
@@ -55,7 +57,7 @@ class ProviderConfig:
             providers.append("openai")
         if self.anthropic_api_key or self.vertex_enabled():
             providers.append("anthropic")
-        if self.google_api_key or self.vertex_enabled():
+        if self.google_api_key:
             providers.append("google")
         if self.xai_api_key:
             providers.append("xai")

--- a/tee_gateway/config.py
+++ b/tee_gateway/config.py
@@ -35,15 +35,27 @@ class ProviderConfig:
     # deliberately absent from initialized_providers() — /health reports it
     # separately as `web_search_enabled`.
     exa_api_key: Optional[str] = None
+    # GCP service-account key (full JSON, as a string). When set, Anthropic and
+    # Google models are served through Vertex AI instead of the vendors' direct
+    # APIs — the per-vendor API keys above then act as an optional fallback for
+    # operators that don't route through GCP. project defaults to the service
+    # account's own project_id; location defaults to Vertex's "global" endpoint.
+    gcp_service_account_json: Optional[str] = None
+    gcp_project_id: Optional[str] = None
+    gcp_location: Optional[str] = None
+
+    def vertex_enabled(self) -> bool:
+        """Whether Anthropic/Google traffic is routed through GCP Vertex AI."""
+        return bool(self.gcp_service_account_json)
 
     def initialized_providers(self) -> list[str]:
-        """Return provider names whose API key is set (non-empty)."""
+        """Return provider names the gateway can serve (API key or Vertex)."""
         providers = []
         if self.openai_api_key:
             providers.append("openai")
-        if self.anthropic_api_key:
+        if self.anthropic_api_key or self.vertex_enabled():
             providers.append("anthropic")
-        if self.google_api_key:
+        if self.google_api_key or self.vertex_enabled():
             providers.append("google")
         if self.xai_api_key:
             providers.append("xai")

--- a/tee_gateway/llm_backend.py
+++ b/tee_gateway/llm_backend.py
@@ -87,8 +87,9 @@ zai_http_client: Optional[httpx.Client] = None
 _provider_config: Optional[ProviderConfig] = None
 
 # GCP Vertex AI routing state, derived from the injected service-account key.
-# When populated, Anthropic and Google models are served through Vertex; the
+# When populated, Anthropic (Claude) models are served through Vertex; the
 # credentials object self-refreshes its OAuth token, so it is built once here.
+# (Gemini stays on the direct API — its key already bills to a GCP project.)
 _vertex_credentials: Optional[service_account.Credentials] = None
 _vertex_project_id: Optional[str] = None
 _vertex_location: str = VERTEX_DEFAULT_LOCATION
@@ -125,7 +126,7 @@ def _build_vertex_state(
 
 
 def vertex_enabled() -> bool:
-    """Whether Anthropic/Google models are currently routed through Vertex AI."""
+    """Whether Anthropic (Claude) models are currently routed through Vertex AI."""
     return _vertex_credentials is not None
 
 
@@ -319,24 +320,11 @@ def get_chat_model_cached(
     logger.info(f"Creating cached chat model - Provider: {provider}, Model: {api_name}")
 
     if provider == "google":
-        # Vertex AI and the direct Gemini API serve the same models under the
-        # same IDs through the same google-genai SDK; only the endpoint and
-        # auth differ. When a GCP service account was injected, route through
-        # Vertex so usage draws on GCP credits/commitments.
-        google_kwargs: dict[str, Any]
-        if vertex_enabled():
-            google_kwargs = {
-                "vertexai": True,
-                "project": _vertex_project_id,
-                "location": _vertex_location,
-                "credentials": _vertex_credentials,
-            }
-        elif config.google_api_key:
-            google_kwargs = {"google_api_key": config.google_api_key}
-        else:
-            raise ValueError(
-                "Neither google_api_key nor GCP credentials set in ProviderConfig"
-            )
+        # Gemini deliberately stays on the direct API: a paid-tier Gemini API
+        # key already bills to its GCP project, so Vertex routing would buy
+        # nothing here. Only Claude moves to Vertex (see the anthropic branch).
+        if not config.google_api_key:
+            raise ValueError("google_api_key not set in ProviderConfig")
 
         # Image-generation models return images inline and do not support the
         # thinking budget; ask for both TEXT and IMAGE modalities so the model
@@ -344,19 +332,19 @@ def get_chat_model_cached(
         if cfg.image_output:
             return ChatGoogleGenerativeAI(
                 model=api_name,
+                google_api_key=config.google_api_key,
                 temperature=effective_temp,
                 max_output_tokens=max_tokens,
                 response_modalities=[Modality.TEXT, Modality.IMAGE],
-                **google_kwargs,
             )
 
         return ChatGoogleGenerativeAI(
             model=api_name,
+            google_api_key=config.google_api_key,
             temperature=effective_temp,
             max_output_tokens=max_tokens,
             thinking_budget=cfg.thinking_budget,
             include_thoughts=False if cfg.thinking_budget is not None else None,
-            **google_kwargs,
         )
 
     elif provider == "openai":

--- a/tee_gateway/llm_backend.py
+++ b/tee_gateway/llm_backend.py
@@ -10,9 +10,12 @@ import json
 import logging
 from collections.abc import Mapping
 from typing import List, Dict, Optional, Any, Generator
-from functools import lru_cache
+from functools import cached_property, lru_cache
 
+import anthropic
 import httpx
+from anthropic import AnthropicVertex, AsyncAnthropicVertex
+from google.oauth2 import service_account
 from pydantic import SecretStr
 from langchain_core.messages import (
     HumanMessage,
@@ -62,6 +65,16 @@ NOUS_BASE_URL = "https://inference-api.nousresearch.com/v1"
 # the subscription Coding Plan endpoint at /api/coding/paas/v4.
 ZAI_BASE_URL = "https://api.z.ai/api/paas/v4"
 
+# Vertex AI's "global" endpoint dynamically routes to whichever region has
+# capacity, is the only endpoint type without a 10% regional pricing premium,
+# and is the only one that serves the newest Claude models — so it is the
+# default unless the operator injects a specific gcp_location.
+VERTEX_DEFAULT_LOCATION = "global"
+
+# OAuth scope for Vertex AI requests, used when minting tokens from the
+# injected service-account key.
+_VERTEX_SCOPES = ("https://www.googleapis.com/auth/cloud-platform",)
+
 # Shared synchronous HTTP clients for each provider.
 # Initialized to None; built by set_provider_config() after key injection.
 openai_http_client: Optional[httpx.Client] = None
@@ -73,11 +86,58 @@ zai_http_client: Optional[httpx.Client] = None
 
 _provider_config: Optional[ProviderConfig] = None
 
+# GCP Vertex AI routing state, derived from the injected service-account key.
+# When populated, Anthropic and Google models are served through Vertex; the
+# credentials object self-refreshes its OAuth token, so it is built once here.
+_vertex_credentials: Optional[service_account.Credentials] = None
+_vertex_project_id: Optional[str] = None
+_vertex_location: str = VERTEX_DEFAULT_LOCATION
+
+
+def _build_vertex_state(
+    config: ProviderConfig,
+) -> tuple[Optional[service_account.Credentials], Optional[str], str]:
+    """Parse the injected GCP service-account key into Vertex routing state.
+
+    Returns ``(credentials, project_id, location)`` — all-``None``/default when
+    no key was injected. Raises ``ValueError`` on a malformed key so the
+    /v1/keys call fails loudly instead of silently falling back to the direct
+    provider APIs.
+    """
+    if not config.gcp_service_account_json:
+        return None, None, VERTEX_DEFAULT_LOCATION
+
+    try:
+        sa_info = json.loads(config.gcp_service_account_json)
+        credentials = service_account.Credentials.from_service_account_info(
+            sa_info, scopes=list(_VERTEX_SCOPES)
+        )
+    except Exception as e:
+        raise ValueError(f"Invalid gcp_service_account_json: {e}") from e
+
+    project_id = config.gcp_project_id or sa_info.get("project_id")
+    if not project_id:
+        raise ValueError(
+            "gcp_project_id not set and the service-account key carries no project_id"
+        )
+    location = config.gcp_location or VERTEX_DEFAULT_LOCATION
+    return credentials, project_id, location
+
+
+def vertex_enabled() -> bool:
+    """Whether Anthropic/Google models are currently routed through Vertex AI."""
+    return _vertex_credentials is not None
+
 
 def set_provider_config(config: ProviderConfig) -> None:
     """Store the provider config and rebuild HTTP clients. Called once after key injection."""
     global _provider_config, openai_http_client, xai_http_client, bytedance_http_client
     global nous_http_client, zai_http_client
+    global _vertex_credentials, _vertex_project_id, _vertex_location
+
+    # Validate the GCP key before touching any shared state, so a malformed
+    # key leaves the existing configuration fully intact.
+    vertex_credentials, vertex_project_id, vertex_location = _build_vertex_state(config)
 
     old_openai = openai_http_client
     old_xai = xai_http_client
@@ -141,6 +201,10 @@ def set_provider_config(config: ProviderConfig) -> None:
     # much tighter timeout — it runs synchronously in front of every chat call.
     configure_moderation_client(config.openai_api_key)
 
+    _vertex_credentials = vertex_credentials
+    _vertex_project_id = vertex_project_id
+    _vertex_location = vertex_location
+
     get_chat_model_cached.cache_clear()
     _provider_config = config
 
@@ -164,6 +228,47 @@ def get_provider_from_model(model: str) -> str:
     """Infer provider from model name. Raises ValueError if model is unknown."""
     cfg = get_model_config(model)
     return cfg.provider
+
+
+class ChatAnthropicVertex(ChatAnthropic):
+    """``ChatAnthropic`` served through GCP Vertex AI (Agent Platform).
+
+    Keeps langchain-anthropic's whole request/response pipeline — tool binding,
+    standard content blocks, streaming, usage extraction, the temperature-strip
+    behavior — and swaps only the underlying SDK clients for
+    ``anthropic.AnthropicVertex``, which rewrites ``/v1/messages`` calls into
+    Vertex ``rawPredict``/``streamRawPredict`` requests (model moves into the
+    URL, ``anthropic_version`` into the body) and signs them with the
+    service-account OAuth token instead of an Anthropic API key.
+    """
+
+    vertex_project_id: str
+    vertex_region: str = VERTEX_DEFAULT_LOCATION
+    # google.auth credentials object (kept as Any: pydantic can't validate it)
+    vertex_credentials: Any = None
+
+    # AnthropicVertex is a sibling of Anthropic (both extend the same base
+    # client) rather than a subclass, but exposes the identical messages
+    # surface langchain-anthropic calls — hence the return-value ignores.
+    @cached_property
+    def _client(self) -> anthropic.Client:
+        return AnthropicVertex(  # type: ignore [return-value]
+            project_id=self.vertex_project_id,
+            region=self.vertex_region,
+            credentials=self.vertex_credentials,
+            timeout=self.default_request_timeout,
+            max_retries=self.max_retries,
+        )
+
+    @cached_property
+    def _async_client(self) -> anthropic.AsyncClient:
+        return AsyncAnthropicVertex(  # type: ignore [return-value]
+            project_id=self.vertex_project_id,
+            region=self.vertex_region,
+            credentials=self.vertex_credentials,
+            timeout=self.default_request_timeout,
+            max_retries=self.max_retries,
+        )
 
 
 def non_streaming_invoke_kwargs(provider: str) -> Dict[str, Any]:
@@ -214,8 +319,24 @@ def get_chat_model_cached(
     logger.info(f"Creating cached chat model - Provider: {provider}, Model: {api_name}")
 
     if provider == "google":
-        if not config.google_api_key:
-            raise ValueError("google_api_key not set in ProviderConfig")
+        # Vertex AI and the direct Gemini API serve the same models under the
+        # same IDs through the same google-genai SDK; only the endpoint and
+        # auth differ. When a GCP service account was injected, route through
+        # Vertex so usage draws on GCP credits/commitments.
+        google_kwargs: dict[str, Any]
+        if vertex_enabled():
+            google_kwargs = {
+                "vertexai": True,
+                "project": _vertex_project_id,
+                "location": _vertex_location,
+                "credentials": _vertex_credentials,
+            }
+        elif config.google_api_key:
+            google_kwargs = {"google_api_key": config.google_api_key}
+        else:
+            raise ValueError(
+                "Neither google_api_key nor GCP credentials set in ProviderConfig"
+            )
 
         # Image-generation models return images inline and do not support the
         # thinking budget; ask for both TEXT and IMAGE modalities so the model
@@ -223,19 +344,19 @@ def get_chat_model_cached(
         if cfg.image_output:
             return ChatGoogleGenerativeAI(
                 model=api_name,
-                google_api_key=config.google_api_key,
                 temperature=effective_temp,
                 max_output_tokens=max_tokens,
                 response_modalities=[Modality.TEXT, Modality.IMAGE],
+                **google_kwargs,
             )
 
         return ChatGoogleGenerativeAI(
             model=api_name,
-            google_api_key=config.google_api_key,
             temperature=effective_temp,
             max_output_tokens=max_tokens,
             thinking_budget=cfg.thinking_budget,
             include_thoughts=False if cfg.thinking_budget is not None else None,
+            **google_kwargs,
         )
 
     elif provider == "openai":
@@ -269,14 +390,33 @@ def get_chat_model_cached(
         )  # type: ignore [call-arg]
 
     elif provider == "anthropic":
-        if not config.anthropic_api_key:
-            raise ValueError("anthropic_api_key not set in ProviderConfig")
-
         # Opus 4.7+ rejects `temperature` outright (HTTP 400). Pass None so
         # langchain-anthropic strips the field from the outgoing payload.
         anthropic_temperature: Optional[float] = (
             effective_temp if cfg.supports_temperature else None
         )
+
+        # Prefer Vertex AI when a GCP service account was injected: every
+        # Claude model in the registry is served on Vertex (dated snapshots
+        # under their `@`-form vertex_api_name), billed against GCP.
+        if vertex_enabled():
+            assert _vertex_project_id is not None
+            return ChatAnthropicVertex(
+                model=cfg.vertex_api_name or api_name,
+                temperature=anthropic_temperature,
+                max_tokens=max_tokens,
+                timeout=READ_TIMEOUT,
+                streaming=True,
+                stream_usage=True,
+                vertex_project_id=_vertex_project_id,
+                vertex_region=_vertex_location,
+                vertex_credentials=_vertex_credentials,
+            )  # type: ignore [call-arg]
+
+        if not config.anthropic_api_key:
+            raise ValueError(
+                "Neither anthropic_api_key nor GCP credentials set in ProviderConfig"
+            )
 
         return ChatAnthropic(
             model=api_name,

--- a/tee_gateway/model_registry.py
+++ b/tee_gateway/model_registry.py
@@ -18,6 +18,13 @@ class ModelConfig:
     api_name: str  # model name sent to provider API
     input_price_usd: Decimal  # USD per token
     output_price_usd: Decimal  # USD per token
+    # Model ID on GCP Vertex AI, when it differs from ``api_name``. Vertex
+    # serves current-generation Claude models under their bare first-party IDs
+    # but dated snapshots under an ``@`` separator (claude-opus-4-5@20251101,
+    # not claude-opus-4-5-20251101); Gemini IDs are identical on both surfaces.
+    # ``None`` means api_name is already the Vertex ID. Only consulted when the
+    # gateway is configured to route the provider through Vertex.
+    vertex_api_name: Optional[str] = None
     force_temperature: Optional[float] = None
     thinking_budget: Optional[int] = None
     # Anthropic deprecated `temperature` for Opus 4.7 — the API returns 400 if
@@ -242,6 +249,7 @@ class SupportedModel(Enum):
         api_name="claude-sonnet-4-5",
         input_price_usd=Decimal("0.000003"),
         output_price_usd=Decimal("0.000015"),
+        vertex_api_name="claude-sonnet-4-5@20250929",
     )
     CLAUDE_SONNET_4_6 = ModelConfig(
         provider="anthropic",
@@ -265,12 +273,14 @@ class SupportedModel(Enum):
         api_name="claude-haiku-4-5-20251001",
         input_price_usd=Decimal("0.000001"),
         output_price_usd=Decimal("0.000005"),
+        vertex_api_name="claude-haiku-4-5@20251001",
     )
     CLAUDE_OPUS_4_5 = ModelConfig(
         provider="anthropic",
         api_name="claude-opus-4-5-20251101",
         input_price_usd=Decimal("0.000005"),
         output_price_usd=Decimal("0.000025"),
+        vertex_api_name="claude-opus-4-5@20251101",
     )
     CLAUDE_OPUS_4_6 = ModelConfig(
         provider="anthropic",

--- a/tee_gateway/test/test_vertex_routing.py
+++ b/tee_gateway/test/test_vertex_routing.py
@@ -1,0 +1,203 @@
+"""Unit tests for GCP Vertex AI routing of Anthropic and Google models.
+
+When a GCP service-account key is injected via /v1/keys, Claude models are
+served through ``AnthropicVertex`` and Gemini models through the google-genai
+SDK's Vertex backend; without it, both fall back to the vendors' direct APIs.
+No network calls are made — the tests only exercise client construction and
+provider routing.
+"""
+
+import json
+import unittest
+
+from cryptography.hazmat.primitives import serialization
+from cryptography.hazmat.primitives.asymmetric import rsa
+
+from tee_gateway import llm_backend
+from tee_gateway.config import ProviderConfig
+from tee_gateway.llm_backend import (
+    ChatAnthropicVertex,
+    get_chat_model_cached,
+    set_provider_config,
+    vertex_enabled,
+)
+from tee_gateway.model_registry import SupportedModel
+
+
+def _fake_service_account_json(project_id: str = "test-project") -> str:
+    """A structurally valid service-account key with a throwaway RSA key."""
+    private_key = rsa.generate_private_key(public_exponent=65537, key_size=2048)
+    pem = private_key.private_bytes(
+        serialization.Encoding.PEM,
+        serialization.PrivateFormat.PKCS8,
+        serialization.NoEncryption(),
+    ).decode()
+    return json.dumps(
+        {
+            "type": "service_account",
+            "project_id": project_id,
+            "private_key_id": "test-key-id",
+            "private_key": pem,
+            "client_email": f"tee-gateway@{project_id}.iam.gserviceaccount.com",
+            "client_id": "1234567890",
+            "token_uri": "https://oauth2.googleapis.com/token",
+        }
+    )
+
+
+_FAKE_SA_JSON = _fake_service_account_json()
+
+
+class VertexRoutingTestCase(unittest.TestCase):
+    def tearDown(self) -> None:
+        # Reset module state so other test files see an unconfigured backend.
+        llm_backend._provider_config = None
+        llm_backend._vertex_credentials = None
+        llm_backend._vertex_project_id = None
+        llm_backend._vertex_location = llm_backend.VERTEX_DEFAULT_LOCATION
+        get_chat_model_cached.cache_clear()
+
+    def _configure(self, **kwargs) -> None:
+        set_provider_config(ProviderConfig(**kwargs))
+
+    # ── routing with GCP credentials ─────────────────────────────────────
+
+    def test_claude_routed_through_vertex_when_gcp_configured(self) -> None:
+        self._configure(gcp_service_account_json=_FAKE_SA_JSON)
+        self.assertTrue(vertex_enabled())
+
+        model = get_chat_model_cached("claude-opus-5", 0.7, 256)
+        self.assertIsInstance(model, ChatAnthropicVertex)
+        self.assertEqual(model.vertex_project_id, "test-project")
+        self.assertEqual(model.vertex_region, "global")
+        self.assertEqual(model.model, "claude-opus-5")
+        # Opus 5 rejects `temperature`; the vertex path must strip it too.
+        self.assertIsNone(model.temperature)
+
+        # The underlying SDK client must be the Vertex client, aimed at the
+        # global aiplatform endpoint.
+        client = model._client
+        self.assertEqual(type(client).__name__, "AnthropicVertex")
+        self.assertIn("aiplatform.googleapis.com", str(client.base_url))
+
+    def test_dated_claude_snapshots_use_vertex_at_form_ids(self) -> None:
+        self._configure(gcp_service_account_json=_FAKE_SA_JSON)
+
+        for user_name, vertex_id in [
+            ("claude-sonnet-4-5", "claude-sonnet-4-5@20250929"),
+            ("claude-haiku-4-5", "claude-haiku-4-5@20251001"),
+            ("claude-opus-4-5", "claude-opus-4-5@20251101"),
+        ]:
+            with self.subTest(model=user_name):
+                model = get_chat_model_cached(user_name, 0.7, 256)
+                self.assertIsInstance(model, ChatAnthropicVertex)
+                self.assertEqual(model.model, vertex_id)
+
+    def test_current_gen_claude_keeps_bare_ids_on_vertex(self) -> None:
+        self._configure(gcp_service_account_json=_FAKE_SA_JSON)
+        for name in [
+            "claude-sonnet-4-6",
+            "claude-sonnet-5",
+            "claude-opus-4-6",
+            "claude-opus-4-7",
+            "claude-opus-4-8",
+            "claude-fable-5",
+        ]:
+            with self.subTest(model=name):
+                model = get_chat_model_cached(name, 0.7, 256)
+                self.assertIsInstance(model, ChatAnthropicVertex)
+                self.assertEqual(model.model, name)
+
+    def test_gemini_routed_through_vertex_when_gcp_configured(self) -> None:
+        self._configure(gcp_service_account_json=_FAKE_SA_JSON)
+
+        model = get_chat_model_cached("gemini-2.5-flash", 0.7, 256)
+        self.assertTrue(model.vertexai)
+        self.assertEqual(model.project, "test-project")
+        self.assertEqual(model.location, "global")
+        # The google-genai client must actually be in Vertex mode.
+        self.assertTrue(model.client._api_client.vertexai)
+
+    def test_gemini_image_output_model_on_vertex(self) -> None:
+        self._configure(gcp_service_account_json=_FAKE_SA_JSON)
+        model = get_chat_model_cached("gemini-2.5-flash-image", 0.7, 256)
+        self.assertTrue(model.vertexai)
+        self.assertEqual(len(model.response_modalities), 2)
+
+    def test_project_and_location_overrides(self) -> None:
+        self._configure(
+            gcp_service_account_json=_FAKE_SA_JSON,
+            gcp_project_id="override-project",
+            gcp_location="us",
+        )
+        model = get_chat_model_cached("claude-sonnet-5", 0.7, 256)
+        self.assertEqual(model.vertex_project_id, "override-project")
+        self.assertEqual(model.vertex_region, "us")
+
+    def test_vertex_preferred_over_direct_anthropic_key(self) -> None:
+        self._configure(
+            anthropic_api_key="sk-ant-test",
+            google_api_key="AIza-test",
+            gcp_service_account_json=_FAKE_SA_JSON,
+        )
+        self.assertIsInstance(
+            get_chat_model_cached("claude-opus-5", 0.7, 256), ChatAnthropicVertex
+        )
+        self.assertTrue(get_chat_model_cached("gemini-2.5-flash", 0.7, 256).vertexai)
+
+    # ── fallback without GCP credentials ─────────────────────────────────
+
+    def test_direct_apis_used_without_gcp_credentials(self) -> None:
+        self._configure(anthropic_api_key="sk-ant-test", google_api_key="AIza-test")
+        self.assertFalse(vertex_enabled())
+
+        claude = get_chat_model_cached("claude-opus-5", 0.7, 256)
+        self.assertNotIsInstance(claude, ChatAnthropicVertex)
+
+        gemini = get_chat_model_cached("gemini-2.5-flash", 0.7, 256)
+        self.assertFalse(gemini.vertexai)
+
+    def test_missing_key_and_gcp_raises(self) -> None:
+        self._configure(openai_api_key="sk-test")
+        with self.assertRaises(ValueError):
+            get_chat_model_cached("claude-opus-5", 0.7, 256)
+        with self.assertRaises(ValueError):
+            get_chat_model_cached("gemini-2.5-flash", 0.7, 256)
+
+    # ── config validation and reporting ──────────────────────────────────
+
+    def test_malformed_service_account_json_rejected(self) -> None:
+        with self.assertRaises(ValueError):
+            self._configure(gcp_service_account_json="not-json")
+        # The failed injection must not leave stale vertex state behind.
+        self.assertFalse(vertex_enabled())
+
+    def test_service_account_without_project_requires_override(self) -> None:
+        sa = json.loads(_FAKE_SA_JSON)
+        del sa["project_id"]
+        with self.assertRaises(ValueError):
+            self._configure(gcp_service_account_json=json.dumps(sa))
+        # An explicit override makes the same key acceptable.
+        self._configure(
+            gcp_service_account_json=json.dumps(sa), gcp_project_id="explicit"
+        )
+        self.assertTrue(vertex_enabled())
+
+    def test_initialized_providers_reflect_vertex(self) -> None:
+        cfg = ProviderConfig(gcp_service_account_json=_FAKE_SA_JSON)
+        self.assertTrue(cfg.vertex_enabled())
+        providers = cfg.initialized_providers()
+        self.assertIn("anthropic", providers)
+        self.assertIn("google", providers)
+        self.assertNotIn("openai", providers)
+
+    def test_registry_vertex_ids_only_set_for_anthropic_snapshots(self) -> None:
+        for supported in SupportedModel:
+            cfg = supported.value
+            if cfg.vertex_api_name is not None:
+                self.assertEqual(cfg.provider, "anthropic")
+                self.assertIn("@", cfg.vertex_api_name)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tee_gateway/test/test_vertex_routing.py
+++ b/tee_gateway/test/test_vertex_routing.py
@@ -1,10 +1,10 @@
-"""Unit tests for GCP Vertex AI routing of Anthropic and Google models.
+"""Unit tests for GCP Vertex AI routing of Anthropic (Claude) models.
 
 When a GCP service-account key is injected via /v1/keys, Claude models are
-served through ``AnthropicVertex`` and Gemini models through the google-genai
-SDK's Vertex backend; without it, both fall back to the vendors' direct APIs.
-No network calls are made — the tests only exercise client construction and
-provider routing.
+served through ``AnthropicVertex``; without it, they fall back to Anthropic's
+direct API. Gemini deliberately stays on the direct Gemini API either way (a
+paid-tier Gemini key already bills to its GCP project). No network calls are
+made — the tests only exercise client construction and provider routing.
 """
 
 import json
@@ -108,21 +108,21 @@ class VertexRoutingTestCase(unittest.TestCase):
                 self.assertIsInstance(model, ChatAnthropicVertex)
                 self.assertEqual(model.model, name)
 
-    def test_gemini_routed_through_vertex_when_gcp_configured(self) -> None:
-        self._configure(gcp_service_account_json=_FAKE_SA_JSON)
-
+    def test_gemini_stays_direct_even_with_gcp_configured(self) -> None:
+        # Gemini keeps the direct API: its paid-tier key already bills to a
+        # GCP project, so only Claude moves to Vertex.
+        self._configure(
+            google_api_key="AIza-test", gcp_service_account_json=_FAKE_SA_JSON
+        )
         model = get_chat_model_cached("gemini-2.5-flash", 0.7, 256)
-        self.assertTrue(model.vertexai)
-        self.assertEqual(model.project, "test-project")
-        self.assertEqual(model.location, "global")
-        # The google-genai client must actually be in Vertex mode.
-        self.assertTrue(model.client._api_client.vertexai)
+        self.assertFalse(model.vertexai)
+        self.assertFalse(model.client._api_client.vertexai)
 
-    def test_gemini_image_output_model_on_vertex(self) -> None:
+        # And GCP credentials are no substitute for the Gemini key.
+        self.tearDown()
         self._configure(gcp_service_account_json=_FAKE_SA_JSON)
-        model = get_chat_model_cached("gemini-2.5-flash-image", 0.7, 256)
-        self.assertTrue(model.vertexai)
-        self.assertEqual(len(model.response_modalities), 2)
+        with self.assertRaises(ValueError):
+            get_chat_model_cached("gemini-2.5-flash", 0.7, 256)
 
     def test_project_and_location_overrides(self) -> None:
         self._configure(
@@ -137,13 +137,11 @@ class VertexRoutingTestCase(unittest.TestCase):
     def test_vertex_preferred_over_direct_anthropic_key(self) -> None:
         self._configure(
             anthropic_api_key="sk-ant-test",
-            google_api_key="AIza-test",
             gcp_service_account_json=_FAKE_SA_JSON,
         )
         self.assertIsInstance(
             get_chat_model_cached("claude-opus-5", 0.7, 256), ChatAnthropicVertex
         )
-        self.assertTrue(get_chat_model_cached("gemini-2.5-flash", 0.7, 256).vertexai)
 
     # ── fallback without GCP credentials ─────────────────────────────────
 
@@ -188,7 +186,8 @@ class VertexRoutingTestCase(unittest.TestCase):
         self.assertTrue(cfg.vertex_enabled())
         providers = cfg.initialized_providers()
         self.assertIn("anthropic", providers)
-        self.assertIn("google", providers)
+        # Gemini is not served by Vertex routing — it still needs its own key.
+        self.assertNotIn("google", providers)
         self.assertNotIn("openai", providers)
 
     def test_registry_vertex_ids_only_set_for_anthropic_snapshots(self) -> None:

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 2
+revision = 3
 requires-python = "==3.12.*"
 
 [options]
@@ -111,6 +111,11 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/66/a2/d31f14e28d49bae983a3634e38dfb4b31c50110b5e403596c5c6a20b23f8/anthropic-0.116.0.tar.gz", hash = "sha256:5fc248fbb9fe03ef686f8a774f81586bca31a043260aab88b387ea3660f4a396", size = 949149, upload-time = "2026-07-02T19:08:10.534Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/c7/dd/2a1e81cf1b163acc340afc4ec74ed1d86f5eed1a809fabdeed3e0997b346/anthropic-0.116.0-py3-none-any.whl", hash = "sha256:6c0a7698e8d652455da3499978279bb2588c7264d0a35be3666009a4258c8256", size = 956896, upload-time = "2026-07-02T19:08:08.756Z" },
+]
+
+[package.optional-dependencies]
+vertex = [
+    { name = "google-auth", extra = ["requests"] },
 ]
 
 [[package]]
@@ -1890,7 +1895,7 @@ name = "tee-gateway"
 version = "1.0.0"
 source = { virtual = "." }
 dependencies = [
-    { name = "anthropic" },
+    { name = "anthropic", extra = ["vertex"] },
     { name = "connexion", extra = ["swagger-ui"] },
     { name = "cryptography" },
     { name = "eth-account" },
@@ -1937,7 +1942,7 @@ test = [
 
 [package.metadata]
 requires-dist = [
-    { name = "anthropic", specifier = ">=0.76.0" },
+    { name = "anthropic", extras = ["vertex"], specifier = ">=0.76.0" },
     { name = "connexion", extras = ["swagger-ui"], specifier = "<3.0.0" },
     { name = "cryptography", specifier = ">=46.0.5" },
     { name = "eth-account", specifier = ">=0.13.0" },


### PR DESCRIPTION
## Summary

Migrates **Anthropic (Claude)** inference onto GCP Vertex AI so it draws on GCP credits/commitments. Routing is opt-in via key injection: when a GCP service-account key is injected the gateway serves Claude through Vertex; without it, Claude falls back to Anthropic's direct API, so existing operators (and 3rd-party PCR-reproducing operators) are unaffected.

**Gemini deliberately stays on the direct Gemini API**: a paid-tier Gemini API key already bills to the GCP project it belongs to, so Vertex routing would buy nothing there — keep `GOOGLE_API_KEY` on a project under the credited billing account. The other providers (OpenAI, xAI, ByteDance, Nous, Z.ai) have no Vertex presence and keep their direct APIs; moderation stays on OpenAI's free endpoint.

## How it works

- **`/v1/keys`** now accepts `gcp_service_account_json` (full key JSON as a string), plus optional `gcp_project_id` (defaults to the service account's own project) and `gcp_location` (defaults to Vertex's `global` endpoint — dynamic capacity routing, no 10% regional premium, and the only endpoint type serving the newest Claude models). A malformed key fails injection with HTTP 400 (details logged in-enclave only, per CodeQL) instead of silently running without Vertex.
- **Claude** runs through `ChatAnthropicVertex`, a thin `ChatAnthropic` subclass that swaps the underlying SDK client for `anthropic.AnthropicVertex` (OAuth from the injected service account; `/v1/messages` rewritten to Vertex `rawPredict`/`streamRawPredict`). Everything else — tool binding, streaming, usage extraction, the Opus 4.7+ temperature-strip behavior — is inherited unchanged from langchain-anthropic.
- **Model IDs**: every Claude model in the registry is available on Vertex (verified against Anthropic's Claude-on-Google-Cloud docs, `claude-fable-5` included). Current-generation models keep their bare IDs; dated snapshots use Vertex's `@`-form via a new `vertex_api_name` registry field (`claude-sonnet-4-5@20250929`, `claude-haiku-4-5@20251001`, `claude-opus-4-5@20251101`).
- **Unchanged**: user-facing model names, the `anthropic` provider name, pricing/rate card (Vertex global-endpoint list prices match Anthropic's direct prices), request hashing, response signing, and settlement.

## Ops

- `scripts/run-enclave.sh` injects `GCP_SERVICE_ACCOUNT_JSON_B64` (base64 so the multi-line key JSON survives the one-line `.env` format), `GCP_PROJECT_ID`, and `GCP_LOCATION`; variables are unset after injection like the other keys.
- `/health` and the `/v1/keys` response report `vertex_enabled`; `initialized_providers` counts `anthropic` as available when GCP credentials are present.
- `pyproject.toml` pins the `anthropic[vertex]` extra (google-auth was already locked transitively; the `uv.lock` delta is 8 lines).

## Testing

- New `tee_gateway/test/test_vertex_routing.py`: Vertex vs. direct routing for Claude, `@`-form ID mapping, project/location overrides, temperature stripping on the Vertex path, Gemini staying on the direct API even with GCP configured, malformed-key rejection with no stale state, and provider reporting.
- Full CI test selection passes: `399 passed, 6 skipped, 110 subtests passed`.
- `make lint` (ruff + mypy) clean.
- Not exercised against live Vertex: needs a real service-account key with `aiplatform.user` on a project with the Claude models enabled in Model Garden. Suggested smoke test after deploy: inject the key, then run one chat completion each on `claude-opus-5` and `claude-sonnet-4-5` (dated-ID path).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LHqrQNMz6HM53ZqYGsxTQA