### PR TITLE
Add Claude Fable 5.1 to model registry

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -126,7 +126,7 @@ Model name prefixes determine routing:
 - **xAI**: grok-2, grok-3, grok-3-mini, grok-4, grok-4.3, grok-4.5, grok-4.6, grok-4-fast, grok-4-1-fast; image generation: grok-2-image
 - **ByteDance** (BytePlus ModelArk, OpenAI-compatible, ap-southeast): seed-1.6, seed-1.8, seed-2.0-lite, deepseek-v4-flash, deepseek-v4-pro, glm-5.2 (Z.ai's model served via a ModelArk deployment endpoint); image generation: seedream-4.0, seedream-5.0-lite, seedance-4.5, seedance-5.0
 - **OpenRouter** (OpenAI-compatible): hermes-4-405b, hermes-4-70b, hy3
-- **Z.ai** (Model API, OpenAI-compatible): glm-5.3, glm-5.3-flash (routed directly through Z.ai's own API — no BytePlus ModelArk deployment endpoint exists for these yet); image generation: glm-image (glm-5.2 chat is routed through BytePlus ModelArk instead, see ByteDance above)
+- **Z.ai** (Model API, OpenAI-compatible): image generation: glm-image (glm-5.2 chat is routed through BytePlus ModelArk, see ByteDance above)
 
 Image generation via OpenAI (gpt-image-2), xAI (grok-2-image), ByteDance
 (seedream-4.0, seedream-5.0-lite, seedance-4.5, seedance-5.0), and Z.ai (glm-image) is served

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -121,12 +121,12 @@ Server configuration:
 
 Model name prefixes determine routing:
 - **OpenAI**: gpt-4.1, gpt-5, gpt-5-mini, gpt-5.2, gpt-5.6-sol/terra/luna, o4-mini; image generation: gpt-image-2
-- **Anthropic**: claude-sonnet-4-0/4-5/4-6, claude-sonnet-5, claude-haiku-4-5, claude-opus-4-5/4-6/4-7/4-8, claude-opus-5, claude-fable-5, claude-3-7-sonnet, claude-3-5-haiku
+- **Anthropic**: claude-sonnet-4-0/4-5/4-6, claude-sonnet-5, claude-haiku-4-5, claude-opus-4-5/4-6/4-7/4-8, claude-opus-5, claude-fable-5, claude-fable-5-1, claude-3-7-sonnet, claude-3-5-haiku
 - **Google**: gemini-3.8-flash, gemini-3.7-flash, gemini-3.6-flash, gemini-3.5-flash-lite, gemini-2.5-flash, gemini-2.5-flash-lite, gemini-2.5-pro, gemini-3-pro-preview, gemini-3-flash-preview, gemini-3.1-pro-preview, gemini-3.5-flash; image generation: gemini-2.5-flash-image, gemini-3.1-flash-image
 - **xAI**: grok-2, grok-3, grok-3-mini, grok-4, grok-4.3, grok-4.5, grok-4.6, grok-4-fast, grok-4-1-fast; image generation: grok-2-image
 - **ByteDance** (BytePlus ModelArk, OpenAI-compatible, ap-southeast): seed-1.6, seed-1.8, seed-2.0-lite, deepseek-v4-flash, deepseek-v4-pro, glm-5.2 (Z.ai's model served via a ModelArk deployment endpoint); image generation: seedream-4.0, seedream-5.0-lite, seedance-4.5, seedance-5.0
 - **OpenRouter** (OpenAI-compatible): hermes-4-405b, hermes-4-70b, hy3
-- **Z.ai** (Model API, OpenAI-compatible): image generation: glm-image (glm-5.2 chat is routed through BytePlus ModelArk, see ByteDance above)
+- **Z.ai** (Model API, OpenAI-compatible): glm-5.3, glm-5.3-flash (routed directly through Z.ai's own API — no BytePlus ModelArk deployment endpoint exists for these yet); image generation: glm-image (glm-5.2 chat is routed through BytePlus ModelArk instead, see ByteDance above)
 
 Image generation via OpenAI (gpt-image-2), xAI (grok-2-image), ByteDance
 (seedream-4.0, seedream-5.0-lite, seedance-4.5, seedance-5.0), and Z.ai (glm-image) is served

--- a/README.md
+++ b/README.md
@@ -39,7 +39,6 @@ The gateway solves this by running inside a hardware-isolated Nitro Enclave wher
 | xAI | grok-4.6, grok-4.5, grok-4.3, grok-4, grok-4-fast, grok-4-1-fast, grok-4-1-fast-non-reasoning |
 | ByteDance | seed-1.6, seed-1.8, seed-2.0-lite, deepseek-v4-flash, deepseek-v4-pro |
 | OpenRouter | hermes-4-405b, hermes-4-70b, hy3 |
-| Z.ai | glm-5.3, glm-5.3-flash |
 
 ## Quick Start
 

--- a/README.md
+++ b/README.md
@@ -34,11 +34,12 @@ The gateway solves this by running inside a hardware-isolated Nitro Enclave wher
 | Provider | Models |
 |----------|--------|
 | OpenAI | gpt-4.1, gpt-5, gpt-5-mini, gpt-5.6-sol, gpt-5.6-terra, gpt-5.6-luna, o4-mini |
-| Anthropic | claude-sonnet-4-5, claude-sonnet-4-6, claude-haiku-4-5, claude-opus-4-5, claude-opus-4-6 |
+| Anthropic | claude-fable-5-1, claude-sonnet-4-5, claude-sonnet-4-6, claude-haiku-4-5, claude-opus-4-5, claude-opus-4-6 |
 | Google | gemini-3.8-flash, gemini-3.7-flash, gemini-3.6-flash, gemini-3.5-flash-lite, gemini-2.5-flash, gemini-2.5-flash-lite, gemini-2.5-pro, gemini-3-pro-preview, gemini-3-flash-preview |
 | xAI | grok-4.6, grok-4.5, grok-4.3, grok-4, grok-4-fast, grok-4-1-fast, grok-4-1-fast-non-reasoning |
 | ByteDance | seed-1.6, seed-1.8, seed-2.0-lite, deepseek-v4-flash, deepseek-v4-pro |
 | OpenRouter | hermes-4-405b, hermes-4-70b, hy3 |
+| Z.ai | glm-5.3, glm-5.3-flash |
 
 ## Quick Start
 

--- a/tee_gateway/model_registry.py
+++ b/tee_gateway/model_registry.py
@@ -627,31 +627,6 @@ class SupportedModel(Enum):
         input_price_usd=Decimal("0.0000014"),
         output_price_usd=Decimal("0.0000044"),
     )
-    # GLM-5.3 supersedes GLM-5.2 as Z.ai's flagship reasoning/coding model
-    # (released 2026-08-18), on a new base with a 1M-token context window.
-    # Unlike GLM-5.2 there is no BytePlus ModelArk deployment endpoint for this
-    # model yet (that requires provisioning one on OpenGradient's BytePlus
-    # account), so this routes directly through Z.ai's own OpenAI-compatible
-    # API (provider="zai") instead — the same client already used for
-    # GLM_IMAGE below, just not previously used for a chat/text model. Same
-    # sticker price as GLM-5.2 per Z.ai's own pricing page.
-    GLM_5_3 = ModelConfig(
-        provider="zai",
-        api_name="glm-5.3",
-        input_price_usd=Decimal("0.0000014"),
-        output_price_usd=Decimal("0.0000044"),
-    )
-    # GLM-5.3-Flash — Z.ai's fast/cheap native-multimodal tier (released
-    # 2026-08-26), 1M-token context window. Priced at Z.ai's standard list
-    # rate; a 50%-off launch promo runs only through 2026-09-09, so the
-    # promotional rate isn't used here. Same ModelArk-endpoint caveat as
-    # GLM-5.3 above: routed directly through Z.ai's own API.
-    GLM_5_3_FLASH = ModelConfig(
-        provider="zai",
-        api_name="glm-5.3-flash",
-        input_price_usd=Decimal("0.00000015"),
-        output_price_usd=Decimal("0.0000005"),
-    )
     # GLM-Image uses Z.ai's image endpoint and is billed per generated image.
     # Z.ai returns hosted URLs only (fetched and inlined by the gateway) and
     # documents neither ``n`` nor ``response_format``, so both are omitted.
@@ -785,8 +760,6 @@ _MODEL_LOOKUP: dict[str, SupportedModel] = {
     # Z.ai
     "glm-5.2": SupportedModel.GLM_5_2,
     "ep-20260803211658-fwpzs": SupportedModel.GLM_5_2,
-    "glm-5.3": SupportedModel.GLM_5_3,
-    "glm-5.3-flash": SupportedModel.GLM_5_3_FLASH,
     "glm-image": SupportedModel.GLM_IMAGE,
     # Legacy — not in current SDK, retained for older SDK versions
     "grok-3-mini-beta": SupportedModel.GROK_3_MINI,  # old beta alias

--- a/tee_gateway/model_registry.py
+++ b/tee_gateway/model_registry.py
@@ -313,6 +313,18 @@ class SupportedModel(Enum):
         output_price_usd=Decimal("0.00005"),
         supports_temperature=False,
     )
+    # Claude Fable 5.1 — supersedes Fable 5 as Anthropic's most capable widely
+    # released model (GA 2026-09-01). Same sticker input/output pricing as
+    # Fable 5; the only pricing change is a 75%-cheaper cached-token read rate,
+    # which this registry doesn't model (base input/output only). Adaptive-
+    # thinking-only; like Opus 4.7+/Fable 5 it rejects `temperature` (HTTP 400).
+    CLAUDE_FABLE_5_1 = ModelConfig(
+        provider="anthropic",
+        api_name="claude-fable-5-1",
+        input_price_usd=Decimal("0.00001"),
+        output_price_usd=Decimal("0.00005"),
+        supports_temperature=False,
+    )
 
     # ── Google Gemini ───────────────────────────────────────────────────
     # Note: gemini-2.5-flash, gemini-2.5-pro, and gemini-2.5-flash-lite are scheduled
@@ -615,6 +627,31 @@ class SupportedModel(Enum):
         input_price_usd=Decimal("0.0000014"),
         output_price_usd=Decimal("0.0000044"),
     )
+    # GLM-5.3 supersedes GLM-5.2 as Z.ai's flagship reasoning/coding model
+    # (released 2026-08-18), on a new base with a 1M-token context window.
+    # Unlike GLM-5.2 there is no BytePlus ModelArk deployment endpoint for this
+    # model yet (that requires provisioning one on OpenGradient's BytePlus
+    # account), so this routes directly through Z.ai's own OpenAI-compatible
+    # API (provider="zai") instead — the same client already used for
+    # GLM_IMAGE below, just not previously used for a chat/text model. Same
+    # sticker price as GLM-5.2 per Z.ai's own pricing page.
+    GLM_5_3 = ModelConfig(
+        provider="zai",
+        api_name="glm-5.3",
+        input_price_usd=Decimal("0.0000014"),
+        output_price_usd=Decimal("0.0000044"),
+    )
+    # GLM-5.3-Flash — Z.ai's fast/cheap native-multimodal tier (released
+    # 2026-08-26), 1M-token context window. Priced at Z.ai's standard list
+    # rate; a 50%-off launch promo runs only through 2026-09-09, so the
+    # promotional rate isn't used here. Same ModelArk-endpoint caveat as
+    # GLM-5.3 above: routed directly through Z.ai's own API.
+    GLM_5_3_FLASH = ModelConfig(
+        provider="zai",
+        api_name="glm-5.3-flash",
+        input_price_usd=Decimal("0.00000015"),
+        output_price_usd=Decimal("0.0000005"),
+    )
     # GLM-Image uses Z.ai's image endpoint and is billed per generated image.
     # Z.ai returns hosted URLs only (fetched and inlined by the gateway) and
     # documents neither ``n`` nor ``response_format``, so both are omitted.
@@ -681,6 +718,7 @@ _MODEL_LOOKUP: dict[str, SupportedModel] = {
     "claude-opus-4-8": SupportedModel.CLAUDE_OPUS_4_8,
     "claude-opus-5": SupportedModel.CLAUDE_OPUS_5,
     "claude-fable-5": SupportedModel.CLAUDE_FABLE_5,
+    "claude-fable-5-1": SupportedModel.CLAUDE_FABLE_5_1,
     # Google
     "gemini-2.5-flash": SupportedModel.GEMINI_2_5_FLASH,
     "gemini-2.5-pro": SupportedModel.GEMINI_2_5_PRO,
@@ -747,6 +785,8 @@ _MODEL_LOOKUP: dict[str, SupportedModel] = {
     # Z.ai
     "glm-5.2": SupportedModel.GLM_5_2,
     "ep-20260803211658-fwpzs": SupportedModel.GLM_5_2,
+    "glm-5.3": SupportedModel.GLM_5_3,
+    "glm-5.3-flash": SupportedModel.GLM_5_3_FLASH,
     "glm-image": SupportedModel.GLM_IMAGE,
     # Legacy — not in current SDK, retained for older SDK versions
     "grok-3-mini-beta": SupportedModel.GROK_3_MINI,  # old beta alias

--- a/tests/test_pricing.py
+++ b/tests/test_pricing.py
@@ -145,6 +145,15 @@ class TestModelRegistry(unittest.TestCase):
         # Adaptive-thinking-only; rejects the `temperature` field (HTTP 400)
         self.assertFalse(cfg.supports_temperature)
 
+    def test_claude_fable_5_1_resolves(self):
+        cfg = get_model_config("claude-fable-5-1")
+        self.assertEqual(cfg.provider, "anthropic")
+        self.assertEqual(cfg.api_name, "claude-fable-5-1")
+        self.assertEqual(cfg.input_price_usd, Decimal("0.00001"))
+        self.assertEqual(cfg.output_price_usd, Decimal("0.00005"))
+        # Adaptive-thinking-only; rejects the `temperature` field (HTTP 400)
+        self.assertFalse(cfg.supports_temperature)
+
     # ── OpenAI ──────────────────────────────────────────────────────────────
 
     def test_gpt_4_1_resolves(self):
@@ -535,6 +544,22 @@ class TestModelRegistry(unittest.TestCase):
             get_model_config("glm-5.2"),
         )
 
+    def test_glm_5_3_resolves(self):
+        # Unlike GLM-5.2, no ModelArk deployment endpoint exists yet, so this
+        # routes directly through Z.ai's own API.
+        cfg = get_model_config("glm-5.3")
+        self.assertEqual(cfg.provider, "zai")
+        self.assertEqual(cfg.api_name, "glm-5.3")
+        self.assertEqual(cfg.input_price_usd, Decimal("0.0000014"))
+        self.assertEqual(cfg.output_price_usd, Decimal("0.0000044"))
+
+    def test_glm_5_3_flash_resolves(self):
+        cfg = get_model_config("glm-5.3-flash")
+        self.assertEqual(cfg.provider, "zai")
+        self.assertEqual(cfg.api_name, "glm-5.3-flash")
+        self.assertEqual(cfg.input_price_usd, Decimal("0.00000015"))
+        self.assertEqual(cfg.output_price_usd, Decimal("0.0000005"))
+
     def test_glm_image_resolves(self):
         cfg = get_model_config("glm-image")
         self.assertEqual(cfg.provider, "zai")
@@ -710,6 +735,13 @@ class TestCalculateSessionCostOPG(unittest.TestCase):
         # Same price tier as opus-4-5/4-6/4-7/4-8: 1000*0.000005 + 500*0.000025 = 0.0175 USD
         self.assertEqual(cost, 17_500_000_000_000_000)
 
+    def test_claude_fable_5_1_cost(self):
+        cost = self._calc("claude-fable-5-1", 1000, 500)
+        expected = _expected_cost_opg("claude-fable-5-1", 1000, 500)
+        self.assertEqual(cost, expected)
+        # Same price tier as fable-5: 1000*0.00001 + 500*0.00005 = 0.035 USD
+        self.assertEqual(cost, 35_000_000_000_000_000)
+
     # ── Google Gemini ────────────────────────────────────────────────────────
 
     def test_gemini_2_5_flash_cost(self):
@@ -876,6 +908,22 @@ class TestCalculateSessionCostOPG(unittest.TestCase):
             self._calc("hy3", 1000, 500),
             247_500_000_000_000,
         )
+
+    # ── Z.ai ───────────────────────────────────────────────────────────────
+
+    def test_glm_5_3_cost(self):
+        cost = self._calc("glm-5.3", 1000, 500)
+        expected = _expected_cost_opg("glm-5.3", 1000, 500)
+        self.assertEqual(cost, expected)
+        # 1000*0.0000014 + 500*0.0000044 = 0.0014 + 0.0022 = 0.0036 USD
+        self.assertEqual(cost, 3_600_000_000_000_000)
+
+    def test_glm_5_3_flash_cost(self):
+        cost = self._calc("glm-5.3-flash", 1000, 500)
+        expected = _expected_cost_opg("glm-5.3-flash", 1000, 500)
+        self.assertEqual(cost, expected)
+        # 1000*0.00000015 + 500*0.0000005 = 0.00015 + 0.00025 = 0.0004 USD
+        self.assertEqual(cost, 400_000_000_000_000)
 
     # ── Haiku is cheaper than Sonnet ────────────────────────────────────────
 

--- a/tests/test_pricing.py
+++ b/tests/test_pricing.py
@@ -544,22 +544,6 @@ class TestModelRegistry(unittest.TestCase):
             get_model_config("glm-5.2"),
         )
 
-    def test_glm_5_3_resolves(self):
-        # Unlike GLM-5.2, no ModelArk deployment endpoint exists yet, so this
-        # routes directly through Z.ai's own API.
-        cfg = get_model_config("glm-5.3")
-        self.assertEqual(cfg.provider, "zai")
-        self.assertEqual(cfg.api_name, "glm-5.3")
-        self.assertEqual(cfg.input_price_usd, Decimal("0.0000014"))
-        self.assertEqual(cfg.output_price_usd, Decimal("0.0000044"))
-
-    def test_glm_5_3_flash_resolves(self):
-        cfg = get_model_config("glm-5.3-flash")
-        self.assertEqual(cfg.provider, "zai")
-        self.assertEqual(cfg.api_name, "glm-5.3-flash")
-        self.assertEqual(cfg.input_price_usd, Decimal("0.00000015"))
-        self.assertEqual(cfg.output_price_usd, Decimal("0.0000005"))
-
     def test_glm_image_resolves(self):
         cfg = get_model_config("glm-image")
         self.assertEqual(cfg.provider, "zai")
@@ -908,22 +892,6 @@ class TestCalculateSessionCostOPG(unittest.TestCase):
             self._calc("hy3", 1000, 500),
             247_500_000_000_000,
         )
-
-    # ── Z.ai ───────────────────────────────────────────────────────────────
-
-    def test_glm_5_3_cost(self):
-        cost = self._calc("glm-5.3", 1000, 500)
-        expected = _expected_cost_opg("glm-5.3", 1000, 500)
-        self.assertEqual(cost, expected)
-        # 1000*0.0000014 + 500*0.0000044 = 0.0014 + 0.0022 = 0.0036 USD
-        self.assertEqual(cost, 3_600_000_000_000_000)
-
-    def test_glm_5_3_flash_cost(self):
-        cost = self._calc("glm-5.3-flash", 1000, 500)
-        expected = _expected_cost_opg("glm-5.3-flash", 1000, 500)
-        self.assertEqual(cost, expected)
-        # 1000*0.00000015 + 500*0.0000005 = 0.00015 + 0.00025 = 0.0004 USD
-        self.assertEqual(cost, 400_000_000_000_000)
 
     # ── Haiku is cheaper than Sonnet ────────────────────────────────────────
 


### PR DESCRIPTION
## Summary

Routine check for new releases from providers already integrated in the gateway. This PR adds one confirmed new release:

- **Claude Fable 5.1** (Anthropic, GA 2026-09-01) — supersedes Claude Fable 5 as Anthropic's most capable model. API name `claude-fable-5-1`. Same sticker input/output price as Fable 5 ($10/$50 per MTok); the only pricing change is a 75%-cheaper cached-read rate, which this registry doesn't model (base input/output only).
  - Sources: [Anthropic's own docs](https://platform.claude.com/docs/en/release-notes/system-prompts/claude-fable-5-1), [anthropic.com announcement](https://www.anthropic.com/claude-fable-and-mythos-5-1), [TechSpot](https://www.techspot.com/news/113701-anthropic-releases-claude-fable-51-stronger-coding-science.html), [VentureBeat](``https://venturebeat.com/technology/anthropics-claude-fable-5-1-and-mythos-5-1-arrive-with-a-75-cost-reduction-for-fable-cache-reads).``
  - **Not added**: Claude Mythos 5.1, announced the same day — it's restricted to vetted cyberdefender/life-science orgs, not generally API-available, so it doesn't fit this gateway's open-routing model.

~~GLM-5.3 / GLM-5.3-Flash~~ — an earlier version of this PR also added these, routed directly through Z.ai's own API since no BytePlus ModelArk deployment endpoint exists for them yet. That routing path isn't wanted, so they've been dropped from this change; `glm-5.2` is untouched.

## Changes

- `tee_gateway/model_registry.py`: added `CLAUDE_FABLE_5_1` enum entry + `_MODEL_LOOKUP` alias.
- `tests/test_pricing.py`: resolve + cost tests.
- `CLAUDE.md` / `README.md`: updated the "Supported Providers" / "Supported Models" tables.

## Test plan

- [x] `PYTHONPATH=. uv run pytest tests/test_pricing.py` — 136 passed
- [x] `uv run ruff format --check tee_gateway` / `uv run ruff check tee_gateway` — clean
- [x] `uv run mypy tee_gateway` — no issues
- [x] `uv.lock` untouched (no dependency changes)

## Related

Companion PR in `chat-api`: [OpenGradient/chat-api#283](https://github.com/OpenGradient/chat-api/pull/283)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SZToNkwZzrfbKcHqEo5Ytn