### PR TITLE
Do not register models the catalog would not offer

### DIFF
--- a/.claude/skills/add-gateway-model/SKILL.md
+++ b/.claude/skills/add-gateway-model/SKILL.md
@@ -16,6 +16,22 @@ change. A model from a *new* provider is a different, larger job: it needs a
 client, an API key path in `__main__.py` and `/v1/keys`, and is out of scope
 for a routine model addition.
 
+## Register only what will actually be offered
+
+The registry is cheap to append to, which is exactly why it grows without
+anyone deciding to. Do not register a model speculatively: routing exists so
+chat-api's catalog can offer the model, and that catalog holds a real curation
+bar (`.claude/skills/add-catalog-model/SKILL.md` there — a new model earns a
+picker row only if it gives users something no current row does, and a better
+model replaces the one it supersedes rather than joining it). Apply the same
+judgement here first. If the model would not clear that bar, do not register
+it; if it supersedes a model already registered, expect the catalog change to
+hide the old one, and say which in your PR.
+
+Registered-but-unoffered ids are not free: every one of them is a name the
+gateway must keep routing, price correctly and test, for a model no user can
+select.
+
 ## Steps
 
 1. **Check it isn't already there.** Grep `_MODEL_LOOKUP` for the api name and


### PR DESCRIPTION
Curation policy for the daily model-release watch. One file, no code change — the registry itself is untouched. (Split out of the closed #150, which also carried a CI workflow that may not be needed; this half is needed either way.)

The registry is cheap to append to, which is exactly why it grows without anyone deciding it should. A daily job proposing every model our providers ship makes that worse: left alone it would register routing for models nothing surfaces, and each one is a name the gateway then has to route, price correctly and test forever for a model no user can select.

`.claude/skills/add-gateway-model/SKILL.md` now points at the bar that actually governs this — the one in chat-api's `add-catalog-model` skill, tightened in [OpenGradient/chat-api#282](https://github.com/OpenGradient/chat-api/pull/282), where a new model earns a picker row only if it offers something no current row does, and a better model replaces the one it supersedes rather than joining it. Registration is downstream of that decision, so it gets applied here first rather than registering speculatively and sorting it out later.

Practically, for a run adding a model: apply the catalog's bar before touching the enum, and if the new model supersedes one already registered, expect the catalog change to hide the old one and say which in the PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LCzE1jP1Yvy4fbSj4xtRkv

---
_Generated by [Claude Code](https://claude.ai/code/session_01LCzE1jP1Yvy4fbSj4xtRkv)_