### PR TITLE
Remove the Z.ai provider

### DIFF
--- a/.claude/skills/add-gateway-model/SKILL.md
+++ b/.claude/skills/add-gateway-model/SKILL.md
@@ -10,7 +10,7 @@ model name is rejected outright — there is no fallback — so every model the
 gateway can route is added here, with pricing, before anything else can use it.
 
 Adding a model to a provider the gateway **already** speaks (OpenAI, Anthropic,
-Google, xAI, ByteDance/ModelArk, OpenRouter, Z.ai) touches only the files
+Google, xAI, ByteDance/ModelArk, OpenRouter) touches only the files
 below. `llm_backend.py` routes off `ModelConfig.provider`, so it needs no
 change. A model from a *new* provider is a different, larger job: it needs a
 client, an API key path in `__main__.py` and `/v1/keys`, and is out of scope

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -40,7 +40,6 @@ jobs:
       # The suite reads OPENROUTER_API_KEY (the provider was renamed from Nous);
       # accept either secret name so the job runs whichever the repo still holds.
       OPENROUTER_API_KEY: ${{ secrets.OPENROUTER_API_KEY || secrets.NOUS_API_KEY }}
-      ZAI_API_KEY: ${{ secrets.ZAI_API_KEY }}
     steps:
       - uses: actions/checkout@v4
       - uses: astral-sh/setup-uv@v5
@@ -49,7 +48,7 @@ jobs:
         run: |
           for name in \
             OPENAI_API_KEY ANTHROPIC_API_KEY GOOGLE_API_KEY XAI_API_KEY \
-            ARK_API_KEY OPENROUTER_API_KEY ZAI_API_KEY
+            ARK_API_KEY OPENROUTER_API_KEY
           do
             if [[ -z "${!name}" ]]; then
               echo "Missing required repository secret: $name" >&2

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -69,7 +69,6 @@ API keys (injected at runtime via POST /v1/keys — do NOT bake into the image):
 - `XAI_API_KEY`
 - `ARK_API_KEY` (BytePlus / ByteDance ModelArk; injected as `bytedance_api_key`)
 - `OPENROUTER_API_KEY` (OpenRouter; injected as `openrouter_api_key`)
-- `ZAI_API_KEY` (Z.ai Model API; injected as `zai_api_key`)
 - `EXA_API_KEY` (Exa search; injected as `exa_api_key`) — backs the in-enclave
   `/v1/web_search` endpoint, not an LLM provider. Without it the endpoint
   returns 503 and `/health` reports `web_search_enabled: false`.
@@ -126,15 +125,14 @@ Model name prefixes determine routing:
 - **xAI**: grok-2, grok-3, grok-3-mini, grok-4, grok-4.3, grok-4.5, grok-4.6, grok-4-fast, grok-4-1-fast; image generation: grok-2-image
 - **ByteDance** (BytePlus ModelArk, OpenAI-compatible, ap-southeast): seed-1.6, seed-1.8, seed-2.0-lite, deepseek-v4-flash, deepseek-v4-pro, glm-5.2 (Z.ai's model served via a ModelArk deployment endpoint); image generation: seedream-4.0, seedream-5.0-lite, seedance-4.5, seedance-5.0
 - **OpenRouter** (OpenAI-compatible): hermes-4-405b, hermes-4-70b, hy3
-- **Z.ai** (Model API, OpenAI-compatible): image generation: glm-image (glm-5.2 chat is routed through BytePlus ModelArk, see ByteDance above)
 
-Image generation via OpenAI (gpt-image-2), xAI (grok-2-image), ByteDance
-(seedream-4.0, seedream-5.0-lite, seedance-4.5, seedance-5.0), and Z.ai (glm-image) is served
+Image generation via OpenAI (gpt-image-2), xAI (grok-2-image) and ByteDance
+(seedream-4.0, seedream-5.0-lite, seedance-4.5, seedance-5.0) is served
 through a provider `/images/generations` endpoint rather than the chat path (see
 `image_generation.py`), but is surfaced on `/v1/chat/completions` exactly like
 Gemini's inline-image models (images returned out-of-band under the message
 `images` key). The client always receives inline bytes: providers that hand back
-a hosted URL (Z.ai, Seedance, Seedream 5.0 Lite) are fetched inside the enclave
+a hosted URL (Seedance, Seedream 5.0 Lite) are fetched inside the enclave
 and inlined as `data:` URIs (the fetch is guarded: http(s) only, non-public IP
 hosts rejected, redirects + size capped, and only ever called on provider-
 response URLs, never client input). Image-to-image editing and multi-image

--- a/README.md
+++ b/README.md
@@ -55,7 +55,6 @@ export GOOGLE_API_KEY=...
 export XAI_API_KEY=...
 export ARK_API_KEY=...   # BytePlus / ByteDance ModelArk
 export OPENROUTER_API_KEY=...  # OpenRouter
-export ZAI_API_KEY=...   # Z.ai Model API
 
 # Run server (starts the Flask/connexion app on port 8000)
 make test-local
@@ -407,7 +406,6 @@ Clients use an x402-compatible client (e.g., the [x402 SDK](https://github.com/o
 | `XAI_API_KEY` | - | xAI API key |
 | `ARK_API_KEY` | - | BytePlus / ByteDance ModelArk API key (injected as `bytedance_api_key`) |
 | `OPENROUTER_API_KEY` | - | OpenRouter API key (injected as `openrouter_api_key`) |
-| `ZAI_API_KEY` | - | Z.ai Model API key (injected as `zai_api_key`) |
 | `EVM_PAYMENT_ADDRESS` | - | Wallet address to receive x402 payments |
 | `FACILITATOR_URL` | see `tee_gateway/__main__.py` | x402 payment facilitator endpoint |
 

--- a/scripts/run-enclave.sh
+++ b/scripts/run-enclave.sh
@@ -91,7 +91,6 @@ if [ -f "$ENV_FILE" ]; then
         XAI_API_KEY="$(grep -E '^XAI_API_KEY=' "$ENV_FILE" | cut -d'=' -f2-)"
         ARK_API_KEY="$(grep -E '^ARK_API_KEY=' "$ENV_FILE" | cut -d'=' -f2-)"
         OPENROUTER_API_KEY="$(grep -E '^OPENROUTER_API_KEY=' "$ENV_FILE" | cut -d'=' -f2-)"
-        ZAI_API_KEY="$(grep -E '^ZAI_API_KEY=' "$ENV_FILE" | cut -d'=' -f2-)"
         # Backs the in-enclave `web_search` tool (Exa), not an LLM provider.
         EXA_API_KEY="$(grep -E '^EXA_API_KEY=' "$ENV_FILE" | cut -d'=' -f2-)"
 
@@ -111,7 +110,6 @@ if [ -f "$ENV_FILE" ]; then
             --arg xai "$XAI_API_KEY" \
             --arg bytedance "$ARK_API_KEY" \
             --arg openrouter "$OPENROUTER_API_KEY" \
-            --arg zai "$ZAI_API_KEY" \
             --arg exa "$EXA_API_KEY" \
             --arg hb_contract "$HEARTBEAT_CONTRACT_ADDRESS" \
             --arg facilitator "$FACILITATOR_URL" \
@@ -123,7 +121,6 @@ if [ -f "$ENV_FILE" ]; then
                 xai_api_key: $xai,
                 bytedance_api_key: $bytedance,
                 openrouter_api_key: $openrouter,
-                zai_api_key: $zai,
                 exa_api_key: $exa
             }
             + if $hb_contract != "" then {heartbeat_contract_address: $hb_contract} else {} end
@@ -155,7 +152,7 @@ if [ -f "$ENV_FILE" ]; then
 
         # Clear key variables from this shell immediately after use
         unset OPENAI_API_KEY GOOGLE_API_KEY ANTHROPIC_API_KEY XAI_API_KEY ARK_API_KEY
-        unset OPENROUTER_API_KEY ZAI_API_KEY EXA_API_KEY
+        unset OPENROUTER_API_KEY EXA_API_KEY
         unset HEARTBEAT_CONTRACT_ADDRESS FACILITATOR_URL TEE_HEARTBEAT_INTERVAL
     fi
 else

--- a/tee_gateway/__main__.py
+++ b/tee_gateway/__main__.py
@@ -421,7 +421,6 @@ def set_provider_keys():
             xai_api_key=body.get("xai_api_key") or None,
             bytedance_api_key=body.get("bytedance_api_key") or None,
             openrouter_api_key=body.get("openrouter_api_key") or None,
-            zai_api_key=body.get("zai_api_key") or None,
             exa_api_key=body.get("exa_api_key") or None,
         )
         set_provider_config(provider_config)
@@ -487,9 +486,6 @@ def set_provider_keys():
             _set(provider_config.openrouter_api_key),
         )
         logger.info(
-            "  zai_api_key                 : %s", _set(provider_config.zai_api_key)
-        )
-        logger.info(
             "  exa_api_key (web search)    : %s", _set(provider_config.exa_api_key)
         )
         logger.info("  facilitator_url             : %s", facilitator_url)
@@ -525,7 +521,6 @@ def set_provider_keys():
             "xai": provider_config.xai_api_key,
             "bytedance": provider_config.bytedance_api_key,
             "openrouter": provider_config.openrouter_api_key,
-            "zai": provider_config.zai_api_key,
         }.items()
         if k
     ]

--- a/tee_gateway/config.py
+++ b/tee_gateway/config.py
@@ -29,7 +29,6 @@ class ProviderConfig:
     xai_api_key: Optional[str] = None
     bytedance_api_key: Optional[str] = None
     openrouter_api_key: Optional[str] = None
-    zai_api_key: Optional[str] = None
     # Exa, which backs the `web_search` tool the gateway executes inside the
     # enclave for every model (see web_search.py). Not an LLM provider, so it is
     # deliberately absent from initialized_providers() — /health reports it
@@ -51,8 +50,6 @@ class ProviderConfig:
             providers.append("bytedance")
         if self.openrouter_api_key:
             providers.append("openrouter")
-        if self.zai_api_key:
-            providers.append("zai")
         return providers
 
 

--- a/tee_gateway/image_generation.py
+++ b/tee_gateway/image_generation.py
@@ -1,9 +1,9 @@
 """Endpoint-based image generation.
 
-OpenAI (gpt-image), xAI (Aurora), ByteDance (Seedream/Seedance) and Z.ai
-(GLM-Image) expose image generation through a dedicated OpenAI-compatible
-``POST /images/generations`` endpoint rather than the chat path. This module
-owns everything specific to that flow:
+OpenAI (gpt-image), xAI (Aurora) and ByteDance (Seedream/Seedance) expose image
+generation through a dedicated OpenAI-compatible ``POST /images/generations``
+endpoint rather than the chat path. This module owns everything specific to
+that flow:
 
   * ``generate_images`` — shape and send the provider request, always returning
     inline ``data:`` URIs (a provider-hosted URL is fetched into the enclave so
@@ -57,7 +57,6 @@ _IMAGE_CLIENT_ATTRS = {
     "openai": "openai_http_client",
     "x-ai": "xai_http_client",
     "bytedance": "bytedance_http_client",
-    "zai": "zai_http_client",
 }
 
 # Bounds on the URL fetch (egress hardening). Provider images are well under the
@@ -69,12 +68,11 @@ _ALLOWED_FETCH_SCHEMES = {"http", "https"}
 # Shared keyless client for fetching provider-hosted image URLs into the enclave.
 _image_fetch_client: Optional[httpx.Client] = None
 
-# Retry policy for the hosted-URL fetch. Some providers (notably Z.ai, whose
-# generations response points at mfile.z.ai) return the URL before the file is
-# visible on their CDN, so an immediate GET can 404 with "file not exist" even
-# though the image was generated — retrying shortly after succeeds. 404 covers
-# that visibility race; 5xx and transport errors are ordinary transient CDN
-# failures. Anything else (403, size-cap ValueError, …) fails fast.
+# Retry policy for the hosted-URL fetch. Some providers return the URL before
+# the file is visible on their CDN, so an immediate GET can 404 with "file not
+# exist" even though the image was generated — retrying shortly after succeeds.
+# 404 covers that visibility race; 5xx and transport errors are ordinary
+# transient CDN failures. Anything else (403, size-cap ValueError, …) fails fast.
 _FETCH_RETRY_STATUS_CODES = frozenset({404, 500, 502, 503, 504})
 _FETCH_RETRY_DELAYS_SECONDS = (1.0, 2.0, 4.0)
 

--- a/tee_gateway/llm_backend.py
+++ b/tee_gateway/llm_backend.py
@@ -56,19 +56,12 @@ BYTEDANCE_BASE_URL = "https://ark.ap-southeast.bytepluses.com/api/v3"
 # OpenRouter's OpenAI-compatible endpoint.
 OPENROUTER_BASE_URL = "https://openrouter.ai/api/v1"
 
-# Z.ai Model API OpenAI-compatible endpoint. The full chat URL is
-# https://api.z.ai/api/paas/v4/chat/completions; ChatOpenAI appends
-# /chat/completions to this base URL. Do not confuse this paid Model API with
-# the subscription Coding Plan endpoint at /api/coding/paas/v4.
-ZAI_BASE_URL = "https://api.z.ai/api/paas/v4"
-
 # Shared synchronous HTTP clients for each provider.
 # Initialized to None; built by set_provider_config() after key injection.
 openai_http_client: Optional[httpx.Client] = None
 xai_http_client: Optional[httpx.Client] = None
 bytedance_http_client: Optional[httpx.Client] = None
 openrouter_http_client: Optional[httpx.Client] = None
-zai_http_client: Optional[httpx.Client] = None
 
 
 _provider_config: Optional[ProviderConfig] = None
@@ -77,13 +70,12 @@ _provider_config: Optional[ProviderConfig] = None
 def set_provider_config(config: ProviderConfig) -> None:
     """Store the provider config and rebuild HTTP clients. Called once after key injection."""
     global _provider_config, openai_http_client, xai_http_client, bytedance_http_client
-    global openrouter_http_client, zai_http_client
+    global openrouter_http_client
 
     old_openai = openai_http_client
     old_xai = xai_http_client
     old_bytedance = bytedance_http_client
     old_openrouter = openrouter_http_client
-    old_zai = zai_http_client
 
     openai_http_client = httpx.Client(
         base_url="https://api.openai.com/v1",
@@ -124,14 +116,6 @@ def set_provider_config(config: ProviderConfig) -> None:
         http2=True,
         follow_redirects=False,
     )
-    zai_http_client = httpx.Client(
-        base_url=ZAI_BASE_URL,
-        headers={"Authorization": f"Bearer {config.zai_api_key or ''}"},
-        timeout=_TIMEOUT,
-        limits=_LIMITS,
-        http2=True,
-        follow_redirects=False,
-    )
 
     # Web search runs inside the enclave against Exa rather than through any
     # provider's native tool, so its client is built here alongside them.
@@ -152,8 +136,6 @@ def set_provider_config(config: ProviderConfig) -> None:
         old_bytedance.close()
     if old_openrouter is not None:
         old_openrouter.close()
-    if old_zai is not None:
-        old_zai.close()
 
 
 def get_provider_config() -> Optional[ProviderConfig]:
@@ -338,24 +320,6 @@ def get_chat_model_cached(
             api_key=SecretStr(config.openrouter_api_key),
             base_url=OPENROUTER_BASE_URL,
             extra_body={"provider": {"sort": "price"}},
-            streaming=True,
-            stream_usage=True,
-        )  # type: ignore [call-arg]
-
-    elif provider == "zai":
-        if not config.zai_api_key:
-            raise ValueError("zai_api_key not set in ProviderConfig")
-
-        if zai_http_client is None:
-            raise RuntimeError("Z.ai HTTP client has not been initialized")
-
-        return ChatOpenAI(
-            model=api_name,
-            temperature=effective_temp,
-            max_tokens=max_tokens,
-            http_client=zai_http_client,
-            api_key=SecretStr(config.zai_api_key),
-            base_url=ZAI_BASE_URL,
             streaming=True,
             stream_usage=True,
         )  # type: ignore [call-arg]

--- a/tee_gateway/model_registry.py
+++ b/tee_gateway/model_registry.py
@@ -13,8 +13,7 @@ from typing import Any, Mapping, Optional
 
 @dataclass(frozen=True)
 class ModelConfig:
-    # "openai" | "anthropic" | "google" | "x-ai" | "bytedance" |
-    # "openrouter" | "zai"
+    # "openai" | "anthropic" | "google" | "x-ai" | "bytedance" | "openrouter"
     provider: str
     api_name: str  # model name sent to provider API
     input_price_usd: Decimal  # USD per token
@@ -42,10 +41,10 @@ class ModelConfig:
     # The ``response_format`` to request. ``"b64_json"`` returns inline bytes;
     # ``"url"`` returns a hosted link the gateway fetches and inlines (so the
     # client always receives bytes). ``None`` omits the field for endpoints that
-    # don't document it (Z.ai GLM-Image).
+    # don't document it.
     image_response_format: Optional[str] = "b64_json"
-    # Whether to send the OpenAI-style ``n`` count. Some endpoints (Z.ai
-    # GLM-Image, ByteDance Seedance) don't document it and reject/ignore it.
+    # Whether to send the OpenAI-style ``n`` count. Some endpoints (e.g.
+    # ByteDance Seedance) don't document it and reject/ignore it.
     image_send_n: bool = True
     # Whether the endpoint accepts reference images for image-to-image editing.
     # Text-to-image-only endpoints reject it. HOW the references are delivered
@@ -635,7 +634,7 @@ class SupportedModel(Enum):
         output_price_usd=Decimal("0.00000033"),
     )
 
-    # ── Z.ai (Model API, OpenAI-compatible) ─────────────────────────────
+    # ── Z.ai models (served through BytePlus ModelArk) ──────────────────
     # GLM-5.2 is served via a BytePlus ModelArk deployment endpoint (api_name
     # "ep-…") rather than Z.ai's own API — same model, same per-1M-token
     # pricing ($1.40 input, $4.40 output), routed through the bytedance client.
@@ -645,21 +644,6 @@ class SupportedModel(Enum):
         input_price_usd=Decimal("0.0000014"),
         output_price_usd=Decimal("0.0000044"),
     )
-    # GLM-Image uses Z.ai's image endpoint and is billed per generated image.
-    # Z.ai returns hosted URLs only (fetched and inlined by the gateway) and
-    # documents neither ``n`` nor ``response_format``, so both are omitted.
-    GLM_IMAGE = ModelConfig(
-        provider="zai",
-        api_name="glm-image",
-        input_price_usd=Decimal("0"),
-        output_price_usd=Decimal("0"),
-        image_generation=True,
-        per_image_price_usd=Decimal("0.015"),
-        image_response_format=None,
-        image_send_n=False,
-        image_extra_params={"size": "1280x1280"},
-    )
-
     # ── Legacy models (not in current SDK — retained for older SDK versions) ──
     GROK_3_MINI = ModelConfig(
         provider="x-ai",
@@ -777,10 +761,9 @@ _MODEL_LOOKUP: dict[str, SupportedModel] = {
     "hy3": SupportedModel.HY3,
     "tencent/hy3": SupportedModel.HY3,
     "tencent/hy3:floor": SupportedModel.HY3,
-    # Z.ai
+    # Z.ai models (served through BytePlus ModelArk)
     "glm-5.2": SupportedModel.GLM_5_2,
     "ep-20260803211658-fwpzs": SupportedModel.GLM_5_2,
-    "glm-image": SupportedModel.GLM_IMAGE,
     # Legacy — not in current SDK, retained for older SDK versions
     "grok-3-mini-beta": SupportedModel.GROK_3_MINI,  # old beta alias
     "grok-3-mini": SupportedModel.GROK_3_MINI,

--- a/tee_gateway/test/test_image_generation.py
+++ b/tee_gateway/test/test_image_generation.py
@@ -1,5 +1,5 @@
 """Tests for endpoint-based image generation (OpenAI gpt-image, xAI Grok,
-ByteDance Seedream, ByteDance Seedance, Z.ai GLM-Image).
+ByteDance Seedream, ByteDance Seedance).
 
 Unlike Gemini's inline-image chat models (see test_image_billing.py), these
 models are served via a dedicated OpenAI-compatible ``/images/generations``
@@ -30,7 +30,6 @@ SEEDREAM = "seedream-4.0"
 SEEDREAM_5_LITE = "seedream-5.0-lite"
 SEEDANCE = "seedance-4.5"
 SEEDANCE_5 = "seedance-5.0"
-GLM_IMAGE = "glm-image"
 GPT_IMAGE = "gpt-image-2"
 
 
@@ -87,30 +86,6 @@ class TestGenerateImages(unittest.TestCase):
         self.assertEqual(count, 1)
         self.assertEqual(images, ["data:image/jpeg;base64,RkVUQ0hFRA=="])
         fetch.assert_called_once_with("https://img/1.jpg")
-
-    def test_zai_glm_image_uses_documented_payload_and_fetches_url(self):
-        client = MagicMock()
-        client.post.return_value = _mock_response([{"url": "https://z.ai/img.png"}])
-        with (
-            patch.object(llm_backend, "zai_http_client", client),
-            patch.object(
-                image_generation,
-                "_fetch_url_as_data_uri",
-                return_value="data:image/png;base64,RkVUQ0hFRA==",
-            ),
-        ):
-            images, count = generate_images(GLM_IMAGE, "a poster", n=3)
-
-        self.assertEqual(count, 1)
-        self.assertEqual(images, ["data:image/png;base64,RkVUQ0hFRA=="])
-
-        _, kwargs = client.post.call_args
-        payload = kwargs["json"]
-        self.assertEqual(payload["model"], "glm-image")
-        self.assertEqual(payload["prompt"], "a poster")
-        self.assertEqual(payload["size"], "1280x1280")
-        self.assertNotIn("n", payload)
-        self.assertNotIn("response_format", payload)
 
     def test_openai_gpt_image_omits_response_format_and_pins_size_quality(self):
         # gpt-image models always return base64 and reject `response_format`, so
@@ -324,8 +299,8 @@ class TestGenerateImages(unittest.TestCase):
         self.assertNotIn("image", kwargs["json"])
 
     def test_reference_images_ignored_for_non_bytedance(self):
-        # xAI/Z.ai text-to-image endpoints don't support image edit; the `image`
-        # field must not leak into their payloads.
+        # xAI's text-to-image endpoint doesn't support image edit; the `image`
+        # field must not leak into its payload.
         client = MagicMock()
         client.post.return_value = _mock_response([{"b64_json": "x"}])
         with patch.object(llm_backend, "xai_http_client", client):
@@ -598,7 +573,7 @@ def _ok_stream_ctx(chunks: list[bytes]) -> MagicMock:
 class TestFetchUrlRetry(unittest.TestCase):
     """The hosted-URL fetch retries CDN-visibility 404s and transient errors.
 
-    Z.ai's generations response can point at a file mfile.z.ai hasn't made
+    A provider's generations response can point at a file its CDN hasn't made
     visible yet, so the immediate fetch 404s with "file not exist" even though
     the image exists moments later. A 404 on a provider-returned URL is
     therefore retried, not trusted.
@@ -808,7 +783,7 @@ class TestPerImageBilling(unittest.TestCase):
         return {"prompt_tokens": 0, "completion_tokens": 0, "total_tokens": 0}
 
     def test_single_image_charged_flat_price(self):
-        for model in (GROK_IMAGE, SEEDREAM, SEEDANCE, SEEDANCE_5, GLM_IMAGE, GPT_IMAGE):
+        for model in (GROK_IMAGE, SEEDREAM, SEEDANCE, SEEDANCE_5, GPT_IMAGE):
             with self.subTest(model=model):
                 cfg = get_model_config(model)
                 cost = compute_session_cost(model, self._zero_usage(), image_count=1)

--- a/tee_gateway/test/test_provider_usage_integration.py
+++ b/tee_gateway/test/test_provider_usage_integration.py
@@ -55,7 +55,7 @@ PROVIDER_SMOKE_MODELS = (
     _ProviderCase("xAI", "grok-4-fast", "XAI_API_KEY"),
     _ProviderCase("ByteDance", "deepseek-v4-flash", "ARK_API_KEY"),
     _ProviderCase("OpenRouter", "hermes-4-70b", "OPENROUTER_API_KEY"),
-    _ProviderCase("Z.ai", "glm-5.2", "ZAI_API_KEY"),
+    _ProviderCase("Z.ai via ModelArk", "glm-5.2", "ARK_API_KEY"),
 )
 
 # The newest model per provider — one each, so the run stays cheap. Replace a
@@ -75,7 +75,6 @@ IMAGE_MODELS = (
     _ProviderCase("Google", "gemini-3.1-flash-image", "GOOGLE_API_KEY"),
     _ProviderCase("xAI", "grok-imagine-image", "XAI_API_KEY"),
     _ProviderCase("ByteDance", "seedream-5.0-lite", "ARK_API_KEY"),
-    _ProviderCase("Z.ai", "glm-image", "ZAI_API_KEY"),
 )
 
 CHAT_MODELS = PROVIDER_SMOKE_MODELS + NEW_CHAT_MODELS
@@ -257,7 +256,6 @@ class TestLiveProviderUsageBilling(unittest.TestCase):
                 xai_api_key=os.environ["XAI_API_KEY"],
                 bytedance_api_key=os.environ["ARK_API_KEY"],
                 openrouter_api_key=os.environ["OPENROUTER_API_KEY"],
-                zai_api_key=os.environ["ZAI_API_KEY"],
             )
         )
         set_price_feed(_FixedPriceFeed())  # type: ignore[arg-type]

--- a/tee_gateway/web_search.py
+++ b/tee_gateway/web_search.py
@@ -6,7 +6,7 @@ Anthropic's ``web_search_20250305``, Gemini's ``google_search`` grounding, and
 xAI's Responses-API ``web_search``). Those differed in every dimension that
 matters: which models could use them, what the results looked like, what the
 response reported back, and what a "search" cost ($0.01–$0.035, with xAI billing
-per *citation*). Models on providers without one (ByteDance, OpenRouter, Z.ai) simply
+per *citation*). Models on providers without one (ByteDance, OpenRouter) simply
 could not search at all.
 
 Search is now a dedicated, model-free endpoint — ``POST /v1/web_search``, served

--- a/tests/test_pricing.py
+++ b/tests/test_pricing.py
@@ -539,7 +539,7 @@ class TestModelRegistry(unittest.TestCase):
         self.assertEqual(cfg, get_model_config("tencent/hy3"))
         self.assertEqual(cfg, get_model_config("tencent/hy3:floor"))
 
-    # ── Z.ai (Model API) ───────────────────────────────────────────────────
+    # ── Z.ai models (served through BytePlus ModelArk) ─────────────────────
 
     def test_glm_5_2_resolves(self):
         # GLM-5.2 is served via a BytePlus ModelArk deployment endpoint, not
@@ -555,13 +555,6 @@ class TestModelRegistry(unittest.TestCase):
             get_model_config("ep-20260803211658-fwpzs"),
             get_model_config("glm-5.2"),
         )
-
-    def test_glm_image_resolves(self):
-        cfg = get_model_config("glm-image")
-        self.assertEqual(cfg.provider, "zai")
-        self.assertEqual(cfg.api_name, "glm-image")
-        self.assertTrue(cfg.image_generation)
-        self.assertEqual(cfg.per_image_price_usd, Decimal("0.015"))
 
     # ── Errors ───────────────────────────────────────────────────────────────
 


### PR DESCRIPTION
Z.ai is no longer used, so this drops the provider entirely.

Its only registry entry was the `glm-image` image-generation model. **GLM-5.2 chat is unaffected** — it is served through a BytePlus ModelArk deployment endpoint (`ep-…`) on the `bytedance` provider, not through Z.ai's own API.

## Removed

- `glm-image` from the model registry (enum entry + `_MODEL_LOOKUP` alias) and its pricing test
- The `zai` provider branch, `zai_http_client` and `ZAI_BASE_URL` in `llm_backend.py`, and the `zai` entry in the image-generation client map
- `zai_api_key` from `ProviderConfig`, the `/v1/keys` handler, the startup key log, and the `providers_initialized` response
- `ZAI_API_KEY` from `scripts/run-enclave.sh` key injection, the live-provider CI job, and the README / CLAUDE.md env tables
- Z.ai-specific comments and the `glm-image` unit test in `test_image_generation.py`

## Notes

- **Backwards compatible for deployers**: an older host that still POSTs `zai_api_key` to `/v1/keys` keeps working — the field is now simply ignored rather than rejected.
- The live provider smoke case for `glm-5.2` now reads `ARK_API_KEY`, which is the key that actually serves it. Previously it read `ZAI_API_KEY`, which was never the key used for that request.
- No dependency changes, so `uv.lock` is untouched. (Source changes do move the PCR measurements, as with any code change.)
- Dropping `glm-image` means that model can no longer be routed. It is the one user-visible removal here; flagging it in case the chat-api catalog still offers it.

## Testing

- `make lint` — ruff format, ruff check, mypy all clean
- `uv run --group test pytest tee_gateway/test/ tests/test_pricing.py tests/test_opengradient_field.py` — 401 passed, 6 skipped, 115 subtests passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011fpkbFt9CvHuPjevymVUnY

---
_Generated by [Claude Code](https://claude.ai/code/session_011fpkbFt9CvHuPjevymVUnY)_