### PR TITLE
Omit `temperature` for GPT-6 Astra (every request 400s today)

### DIFF
--- a/tee_gateway/llm_backend.py
+++ b/tee_gateway/llm_backend.py
@@ -207,9 +207,15 @@ def get_chat_model_cached(
     cfg = get_model_config(model)
     provider = cfg.provider
     api_name = cfg.api_name
-    effective_temp = (
-        cfg.force_temperature if cfg.force_temperature is not None else temperature
-    )
+    # Models that reject `temperature` outright (HTTP 400) get None, which every
+    # langchain-<provider> package treats as "omit the field" rather than
+    # "send null". This is provider-agnostic on purpose: the same restriction
+    # exists on Anthropic (Opus 4.7+, Fable 5) and OpenAI (GPT-6 Astra).
+    effective_temp: Optional[float] = None
+    if cfg.supports_temperature:
+        effective_temp = (
+            cfg.force_temperature if cfg.force_temperature is not None else temperature
+        )
 
     logger.info(f"Creating cached chat model - Provider: {provider}, Model: {api_name}")
 
@@ -272,16 +278,10 @@ def get_chat_model_cached(
         if not config.anthropic_api_key:
             raise ValueError("anthropic_api_key not set in ProviderConfig")
 
-        # Opus 4.7+ rejects `temperature` outright (HTTP 400). Pass None so
-        # langchain-anthropic strips the field from the outgoing payload.
-        anthropic_temperature: Optional[float] = (
-            effective_temp if cfg.supports_temperature else None
-        )
-
         return ChatAnthropic(
             model=api_name,
             api_key=SecretStr(config.anthropic_api_key),
-            temperature=anthropic_temperature,
+            temperature=effective_temp,
             max_tokens=max_tokens,
             timeout=READ_TIMEOUT,
             streaming=True,

--- a/tee_gateway/model_registry.py
+++ b/tee_gateway/model_registry.py
@@ -21,8 +21,10 @@ class ModelConfig:
     output_price_usd: Decimal  # USD per token
     force_temperature: Optional[float] = None
     thinking_budget: Optional[int] = None
-    # Anthropic deprecated `temperature` for Opus 4.7 — the API returns 400 if
-    # the field is present at all. Set False on models that reject it.
+    # Some models reject `temperature` outright — the API returns 400 if the
+    # field is present at all (Anthropic from Opus 4.7 on, OpenAI from GPT-6
+    # Astra on). Set False on those; the backend then omits the field entirely
+    # instead of sending a value.
     supports_temperature: bool = True
     # Image-output models (e.g. Gemini "nano banana") return generated images as
     # inline content blocks of a chat response. The backend requests the IMAGE
@@ -219,12 +221,17 @@ class SupportedModel(Enum):
     # shell, apply-patch, computer use and MCP. Priced at $10/$50 per MTok.
     # Same reasoning_effort/function-tools conflict on Chat Completions as the
     # gpt-5.6 family, so it also routes through the Responses API for tools.
+    # Reasoning-only sampling: the API rejects `temperature` with HTTP 400
+    # ("Unsupported parameter"), so supports_temperature=False. langchain's own
+    # workaround only strips temperature for model names starting with "gpt-5",
+    # which is why this model needs the registry flag.
     GPT_6_ASTRA = ModelConfig(
         provider="openai",
         api_name="gpt-6-astra",
         input_price_usd=Decimal("0.00001"),
         output_price_usd=Decimal("0.00005"),
         responses_api_for_tools=True,
+        supports_temperature=False,
     )
     # Image generation via OpenAI's /images/generations endpoint (gpt-image).
     # Unlike DALL·E, gpt-image models always return base64 (``b64_json``) and

--- a/tee_gateway/test/test_tee_core.py
+++ b/tee_gateway/test/test_tee_core.py
@@ -13,6 +13,7 @@ None of these tests require a running server, API keys, or nitriding.
 import base64
 import json
 import unittest
+from typing import Optional
 from unittest import mock
 
 from cryptography.hazmat.primitives import hashes
@@ -21,14 +22,18 @@ from eth_hash.auto import keccak
 from langchain_core.messages import AIMessage, HumanMessage, SystemMessage, ToolMessage
 
 from tee_gateway import ohttp
+from tee_gateway.config import ProviderConfig
 from tee_gateway.llm_backend import (
     AttachmentValidationError,
     canonical_user_content,
     convert_messages,
     extract_usage,
+    get_chat_model_cached,
+    get_provider_config,
+    set_provider_config,
     validate_attachments,
 )
-from tee_gateway.model_registry import get_model_config, get_rate_card
+from tee_gateway.model_registry import SupportedModel, get_model_config, get_rate_card
 from tee_gateway.tee_manager import (
     TEEKeyManager,
     compute_ohttp_config_hash,
@@ -958,3 +963,75 @@ class TestExtractUsage(unittest.TestCase):
 
 if __name__ == "__main__":
     unittest.main()
+
+
+# ---------------------------------------------------------------------------
+# temperature omission (supports_temperature=False)
+# ---------------------------------------------------------------------------
+
+
+class TestTemperatureOmission(unittest.TestCase):
+    """Models flagged ``supports_temperature=False`` must be constructed with no
+    temperature at all.
+
+    Clients always send a temperature (chat-app pins 0.0, and it is part of the
+    signed request hash), so a model whose API rejects the field — Anthropic
+    from Opus 4.7 on, OpenAI from GPT-6 Astra on — fails every single request
+    with HTTP 400 "Unsupported parameter: 'temperature' is not supported with
+    this model" unless the backend drops it. ``None`` is what makes each
+    langchain-<provider> package omit the key from the outgoing payload.
+    """
+
+    _saved_config: Optional[ProviderConfig] = None
+
+    @classmethod
+    def setUpClass(cls) -> None:
+        cls._saved_config = get_provider_config()
+        set_provider_config(
+            ProviderConfig(
+                openai_api_key="test-openai-key",
+                anthropic_api_key="test-anthropic-key",
+                google_api_key="test-google-key",
+                xai_api_key="test-xai-key",
+            )
+        )
+
+    @classmethod
+    def tearDownClass(cls) -> None:
+        if cls._saved_config is not None:
+            set_provider_config(cls._saved_config)
+        get_chat_model_cached.cache_clear()
+
+    def test_gpt_6_astra_omits_temperature(self):
+        model = get_chat_model_cached("gpt-6-astra", 0.0, 1024)
+        self.assertIsNone(model.temperature)
+        self.assertNotIn("temperature", model._default_params)
+
+    def test_gpt_6_astra_omits_temperature_on_responses_api(self):
+        """The Responses API path (used when tools are bound) must drop it too."""
+        model = get_chat_model_cached("gpt-6-astra", 0.0, 1024, True)
+        self.assertIsNone(model.temperature)
+        self.assertNotIn("temperature", model._default_params)
+
+    def test_opus_omits_temperature(self):
+        model = get_chat_model_cached("claude-opus-5", 0.0, 1024)
+        self.assertIsNone(model.temperature)
+
+    def test_temperature_supporting_model_keeps_it(self):
+        model = get_chat_model_cached("gpt-4.1", 0.0, 1024)
+        self.assertEqual(model.temperature, 0.0)
+        self.assertEqual(model._default_params.get("temperature"), 0.0)
+
+    def test_forced_temperature_still_applied(self):
+        model = get_chat_model_cached("o4-mini", 0.0, 1024)
+        self.assertEqual(model.temperature, 1.0)
+
+    def test_every_supports_temperature_false_model_builds_without_it(self):
+        """Registry-wide: nothing flagged False may reach a provider with a value."""
+        for supported in SupportedModel:
+            cfg = supported.value
+            if cfg.supports_temperature or cfg.image_generation:
+                continue
+            with self.subTest(model=cfg.api_name):
+                model = get_chat_model_cached(cfg.api_name, 0.0, 1024)
+                self.assertIsNone(model.temperature)


### PR DESCRIPTION
## The bug

Every GPT-6 Astra chat fails:

```
Error code: 400 - {'error': {'message': "Unsupported parameter: 'temperature' is not supported with this model.", 'type': 'invalid_request_error', 'param': 'temperature', 'code': None}}
```

Astra rejects `temperature` outright — the API 400s if the field is present at all. Clients always send one (chat-app pins `temperature: 0.0`, and it is part of the signed request hash), so the model has been unusable since it was registered in #153.

## Why it slipped through

The gpt-5.6 family has the same restriction and never showed it, because `langchain-openai` strips `temperature` itself — but only for model names starting with `gpt-5`:

```python
>>> ChatOpenAI(model="gpt-5.6-sol", temperature=0.0)._default_params   # no temperature
>>> ChatOpenAI(model="gpt-6-astra", temperature=0.0)._default_params   # temperature: 0.0  ← 400
```

`gpt-6-astra` misses that workaround, so the value went out on the wire.

## The fix

`supports_temperature=False` already existed in `ModelConfig` (for Anthropic's Opus 4.7+ and Fable 5) but was only honored inside the Anthropic branch of `get_chat_model_cached`. Moved the check up next to `force_temperature` so the effective temperature is `None` for any flagged model regardless of provider — every `langchain-<provider>` package treats `None` as "omit the field" rather than "send null" — and flagged Astra in the registry.

This keeps the restriction in the registry rather than depending on langchain's model-name heuristics, and covers both request paths (Chat Completions, and the Responses API used when tools are bound).

## Tests

`tee_gateway/test/test_tee_core.py::TestTemperatureOmission`:

- Astra omits `temperature` on the Chat Completions path and on the Responses API path
- an Anthropic flagged model omits it
- an unflagged model (`gpt-4.1`) still sends `0.0`
- `force_temperature` (o4-mini) is still applied
- registry-wide sweep: nothing flagged `supports_temperature=False` can be constructed with a temperature

`make lint` and the CI test command pass locally (403 passed, 6 skipped, 117 subtests).

## Notes

- No client change needed — the gateway is the single choke point for both chat-app's direct OHTTP path and chat-api's SDK path, both of which always send a temperature.
- Registry-only change plus one backend line; no dependency or lockfile change, so nothing here alters PCR inputs beyond the source itself.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019GiCnGpGxLEusqVUS6zUHw

---
_Generated by [Claude Code](https://claude.ai/code/session_019GiCnGpGxLEusqVUS6zUHw)_