### PR TITLE
add-gateway-model: check the provider's docs for rejected parameters

### DIFF
--- a/.claude/skills/add-gateway-model/SKILL.md
+++ b/.claude/skills/add-gateway-model/SKILL.md
@@ -60,8 +60,8 @@ select.
    comment saying why:
    - `supports_temperature=False` — the API 400s if `temperature` is present
      at all. Read the section below before deciding this one: getting it wrong
-     breaks 100% of the model's requests, and nothing short of a live call
-     tells you.
+     breaks 100% of the model's requests, and the only place it is written
+     down is the provider's own docs.
    - `force_temperature=1.0` — reasoning models that accept only one value.
    - `responses_api_for_tools=True` — OpenAI reasoning models that reject
      `reasoning_effort` alongside function tools on Chat Completions.
@@ -94,17 +94,18 @@ select.
 7. **Run `make lint` and `uv run pytest tests/test_pricing.py`.** Do not touch
    `uv.lock` — it is baked into the image and changes the PCR measurements.
 
-8. **Send one real request to the model before you call it done** (see below).
-   The unit suite constructs models but never calls a provider, so it cannot
-   tell a working registration from one that 400s every time.
+8. **Read the provider's API docs for the model's supported parameters** and
+   set the matching flags (see below). You are already on the pricing page in
+   step 2 — the parameter list is the other thing that page's siblings tell you
+   and nothing else does.
 
 ## Parameter restrictions are the thing that bites
 
-Pricing is checkable on a web page. Which request fields a model *accepts* is
-not, and the registry's optional flags exist because providers keep removing
-fields from their newest models — `temperature` first among them. A model whose
-API rejects a field the gateway sends fails **every** request, immediately,
-with nothing partial about it:
+Pricing gets looked up as a matter of course. Which request fields a model
+*accepts* is on the same docs and nobody reads it — and the registry's optional
+flags exist because providers keep removing fields from their newest models,
+`temperature` first among them. A model whose API rejects a field the gateway
+sends fails **every** request, immediately, with nothing partial about it:
 
 ```
 400 Unsupported parameter: 'temperature' is not supported with this model.
@@ -127,42 +128,43 @@ client-side workaround. Three things make this easy to miss:
 - **Reasoning-first models are the usual suspects.** Anthropic dropped
   `temperature` at Opus 4.7 and kept it dropped (Fable 5, Fable 5.1); OpenAI
   dropped it for the o-series, then constrained it for gpt-5, then dropped it
-  for GPT-6. Treat a new flagship reasoning model as rejecting it until a live
-  call says otherwise, and read the provider's API changelog for the release,
-  not just its pricing page.
+  for GPT-6. Treat a new flagship reasoning model as rejecting it until the
+  docs say otherwise — and read the API reference and the release changelog,
+  not just the pricing page.
 
-### Proving it
+### Where the docs say it
 
-`tee_gateway/test/test_provider_usage_integration.py` makes real, billable
-requests through the actual chat-controller path, with `temperature=0` and
-`max_tokens` set, in both streaming and non-streaming modes. Point its
-`NEW_CHAT_MODELS` tuple (or `IMAGE_MODELS`) at the model you just registered —
-it holds the newest model per provider, so replace that provider's entry rather
-than growing the list — and run it:
+Check these, for the specific model, before you set or omit the flags:
 
-```sh
-RUN_PROVIDER_INTEGRATION_TESTS=1 \
-  OPENAI_API_KEY=... ANTHROPIC_API_KEY=... GOOGLE_API_KEY=... XAI_API_KEY=... \
-  ARK_API_KEY=... OPENROUTER_API_KEY=... ZAI_API_KEY=... \
-  uv run --group test pytest \
-  tee_gateway/test/test_provider_usage_integration.py -v
-```
+- **The model's own reference page.** OpenAI's model pages carry a supported-
+  parameters list; Anthropic's model docs and its migration pages call out
+  fields that were removed. This is the authoritative answer and usually a
+  30-second read.
+- **The reasoning-model guide for the provider.** OpenAI documents the
+  unsupported sampling parameters for reasoning models in one place rather
+  than per model — `temperature`, `top_p` and friends — and a new flagship
+  usually inherits that list rather than the chat models'.
+- **The release changelog / announcement post for that model.** Removals
+  arrive here first, and often only here for the first weeks after launch.
 
-No local keys? The same suite is a manual CI job — GitHub Actions → **Test** →
-*Run workflow* runs `live-provider-usage` with the repo's provider secrets
-(`workflow_dispatch` only, so it never fires on a PR).
+Cite what you found in the PR body next to the pricing citation, in one line:
+which fields the model rejects, and where it says so. If the docs genuinely do
+not say — the model is days old and the reference page is still a stub —
+register it with `supports_temperature=False` rather than without: the gateway
+omitting a field the model would have accepted costs a sampling knob nothing
+currently varies (every client pins `temperature: 0.0`), while sending one it
+rejects costs 100% of its requests.
 
-It needs every provider key (the module refuses to run without them) and costs
-real money, which is why it is not part of `make test`. Run it anyway for a new
-model: a few cents here against a model that answers nothing in production. If
-the keys are genuinely not available to you, say so in the PR body — plainly,
-as an unverified registration — rather than letting silence imply it was
-checked.
+There is also a live suite for the rare case where the docs are contradictory
+and it matters: `tee_gateway/test/test_provider_usage_integration.py` runs real
+billable requests through the chat-controller path, locally with every provider
+key set, or via GitHub Actions → **Test** → *Run workflow* (the
+`live-provider-usage` job, `workflow_dispatch` only). It is not part of a
+routine model addition — the docs are.
 
-A 400 from this test is the finding. Read the `param` field in the error, set
-the matching flag, and re-run until the model actually answers; `llm_backend`
-passes `None` for a flagged field, which every `langchain-<provider>` package
-turns into "omit the key" rather than "send null".
+When a flag is right, `llm_backend` passes `None` for that field, which every
+`langchain-<provider>` package turns into "omit the key" rather than "send
+null".
 
 ## What this does *not* cover
 

--- a/.claude/skills/add-gateway-model/SKILL.md
+++ b/.claude/skills/add-gateway-model/SKILL.md
@@ -58,7 +58,10 @@ select.
 
    Reach for the optional fields only when the model needs them, and leave a
    comment saying why:
-   - `supports_temperature=False` — the API 400s if `temperature` is present.
+   - `supports_temperature=False` — the API 400s if `temperature` is present
+     at all. Read the section below before deciding this one: getting it wrong
+     breaks 100% of the model's requests, and nothing short of a live call
+     tells you.
    - `force_temperature=1.0` — reasoning models that accept only one value.
    - `responses_api_for_tools=True` — OpenAI reasoning models that reject
      `reasoning_effort` alongside function tools on Chat Completions.
@@ -90,6 +93,76 @@ select.
 
 7. **Run `make lint` and `uv run pytest tests/test_pricing.py`.** Do not touch
    `uv.lock` — it is baked into the image and changes the PCR measurements.
+
+8. **Send one real request to the model before you call it done** (see below).
+   The unit suite constructs models but never calls a provider, so it cannot
+   tell a working registration from one that 400s every time.
+
+## Parameter restrictions are the thing that bites
+
+Pricing is checkable on a web page. Which request fields a model *accepts* is
+not, and the registry's optional flags exist because providers keep removing
+fields from their newest models — `temperature` first among them. A model whose
+API rejects a field the gateway sends fails **every** request, immediately,
+with nothing partial about it:
+
+```
+400 Unsupported parameter: 'temperature' is not supported with this model.
+```
+
+Every client sends a temperature (chat-app pins `0.0`, and it is inside the
+signed request hash), so there is no traffic that avoids the bad path and no
+client-side workaround. Three things make this easy to miss:
+
+- **Restrictions do not travel down a family.** GPT-6 Astra rejects
+  `temperature`; every gpt-5.x model in the registry is registered without the
+  flag. Copying the closest sibling's `ModelConfig` — right for pricing shape,
+  request shaping and `responses_api_for_tools` — is exactly wrong here.
+- **langchain hides it for some names and not others.** `langchain-openai`
+  strips `temperature` itself for model names starting with `gpt-5`, and only
+  those, so the whole gpt-5.6 family worked without the flag and the first
+  `gpt-6-*` model did not. Never conclude "the sibling works, so the field is
+  fine" — the sibling may be surviving on a provider-package special case
+  keyed to its *name*.
+- **Reasoning-first models are the usual suspects.** Anthropic dropped
+  `temperature` at Opus 4.7 and kept it dropped (Fable 5, Fable 5.1); OpenAI
+  dropped it for the o-series, then constrained it for gpt-5, then dropped it
+  for GPT-6. Treat a new flagship reasoning model as rejecting it until a live
+  call says otherwise, and read the provider's API changelog for the release,
+  not just its pricing page.
+
+### Proving it
+
+`tee_gateway/test/test_provider_usage_integration.py` makes real, billable
+requests through the actual chat-controller path, with `temperature=0` and
+`max_tokens` set, in both streaming and non-streaming modes. Point its
+`NEW_CHAT_MODELS` tuple (or `IMAGE_MODELS`) at the model you just registered —
+it holds the newest model per provider, so replace that provider's entry rather
+than growing the list — and run it:
+
+```sh
+RUN_PROVIDER_INTEGRATION_TESTS=1 \
+  OPENAI_API_KEY=... ANTHROPIC_API_KEY=... GOOGLE_API_KEY=... XAI_API_KEY=... \
+  ARK_API_KEY=... OPENROUTER_API_KEY=... ZAI_API_KEY=... \
+  uv run --group test pytest \
+  tee_gateway/test/test_provider_usage_integration.py -v
+```
+
+No local keys? The same suite is a manual CI job — GitHub Actions → **Test** →
+*Run workflow* runs `live-provider-usage` with the repo's provider secrets
+(`workflow_dispatch` only, so it never fires on a PR).
+
+It needs every provider key (the module refuses to run without them) and costs
+real money, which is why it is not part of `make test`. Run it anyway for a new
+model: a few cents here against a model that answers nothing in production. If
+the keys are genuinely not available to you, say so in the PR body — plainly,
+as an unverified registration — rather than letting silence imply it was
+checked.
+
+A 400 from this test is the finding. Read the `param` field in the error, set
+the matching flag, and re-run until the model actually answers; `llm_backend`
+passes `None` for a flagged field, which every `langchain-<provider>` package
+turns into "omit the key" rather than "send null".
 
 ## What this does *not* cover
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -37,7 +37,9 @@ jobs:
       GOOGLE_API_KEY: ${{ secrets.GOOGLE_API_KEY }}
       XAI_API_KEY: ${{ secrets.XAI_API_KEY }}
       ARK_API_KEY: ${{ secrets.ARK_API_KEY }}
-      NOUS_API_KEY: ${{ secrets.NOUS_API_KEY }}
+      # The suite reads OPENROUTER_API_KEY (the provider was renamed from Nous);
+      # accept either secret name so the job runs whichever the repo still holds.
+      OPENROUTER_API_KEY: ${{ secrets.OPENROUTER_API_KEY || secrets.NOUS_API_KEY }}
       ZAI_API_KEY: ${{ secrets.ZAI_API_KEY }}
     steps:
       - uses: actions/checkout@v4
@@ -47,7 +49,7 @@ jobs:
         run: |
           for name in \
             OPENAI_API_KEY ANTHROPIC_API_KEY GOOGLE_API_KEY XAI_API_KEY \
-            ARK_API_KEY NOUS_API_KEY ZAI_API_KEY
+            ARK_API_KEY OPENROUTER_API_KEY ZAI_API_KEY
           do
             if [[ -z "${!name}" ]]; then
               echo "Missing required repository secret: $name" >&2

--- a/tee_gateway/test/test_provider_usage_integration.py
+++ b/tee_gateway/test/test_provider_usage_integration.py
@@ -58,10 +58,9 @@ PROVIDER_SMOKE_MODELS = (
     _ProviderCase("Z.ai", "glm-5.2", "ZAI_API_KEY"),
 )
 
-# The newest model per provider — one each, so the run stays cheap. When a
-# model is added to the registry, replace its provider's entry here and run
-# this suite: it is the only check that catches a request field the model's
-# API rejects (see .claude/skills/add-gateway-model/SKILL.md).
+# The newest model per provider — one each, so the run stays cheap. Replace a
+# provider's entry when a newer model is registered, so a dispatch of this
+# suite exercises what actually shipped rather than last quarter's flagship.
 NEW_CHAT_MODELS = (
     _ProviderCase("OpenAI", "gpt-6-astra", "OPENAI_API_KEY"),
     _ProviderCase("Anthropic", "claude-fable-5-1", "ANTHROPIC_API_KEY"),

--- a/tee_gateway/test/test_provider_usage_integration.py
+++ b/tee_gateway/test/test_provider_usage_integration.py
@@ -58,9 +58,13 @@ PROVIDER_SMOKE_MODELS = (
     _ProviderCase("Z.ai", "glm-5.2", "ZAI_API_KEY"),
 )
 
+# The newest model per provider — one each, so the run stays cheap. When a
+# model is added to the registry, replace its provider's entry here and run
+# this suite: it is the only check that catches a request field the model's
+# API rejects (see .claude/skills/add-gateway-model/SKILL.md).
 NEW_CHAT_MODELS = (
-    _ProviderCase("OpenAI", "gpt-5.6-luna", "OPENAI_API_KEY"),
-    _ProviderCase("Anthropic", "claude-sonnet-5", "ANTHROPIC_API_KEY"),
+    _ProviderCase("OpenAI", "gpt-6-astra", "OPENAI_API_KEY"),
+    _ProviderCase("Anthropic", "claude-fable-5-1", "ANTHROPIC_API_KEY"),
     _ProviderCase("Google", "gemini-3.8-flash", "GOOGLE_API_KEY"),
     _ProviderCase("xAI", "grok-4.5", "XAI_API_KEY"),
     _ProviderCase("ByteDance", "seed-2.0-lite", "ARK_API_KEY"),


### PR DESCRIPTION
## Why

GPT-6 Astra was added with correct pricing, correct aliases, correct `responses_api_for_tools`, and a green unit suite — and 400ed on **every** request, because it rejects `temperature` (fix: #154). The skill already listed `supports_temperature=False` among the optional fields, but nothing in the process said to go find out whether it was needed. Pricing gets looked up as a matter of course; the supported-parameter list is on the same docs and nobody reads it.

## What changed

**`.claude/skills/add-gateway-model/SKILL.md`** — new section "Parameter restrictions are the thing that bites", plus a step 8: read the provider's API docs for the model's supported parameters and set the matching flags. Three traps, written down:

- **Restrictions don't travel down a family.** Copying the closest sibling's `ModelConfig` is right for pricing shape, request shaping and `responses_api_for_tools`, and wrong for this.
- **langchain-openai strips `temperature` for names starting with `gpt-5`, and only those** — so the whole gpt-5.6 family worked without the flag and the first `gpt-6-*` model did not. "The sibling works" proves nothing; the sibling may be surviving on a provider-package special case keyed to its name.
- **Reasoning-first flagships are where the field keeps getting dropped** (Opus 4.7+, o-series, gpt-5, GPT-6). Assume rejected until the docs say otherwise.

Where to look, for the specific model: its own reference page, the provider's reasoning-model guide (which lists the unsupported sampling params once for the whole family rather than per model), and the release changelog — where removals land first and often only, in the weeks after a launch. Cite what you found in the PR body next to the pricing citation.

And the default when the docs are still a stub: register `supports_temperature=False`. Omitting a field the model would have accepted costs a sampling knob no client varies (every client pins `temperature: 0.0`); sending one it rejects costs 100% of its requests.

The live suite (`test_provider_usage_integration.py`, `workflow_dispatch` only) stays mentioned as the fallback for contradictory docs, explicitly not part of a routine model addition.

**`test_provider_usage_integration.py`** — `NEW_CHAT_MODELS` now points at the actual newest models per provider (`gpt-6-astra`, `claude-fable-5-1`); it still listed `gpt-5.6-luna` and Sonnet 5, so a dispatch was exercising last quarter's flagships.

**`.github/workflows/test.yml`** — the `live-provider-usage` job exported `NOUS_API_KEY`, but the suite reads `OPENROUTER_API_KEY` (the provider was renamed), so the job failed in its own key-check step before running anything. It now accepts either secret name: `${{ secrets.OPENROUTER_API_KEY || secrets.NOUS_API_KEY }}`. **Worth a maintainer's eye** — I can't see which secret the repo actually holds; if it's neither, the check step now says so clearly instead of failing later.

## Merge order

Land after #154. The skill's closing line ("`llm_backend` passes `None` for a flagged field, which every langchain-&lt;provider&gt; package turns into omit-the-key") describes the behavior that PR introduces for non-Anthropic providers.

## Verification

`make lint` clean; unit suite green (403 passed, 6 skipped, 117 subtests); workflow YAML parses. No live provider calls were made.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019GiCnGpGxLEusqVUS6zUHw