### PR TITLE
Add Tencent Hy4 Preview to the model registry

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -125,7 +125,7 @@ Model name prefixes determine routing:
 - **Google**: gemini-3.8-flash, gemini-3.7-flash, gemini-3.6-flash, gemini-3.5-flash-lite, gemini-2.5-flash, gemini-2.5-flash-lite, gemini-2.5-pro, gemini-3-pro-preview, gemini-3-flash-preview, gemini-3.1-pro-preview, gemini-3.5-flash; image generation: gemini-2.5-flash-image, gemini-3.1-flash-image
 - **xAI**: grok-2, grok-3, grok-3-mini, grok-4, grok-4.3, grok-4.5, grok-4.6, grok-4-fast, grok-4-1-fast; image generation: grok-2-image, grok-imagine-image-2.0
 - **ByteDance** (BytePlus ModelArk, OpenAI-compatible, ap-southeast): seed-1.6, seed-1.8, seed-2.0-lite, deepseek-v4-flash, deepseek-v4-pro, glm-5.2 (Z.ai's model served via a ModelArk deployment endpoint); image generation: seedream-4.0, seedream-5.0-lite, seedance-4.5, seedance-5.0
-- **OpenRouter** (OpenAI-compatible): hermes-4-405b, hermes-4-70b, hy3
+- **OpenRouter** (OpenAI-compatible): hy4-preview, hermes-4-405b, hermes-4-70b, hy3
 - **Z.ai** (Model API, OpenAI-compatible): image generation: glm-image (glm-5.2 chat is routed through BytePlus ModelArk, see ByteDance above)
 
 Image generation via OpenAI (gpt-image-2), xAI (grok-2-image, grok-imagine-image-2.0), ByteDance

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ The gateway solves this by running inside a hardware-isolated Nitro Enclave wher
 | Google | gemini-3.8-flash, gemini-3.7-flash, gemini-3.6-flash, gemini-3.5-flash-lite, gemini-2.5-flash, gemini-2.5-flash-lite, gemini-2.5-pro, gemini-3-pro-preview, gemini-3-flash-preview |
 | xAI | grok-4.6, grok-4.5, grok-4.3, grok-4, grok-4-fast, grok-4-1-fast, grok-4-1-fast-non-reasoning |
 | ByteDance | seed-1.6, seed-1.8, seed-2.0-lite, deepseek-v4-flash, deepseek-v4-pro |
-| OpenRouter | hermes-4-405b, hermes-4-70b, hy3 |
+| OpenRouter | hy4-preview, hermes-4-405b, hermes-4-70b, hy3 |
 
 ## Quick Start
 

--- a/tee_gateway/model_registry.py
+++ b/tee_gateway/model_registry.py
@@ -631,6 +631,19 @@ class SupportedModel(Enum):
     )
 
     # ── OpenRouter (OpenAI-compatible) ──────────────────────────────────
+    # Tencent Hy4 Preview — 770B-parameter (49B active) open-weight MoE,
+    # open-sourced 2026-08-28, aimed at coding agents and long-horizon
+    # tool-use with a 1,048,576-token context window. Routed through
+    # OpenRouter like hy3, using OpenRouter's list pricing. Tencent
+    # recommends temperature=0.9 for inference; the model accepts the
+    # standard sampling params (OpenRouter model page), so no
+    # supports_temperature/force_temperature override is needed.
+    HY4_PREVIEW = ModelConfig(
+        provider="openrouter",
+        api_name="tencent/hy4-preview",
+        input_price_usd=Decimal("0.000000834"),
+        output_price_usd=Decimal("0.000002501"),
+    )
     # Nous no longer serves Hermes 4 through Nous Portal, so both models route
     # through their canonical OpenRouter slugs and use OpenRouter list pricing.
     HERMES_4_405B = ModelConfig(
@@ -796,6 +809,9 @@ _MODEL_LOOKUP: dict[str, SupportedModel] = {
     "hy3": SupportedModel.HY3,
     "tencent/hy3": SupportedModel.HY3,
     "tencent/hy3:floor": SupportedModel.HY3,
+    "hy4-preview": SupportedModel.HY4_PREVIEW,
+    "hy4": SupportedModel.HY4_PREVIEW,
+    "tencent/hy4-preview": SupportedModel.HY4_PREVIEW,
     # Z.ai
     "glm-5.2": SupportedModel.GLM_5_2,
     "ep-20260803211658-fwpzs": SupportedModel.GLM_5_2,

--- a/tests/test_pricing.py
+++ b/tests/test_pricing.py
@@ -552,6 +552,15 @@ class TestModelRegistry(unittest.TestCase):
         self.assertEqual(cfg, get_model_config("tencent/hy3"))
         self.assertEqual(cfg, get_model_config("tencent/hy3:floor"))
 
+    def test_hy4_preview_resolves(self):
+        cfg = get_model_config("hy4-preview")
+        self.assertEqual(cfg.provider, "openrouter")
+        self.assertEqual(cfg.api_name, "tencent/hy4-preview")
+        self.assertEqual(cfg.input_price_usd, Decimal("0.000000834"))
+        self.assertEqual(cfg.output_price_usd, Decimal("0.000002501"))
+        self.assertEqual(cfg, get_model_config("hy4"))
+        self.assertEqual(cfg, get_model_config("tencent/hy4-preview"))
+
     # ── Z.ai (Model API) ───────────────────────────────────────────────────
 
     def test_glm_5_2_resolves(self):
@@ -925,6 +934,12 @@ class TestCalculateSessionCostOPG(unittest.TestCase):
         self.assertEqual(
             self._calc("hy3", 1000, 500),
             247_500_000_000_000,
+        )
+
+    def test_hy4_preview_cost(self):
+        self.assertEqual(
+            self._calc("hy4-preview", 1000, 500),
+            2_084_500_000_000_000,
         )
 
     # ── Haiku is cheaper than Sonnet ────────────────────────────────────────


### PR DESCRIPTION
## Summary

- Registers Tencent's **Hy4 Preview** — a 770B-parameter (49B active) open-weight MoE with a 1,048,576-token context window, open-sourced 2026-08-28 — routed through OpenRouter, the same path as `hy3`.
- Pricing ($0.834 / $2.501 per MTok) taken from [OpenRouter's Hy4 Preview page](https://openrouter.ai/tencent/hy4-preview).
- Tencent's docs recommend `temperature=0.9` for inference and the model accepts the standard sampling params per the OpenRouter listing, so no `supports_temperature`/`force_temperature` override was needed.
- Registered names: `hy4-preview`, `hy4`, `tencent/hy4-preview`.
- Updated the provider tables in `CLAUDE.md` and `README.md`.

## Found during

Routine check for new releases from providers already integrated in the gateway. Also checked open PR #156 ("Add Z.ai GLM-5.3 and GLM-5.3-Flash") from a previous run of this task — it's unrelated (different files/lines) and still an open draft, so no overlap with this change.

## Test plan

- [x] `uv run pytest tests/test_pricing.py` — 143 passed (added `test_hy4_preview_resolves`, `test_hy4_preview_cost`)
- [x] `make lint` (ruff format + check, mypy) — clean

## Companion PR

opengradient/chat-api#293 — adds the corresponding catalog entry so clients can select the model.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Xay2fLWeP439EAn77TWBTJ