### PR TITLE
Add xAI Grok Imagine Image 2.0 to the model registry

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -123,12 +123,12 @@ Model name prefixes determine routing:
 - **OpenAI**: gpt-6-astra, gpt-4.1, gpt-5, gpt-5-mini, gpt-5.2, gpt-5.6-sol/terra/luna, o4-mini; image generation: gpt-image-2
 - **Anthropic**: claude-sonnet-4-0/4-5/4-6, claude-sonnet-5, claude-haiku-4-5, claude-opus-4-5/4-6/4-7/4-8, claude-opus-5, claude-fable-5, claude-fable-5-1, claude-3-7-sonnet, claude-3-5-haiku
 - **Google**: gemini-3.8-flash, gemini-3.7-flash, gemini-3.6-flash, gemini-3.5-flash-lite, gemini-2.5-flash, gemini-2.5-flash-lite, gemini-2.5-pro, gemini-3-pro-preview, gemini-3-flash-preview, gemini-3.1-pro-preview, gemini-3.5-flash; image generation: gemini-2.5-flash-image, gemini-3.1-flash-image
-- **xAI**: grok-2, grok-3, grok-3-mini, grok-4, grok-4.3, grok-4.5, grok-4.6, grok-4-fast, grok-4-1-fast; image generation: grok-2-image
+- **xAI**: grok-2, grok-3, grok-3-mini, grok-4, grok-4.3, grok-4.5, grok-4.6, grok-4-fast, grok-4-1-fast; image generation: grok-2-image, grok-imagine-image-2.0
 - **ByteDance** (BytePlus ModelArk, OpenAI-compatible, ap-southeast): seed-1.6, seed-1.8, seed-2.0-lite, deepseek-v4-flash, deepseek-v4-pro, glm-5.2 (Z.ai's model served via a ModelArk deployment endpoint); image generation: seedream-4.0, seedream-5.0-lite, seedance-4.5, seedance-5.0
 - **OpenRouter** (OpenAI-compatible): hermes-4-405b, hermes-4-70b, hy3
 - **Z.ai** (Model API, OpenAI-compatible): image generation: glm-image (glm-5.2 chat is routed through BytePlus ModelArk, see ByteDance above)
 
-Image generation via OpenAI (gpt-image-2), xAI (grok-2-image), ByteDance
+Image generation via OpenAI (gpt-image-2), xAI (grok-2-image, grok-imagine-image-2.0), ByteDance
 (seedream-4.0, seedream-5.0-lite, seedance-4.5, seedance-5.0), and Z.ai (glm-image) is served
 through a provider `/images/generations` endpoint rather than the chat path (see
 `image_generation.py`), but is surfaced on `/v1/chat/completions` exactly like

--- a/tee_gateway/model_registry.py
+++ b/tee_gateway/model_registry.py
@@ -511,6 +511,23 @@ class SupportedModel(Enum):
         per_image_price_usd=Decimal("0.02"),
         image_response_format="url",
     )
+    # Grok Imagine Image 2.0 — xAI's newer, higher-quality image model
+    # (released ~2026-08-11), offered alongside grok-imagine-image rather than
+    # replacing it (xAI's own pricing page lists both with no deprecation
+    # notice on the older one). Same hosted-URL response shape as
+    # grok-imagine-image. xAI bills two quality tiers, $0.04/image at low/1K
+    # and $0.08/image at medium/2K (docs.x.ai pricing page); the gateway has
+    # no per-request quality selector yet, so this is registered at the
+    # low/1K (default) tier price.
+    GROK_IMAGINE_IMAGE_2_0 = ModelConfig(
+        provider="x-ai",
+        api_name="grok-imagine-image-2.0",
+        input_price_usd=Decimal("0"),
+        output_price_usd=Decimal("0"),
+        image_generation=True,
+        per_image_price_usd=Decimal("0.04"),
+        image_response_format="url",
+    )
 
     # ── ByteDance (BytePlus ModelArk, OpenAI-compatible) ────────────────
     SEED_1_6 = ModelConfig(
@@ -745,6 +762,8 @@ _MODEL_LOOKUP: dict[str, SupportedModel] = {
     "grok-2-image-latest": SupportedModel.GROK_2_IMAGE,
     "grok-imagine-image": SupportedModel.GROK_2_IMAGE,
     "grok-imagine-image-2026-03-02": SupportedModel.GROK_2_IMAGE,
+    "grok-imagine-image-2.0": SupportedModel.GROK_IMAGINE_IMAGE_2_0,
+    "grok-imagine-image-2-0": SupportedModel.GROK_IMAGINE_IMAGE_2_0,
     # ByteDance
     "seed-1-6-250615": SupportedModel.SEED_1_6,
     "seed-1.6": SupportedModel.SEED_1_6,

--- a/tests/test_pricing.py
+++ b/tests/test_pricing.py
@@ -396,6 +396,19 @@ class TestModelRegistry(unittest.TestCase):
         self.assertEqual(cfg.input_price_usd, Decimal("0.0000002"))
         self.assertEqual(cfg.output_price_usd, Decimal("0.0000015"))
 
+    def test_grok_imagine_image_2_0_resolves(self):
+        cfg = get_model_config("grok-imagine-image-2.0")
+        self.assertEqual(cfg.provider, "x-ai")
+        self.assertEqual(cfg.api_name, "grok-imagine-image-2.0")
+        self.assertTrue(cfg.image_generation)
+        self.assertEqual(cfg.per_image_price_usd, Decimal("0.04"))
+
+    def test_grok_imagine_image_2_0_dash_alias_resolves(self):
+        self.assertEqual(
+            get_model_config("grok-imagine-image-2-0"),
+            get_model_config("grok-imagine-image-2.0"),
+        )
+
     def test_claude_opus_4_7_resolves(self):
         cfg = get_model_config("claude-opus-4-7")
         self.assertEqual(cfg.provider, "anthropic")


### PR DESCRIPTION
## Summary

xAI shipped a new image-generation model, **grok-imagine-image-2.0**
(~2026-08-11), alongside the already-registered `grok-imagine-image`
(`SupportedModel.GROK_2_IMAGE`). Per xAI's own pricing docs
(`docs.x.ai/docs/models`), it's a higher-quality tier — it jumped from #14 to
#2 on public text-to-image/editing leaderboards within a week of release —
offered at $0.04/image (low/1K) to $0.08/image (medium/2K), with **no
deprecation notice** on the older `grok-imagine-image` model. This is
therefore an additive registration, not a replacement.

## Pricing citation

- `docs.x.ai/docs/models` lists three xAI image models: `grok-imagine-image`
  ($0.02/image, already registered), `grok-imagine-image-quality`
  ($0.05/image, not registered), and `grok-imagine-image-2.0` ($0.04/image
  low/1K, $0.08/image medium/2K).
- The gateway has no per-request image-quality tiering yet (that's tracked in
  the still-open #108), so `grok-imagine-image-2.0` is registered at its
  default/low tier price, $0.04/image, matching the pattern used for the
  other flat `per_image_price_usd` entries.

## Changes

- `tee_gateway/model_registry.py`: `GROK_IMAGINE_IMAGE_2_0` enum entry under
  the xAI section (same shape as `GROK_2_IMAGE` — hosted-URL response format,
  no reference-image support registered since that isn't wired for xAI in
  `llm_backend.py`/`image_generation.py` today), plus `_MODEL_LOOKUP` aliases
  (`grok-imagine-image-2.0`, `grok-imagine-image-2-0`).
- `tests/test_pricing.py`: resolve + alias tests, mirroring the
  `seedream-5.0-lite` / `glm-image` image-model tests.
- `CLAUDE.md`: xAI provider row and image-generation list updated.

## Testing

- `uv run --group test python -m pytest tests/test_pricing.py -q` — 141
  passed (was 139).
- `make lint` — ruff format/check + mypy clean.
- `uv run --group test python -m pytest tee_gateway/test/ tests/test_pricing.py
  tests/test_opengradient_field.py -q` — 405 passed, 6 skipped.

## Companion PR

chat-api PR adding this to the served catalog: OpenGradient/chat-api#290

## Notes

There's an unrelated open PR (#156, branch `og/compassionate-thompson-iujsyi`)
adding Z.ai GLM-5.3/5.3-Flash from a previous run of this same routine check —
no file overlap (that PR only touches the Z.ai section).

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DxEfKGgZjAouaG3ad1Nrwv