### PR TITLE
Model-release watch: don't register unofferable models + CI-opened PRs

### DIFF
--- a/.github/workflows/open-model-release-pr.yml
+++ b/.github/workflows/open-model-release-pr.yml
@@ -1,0 +1,59 @@
+name: Open model-release PR
+
+# The daily model-release watch runs in a scheduled Claude session, which can
+# push a branch but cannot open a pull request: the GitHub API access an
+# interactive session has is not passed through to a scheduled one, and the
+# container's git credentials are scoped to git transport only. So the branch
+# arrives here with nothing behind it and this workflow opens the PR.
+#
+# The pushing session has no way to set a title and body either, so it puts
+# them in the commit message — subject becomes the PR title, body becomes the
+# PR body. Keep that contract in step with the routine's prompt.
+
+on:
+  push:
+    branches:
+      - "claude/model-release-**"
+
+permissions:
+  contents: read
+  pull-requests: write
+
+concurrency:
+  group: open-model-release-pr-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  open-draft-pr:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Open a draft PR if the branch has none
+        env:
+          GH_TOKEN: ${{ github.token }}
+          BRANCH: ${{ github.ref_name }}
+          BASE: ${{ github.event.repository.default_branch }}
+        run: |
+          set -euo pipefail
+
+          if [ "$(gh pr list --head "$BRANCH" --state open --json number --jq 'length')" != "0" ]; then
+            echo "An open PR already exists for $BRANCH — leaving it alone."
+            exit 0
+          fi
+
+          title=$(git log -1 --pretty=%s)
+
+          # Commit trailers are bookkeeping, not PR prose.
+          {
+            git log -1 --pretty=%b | sed -E '/^(Co-Authored-By|Claude-Session):/d'
+            printf '\n---\n\nOpened automatically from `%s` by the daily model-release watch.\n' "$BRANCH"
+            printf 'The companion change is on the same branch name in the other repository.\n'
+          } > /tmp/pr-body.md
+
+          gh pr create \
+            --draft \
+            --base "$BASE" \
+            --head "$BRANCH" \
+            --title "$title" \
+            --body-file /tmp/pr-body.md


### PR DESCRIPTION
Two commits, both hardening the daily model-release watch that #149 set up.

### 1. Do not register models the catalog would not offer

The registry is cheap to append to, which is exactly why it grows without anyone deciding it should. A daily job proposing every model our providers ship makes that worse: left alone it would register routing for models nothing surfaces, and each one is a name the gateway then has to route, price and test forever for a model no user can select.

`.claude/skills/add-gateway-model/SKILL.md` now points at the curation bar that actually governs this — the one in chat-api's `add-catalog-model` skill, tightened in [OpenGradient/chat-api#281](https://github.com/OpenGradient/chat-api/pull/281), where a new model earns a picker row only if it offers something no current row does and a better model replaces the one it supersedes rather than joining it. Registration is downstream of that decision, so it gets applied here first rather than registering speculatively and sorting it out later.

No code change; the registry itself is untouched.

### 2. Open the model-release PR from CI

A scheduled Claude session can push a branch but cannot open a pull request: the GitHub API access an interactive session has is session-scoped and isn't passed through when a routine fires, and the container's git credentials cover git transport only — against the REST API they get `403 "GitHub access is not enabled for this session"`. A test run confirmed it end to end: the session pushed fine, then spent several minutes installing the `gh` binary before failing the same way, because the missing piece was authorization, not a CLI.

`.github/workflows/open-model-release-pr.yml` fires on pushes to `claude/model-release-**` and opens the draft PR with the Actions token, taking title and body from the branch's last commit message. It no-ops when the branch already has an open PR.

**⚠️ Needs a setting:** "Allow GitHub Actions to create and approve pull requests" (Settings → Actions → General → Workflow permissions; the org switch overrides the repo one). It's off by default, and `permissions: pull-requests: write` is necessary but not sufficient. A throwaway `claude/model-release-selftest` push produced [run 33783298707](https://github.com/OpenGradient/tee-gateway/actions/runs/33783298707):

```
pull request create failed: GraphQL: GitHub Actions is not permitted
to create or approve pull requests (createPullRequest)
```

If the GitHub App connection turns out to give scheduled sessions API access directly, this second commit becomes unnecessary and can be dropped — the first one stands on its own either way.

Note: the `claude/model-release-selftest` branch is left over from that test and should be deleted; my push credentials can't remove remote branches.

The companion change is [OpenGradient/chat-api#281](https://github.com/OpenGradient/chat-api/pull/281).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LCzE1jP1Yvy4fbSj4xtRkv