### PR TITLE
Add GPT-6 Astra and Claude Fable 5.1 to model registry

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -120,8 +120,8 @@ Server configuration:
 ### Supported Providers
 
 Model name prefixes determine routing:
-- **OpenAI**: gpt-4.1, gpt-5, gpt-5-mini, gpt-5.2, gpt-5.6-sol/terra/luna, o4-mini; image generation: gpt-image-2
-- **Anthropic**: claude-sonnet-4-0/4-5/4-6, claude-sonnet-5, claude-haiku-4-5, claude-opus-4-5/4-6/4-7/4-8, claude-opus-5, claude-fable-5, claude-3-7-sonnet, claude-3-5-haiku
+- **OpenAI**: gpt-6-astra, gpt-4.1, gpt-5, gpt-5-mini, gpt-5.2, gpt-5.6-sol/terra/luna, o4-mini; image generation: gpt-image-2
+- **Anthropic**: claude-sonnet-4-0/4-5/4-6, claude-sonnet-5, claude-haiku-4-5, claude-opus-4-5/4-6/4-7/4-8, claude-opus-5, claude-fable-5, claude-fable-5-1, claude-3-7-sonnet, claude-3-5-haiku
 - **Google**: gemini-3.8-flash, gemini-3.7-flash, gemini-3.6-flash, gemini-3.5-flash-lite, gemini-2.5-flash, gemini-2.5-flash-lite, gemini-2.5-pro, gemini-3-pro-preview, gemini-3-flash-preview, gemini-3.1-pro-preview, gemini-3.5-flash; image generation: gemini-2.5-flash-image, gemini-3.1-flash-image
 - **xAI**: grok-2, grok-3, grok-3-mini, grok-4, grok-4.3, grok-4.5, grok-4.6, grok-4-fast, grok-4-1-fast; image generation: grok-2-image
 - **ByteDance** (BytePlus ModelArk, OpenAI-compatible, ap-southeast): seed-1.6, seed-1.8, seed-2.0-lite, deepseek-v4-flash, deepseek-v4-pro, glm-5.2 (Z.ai's model served via a ModelArk deployment endpoint); image generation: seedream-4.0, seedream-5.0-lite, seedance-4.5, seedance-5.0

--- a/README.md
+++ b/README.md
@@ -33,8 +33,8 @@ The gateway solves this by running inside a hardware-isolated Nitro Enclave wher
 
 | Provider | Models |
 |----------|--------|
-| OpenAI | gpt-4.1, gpt-5, gpt-5-mini, gpt-5.6-sol, gpt-5.6-terra, gpt-5.6-luna, o4-mini |
-| Anthropic | claude-sonnet-4-5, claude-sonnet-4-6, claude-haiku-4-5, claude-opus-4-5, claude-opus-4-6 |
+| OpenAI | gpt-6-astra, gpt-4.1, gpt-5, gpt-5-mini, gpt-5.6-sol, gpt-5.6-terra, gpt-5.6-luna, o4-mini |
+| Anthropic | claude-fable-5-1, claude-sonnet-4-5, claude-sonnet-4-6, claude-haiku-4-5, claude-opus-4-5, claude-opus-4-6 |
 | Google | gemini-3.8-flash, gemini-3.7-flash, gemini-3.6-flash, gemini-3.5-flash-lite, gemini-2.5-flash, gemini-2.5-flash-lite, gemini-2.5-pro, gemini-3-pro-preview, gemini-3-flash-preview |
 | xAI | grok-4.6, grok-4.5, grok-4.3, grok-4, grok-4-fast, grok-4-1-fast, grok-4-1-fast-non-reasoning |
 | ByteDance | seed-1.6, seed-1.8, seed-2.0-lite, deepseek-v4-flash, deepseek-v4-pro |

--- a/tee_gateway/model_registry.py
+++ b/tee_gateway/model_registry.py
@@ -214,6 +214,18 @@ class SupportedModel(Enum):
         output_price_usd=Decimal("0.000006"),
         responses_api_for_tools=True,
     )
+    # GPT-6 Astra — OpenAI's flagship successor to the gpt-5.6 family (GA
+    # 2026-09-03). Ships with native web search, code interpreter, hosted
+    # shell, apply-patch, computer use and MCP. Priced at $10/$50 per MTok.
+    # Same reasoning_effort/function-tools conflict on Chat Completions as the
+    # gpt-5.6 family, so it also routes through the Responses API for tools.
+    GPT_6_ASTRA = ModelConfig(
+        provider="openai",
+        api_name="gpt-6-astra",
+        input_price_usd=Decimal("0.00001"),
+        output_price_usd=Decimal("0.00005"),
+        responses_api_for_tools=True,
+    )
     # Image generation via OpenAI's /images/generations endpoint (gpt-image).
     # Unlike DALL·E, gpt-image models always return base64 (``b64_json``) and
     # reject the ``response_format`` field, so it's omitted. Image-to-image
@@ -309,6 +321,17 @@ class SupportedModel(Enum):
     CLAUDE_FABLE_5 = ModelConfig(
         provider="anthropic",
         api_name="claude-fable-5",
+        input_price_usd=Decimal("0.00001"),
+        output_price_usd=Decimal("0.00005"),
+        supports_temperature=False,
+    )
+    # Claude Fable 5.1 — successor to Fable 5, GA on the first-party API from
+    # 2026-09-01. Same $10/$50 per MTok sticker as Fable 5. Adaptive-
+    # thinking-only; like Fable 5 and Opus 4.7+ it rejects the `temperature`
+    # field (HTTP 400), so supports_temperature=False.
+    CLAUDE_FABLE_5_1 = ModelConfig(
+        provider="anthropic",
+        api_name="claude-fable-5-1",
         input_price_usd=Decimal("0.00001"),
         output_price_usd=Decimal("0.00005"),
         supports_temperature=False,
@@ -669,6 +692,7 @@ _MODEL_LOOKUP: dict[str, SupportedModel] = {
     "gpt-5.6-sol": SupportedModel.GPT_5_6_SOL,
     "gpt-5.6-terra": SupportedModel.GPT_5_6_TERRA,
     "gpt-5.6-luna": SupportedModel.GPT_5_6_LUNA,
+    "gpt-6-astra": SupportedModel.GPT_6_ASTRA,
     "gpt-image-2": SupportedModel.GPT_IMAGE_2,
     # Anthropic
     "claude-sonnet-4-5": SupportedModel.CLAUDE_SONNET_4_5,
@@ -681,6 +705,8 @@ _MODEL_LOOKUP: dict[str, SupportedModel] = {
     "claude-opus-4-8": SupportedModel.CLAUDE_OPUS_4_8,
     "claude-opus-5": SupportedModel.CLAUDE_OPUS_5,
     "claude-fable-5": SupportedModel.CLAUDE_FABLE_5,
+    "claude-fable-5-1": SupportedModel.CLAUDE_FABLE_5_1,
+    "claude-fable-5.1": SupportedModel.CLAUDE_FABLE_5_1,
     # Google
     "gemini-2.5-flash": SupportedModel.GEMINI_2_5_FLASH,
     "gemini-2.5-pro": SupportedModel.GEMINI_2_5_PRO,

--- a/tests/test_pricing.py
+++ b/tests/test_pricing.py
@@ -145,6 +145,19 @@ class TestModelRegistry(unittest.TestCase):
         # Adaptive-thinking-only; rejects the `temperature` field (HTTP 400)
         self.assertFalse(cfg.supports_temperature)
 
+    def test_claude_fable_5_1_resolves(self):
+        cfg = get_model_config("claude-fable-5-1")
+        self.assertEqual(cfg.provider, "anthropic")
+        self.assertEqual(cfg.api_name, "claude-fable-5-1")
+        self.assertEqual(cfg.input_price_usd, Decimal("0.00001"))
+        self.assertEqual(cfg.output_price_usd, Decimal("0.00005"))
+        # Adaptive-thinking-only; rejects the `temperature` field (HTTP 400)
+        self.assertFalse(cfg.supports_temperature)
+
+    def test_claude_fable_5_1_dotted_alias_resolves(self):
+        cfg = get_model_config("claude-fable-5.1")
+        self.assertEqual(cfg, get_model_config("claude-fable-5-1"))
+
     # ── OpenAI ──────────────────────────────────────────────────────────────
 
     def test_gpt_4_1_resolves(self):
@@ -244,6 +257,14 @@ class TestModelRegistry(unittest.TestCase):
         self.assertEqual(cfg.provider, "openai")
         self.assertEqual(cfg.input_price_usd, Decimal("0.000001"))
         self.assertEqual(cfg.output_price_usd, Decimal("0.000006"))
+
+    def test_gpt_6_astra_resolves(self):
+        cfg = get_model_config("gpt-6-astra")
+        self.assertEqual(cfg.provider, "openai")
+        self.assertEqual(cfg.api_name, "gpt-6-astra")
+        self.assertEqual(cfg.input_price_usd, Decimal("0.00001"))
+        self.assertEqual(cfg.output_price_usd, Decimal("0.00005"))
+        self.assertTrue(cfg.responses_api_for_tools)
 
     # ── Google ──────────────────────────────────────────────────────────────
 
@@ -661,6 +682,13 @@ class TestCalculateSessionCostOPG(unittest.TestCase):
         # 1000*0.000001 + 500*0.000006 = 0.001 + 0.003 = 0.004 USD = 4e15 wei
         self.assertEqual(cost, 4_000_000_000_000_000)
 
+    def test_gpt_6_astra_cost(self):
+        cost = self._calc("gpt-6-astra", 1000, 500)
+        expected = _expected_cost_opg("gpt-6-astra", 1000, 500)
+        self.assertEqual(cost, expected)
+        # 1000*0.00001 + 500*0.00005 = 0.01 + 0.025 = 0.035 USD = 3.5e16 wei
+        self.assertEqual(cost, 35_000_000_000_000_000)
+
     # ── Anthropic Sonnet ────────────────────────────────────────────────────
 
     def test_claude_sonnet_4_5_cost(self):
@@ -709,6 +737,15 @@ class TestCalculateSessionCostOPG(unittest.TestCase):
         self.assertEqual(cost, expected)
         # Same price tier as opus-4-5/4-6/4-7/4-8: 1000*0.000005 + 500*0.000025 = 0.0175 USD
         self.assertEqual(cost, 17_500_000_000_000_000)
+
+    # ── Anthropic Fable ─────────────────────────────────────────────────────
+
+    def test_claude_fable_5_1_cost(self):
+        cost = self._calc("claude-fable-5-1", 1000, 500)
+        expected = _expected_cost_opg("claude-fable-5-1", 1000, 500)
+        self.assertEqual(cost, expected)
+        # 1000*0.00001 + 500*0.00005 = 0.01 + 0.025 = 0.035 USD = 3.5e16 wei
+        self.assertEqual(cost, 35_000_000_000_000_000)
 
     # ── Google Gemini ────────────────────────────────────────────────────────
 


### PR DESCRIPTION
## Summary

Registers two new flagship models just released by providers already integrated in the gateway:

- **OpenAI GPT-6 Astra** (`gpt-6-astra`) — GA 2026-09-03, successor to the gpt-5.6 family. $10/MTok input, $50/MTok output. Same `reasoning_effort` + function-tools conflict as the gpt-5.6 models on Chat Completions, so it also routes through the Responses API for tool calls (`responses_api_for_tools=True`).
- **Anthropic Claude Fable 5.1** (`claude-fable-5-1`) — GA on the first-party API 2026-09-01, successor to Claude Fable 5. $10/MTok input, $50/MTok output. Adaptive-thinking-only; rejects the `temperature` field like Fable 5 and Opus 4.7+ (`supports_temperature=False`).

## Changes

- `tee_gateway/model_registry.py`: new `GPT_6_ASTRA` and `CLAUDE_FABLE_5_1` enum entries + lookup aliases (`gpt-6-astra`; `claude-fable-5-1`, `claude-fable-5.1`)
- `tests/test_pricing.py`: resolve + cost tests for both models
- `README.md` / `CLAUDE.md`: updated provider tables

## Test plan

- [x] `uv run --group test pytest tee_gateway/test/ tests/test_pricing.py tests/test_opengradient_field.py --import-mode=importlib` — 397 passed, 6 skipped
- [x] `make lint` — ruff format/check + mypy all clean

Corresponding chat-api PR adding the same two models to the served catalog: OpenGradient/chat-api#285

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DHEirfmj3C6Ap4CzNWC6p4