### PR TITLE
Add OpenAI GPT-Image-2.5 (Flare, Sunburst) to the model registry

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -120,7 +120,7 @@ Server configuration:
 ### Supported Providers
 
 Model name prefixes determine routing:
-- **OpenAI**: gpt-6-astra, gpt-4.1, gpt-5, gpt-5-mini, gpt-5.2, gpt-5.6-sol/terra/luna, o4-mini; image generation: gpt-image-2
+- **OpenAI**: gpt-6-astra, gpt-4.1, gpt-5, gpt-5-mini, gpt-5.2, gpt-5.6-sol/terra/luna, o4-mini; image generation: gpt-image-2.5-flare, gpt-image-2.5-sunburst, gpt-image-2
 - **Anthropic**: claude-sonnet-4-0/4-5/4-6, claude-sonnet-5, claude-haiku-4-5, claude-opus-4-5/4-6/4-7/4-8, claude-opus-5, claude-fable-5, claude-fable-5-1, claude-3-7-sonnet, claude-3-5-haiku
 - **Google**: gemini-3.8-flash, gemini-3.7-flash, gemini-3.6-flash, gemini-3.5-flash-lite, gemini-2.5-flash, gemini-2.5-flash-lite, gemini-2.5-pro, gemini-3-pro-preview, gemini-3-flash-preview, gemini-3.1-pro-preview, gemini-3.5-flash; image generation: gemini-2.5-flash-image, gemini-3.1-flash-image
 - **xAI**: grok-2, grok-3, grok-3-mini, grok-4, grok-4.3, grok-4.5, grok-4.6, grok-4-fast, grok-4-1-fast; image generation: grok-2-image, grok-imagine-image-2.0
@@ -128,7 +128,7 @@ Model name prefixes determine routing:
 - **OpenRouter** (OpenAI-compatible): hermes-4-405b, hermes-4-70b, hy3
 - **Z.ai** (Model API, OpenAI-compatible): image generation: glm-image (glm-5.2 chat is routed through BytePlus ModelArk, see ByteDance above)
 
-Image generation via OpenAI (gpt-image-2), xAI (grok-2-image, grok-imagine-image-2.0), ByteDance
+Image generation via OpenAI (gpt-image-2.5-flare, gpt-image-2.5-sunburst, gpt-image-2), xAI (grok-2-image, grok-imagine-image-2.0), ByteDance
 (seedream-4.0, seedream-5.0-lite, seedance-4.5, seedance-5.0), and Z.ai (glm-image) is served
 through a provider `/images/generations` endpoint rather than the chat path (see
 `image_generation.py`), but is surfaced on `/v1/chat/completions` exactly like

--- a/tee_gateway/model_registry.py
+++ b/tee_gateway/model_registry.py
@@ -344,6 +344,48 @@ class SupportedModel(Enum):
         image_aspect_ratios=_GPT_IMAGE_ASPECT_SIZES,
         image_aspect_ratio_param="size",
     )
+    # GPT-Image-2.5 Flare — OpenAI's fastest model for high-quality, everyday
+    # image generation (GA 2026-09-08), positioned as the general-purpose
+    # successor to gpt-image-2 (50% lower latency, better reference-photo
+    # fidelity). Same /images/generations + /images/edits endpoints,
+    # b64-only output (response_format omitted, as with gpt-image-2), and
+    # per OpenAI's model page "token rates align with GPT Image 2" — text
+    # $5/$1.25(cached) per MTok, image input $8/$2(cached) per MTok, image
+    # output $30 per MTok — so the same flat per-image approximation as
+    # gpt-image-2 applies.
+    GPT_IMAGE_2_5_FLARE = ModelConfig(
+        provider="openai",
+        api_name="gpt-image-2.5-flare",
+        input_price_usd=Decimal("0"),
+        output_price_usd=Decimal("0"),
+        image_generation=True,
+        per_image_price_usd=Decimal("0.05"),
+        image_response_format=None,
+        image_supports_reference=True,
+        image_edit_endpoint="/images/edits",
+        image_extra_params={"quality": "medium"},
+        image_aspect_ratios=_GPT_IMAGE_ASPECT_SIZES,
+        image_aspect_ratio_param="size",
+    )
+    # GPT-Image-2.5 Sunburst — OpenAI's most capable image model, favoring
+    # editing precision over latency for premium/production workflows (GA
+    # 2026-09-08, same day as Flare). Only reachable via /images/generations
+    # and /images/edits (not chat/Responses/Batch), same request shaping and
+    # token rates as Flare/gpt-image-2.
+    GPT_IMAGE_2_5_SUNBURST = ModelConfig(
+        provider="openai",
+        api_name="gpt-image-2.5-sunburst",
+        input_price_usd=Decimal("0"),
+        output_price_usd=Decimal("0"),
+        image_generation=True,
+        per_image_price_usd=Decimal("0.05"),
+        image_response_format=None,
+        image_supports_reference=True,
+        image_edit_endpoint="/images/edits",
+        image_extra_params={"quality": "medium"},
+        image_aspect_ratios=_GPT_IMAGE_ASPECT_SIZES,
+        image_aspect_ratio_param="size",
+    )
 
     # ── Anthropic ───────────────────────────────────────────────────────
     CLAUDE_SONNET_4_5 = ModelConfig(
@@ -842,6 +884,11 @@ _MODEL_LOOKUP: dict[str, SupportedModel] = {
     "gpt-5.6-luna": SupportedModel.GPT_5_6_LUNA,
     "gpt-6-astra": SupportedModel.GPT_6_ASTRA,
     "gpt-image-2": SupportedModel.GPT_IMAGE_2,
+    "gpt-image-2.5": SupportedModel.GPT_IMAGE_2_5_FLARE,
+    "gpt-image-2.5-flare": SupportedModel.GPT_IMAGE_2_5_FLARE,
+    "gpt-image-2.5-flare-2026-09-08": SupportedModel.GPT_IMAGE_2_5_FLARE,
+    "gpt-image-2.5-sunburst": SupportedModel.GPT_IMAGE_2_5_SUNBURST,
+    "gpt-image-2.5-sunburst-2026-09-08": SupportedModel.GPT_IMAGE_2_5_SUNBURST,
     # Anthropic
     "claude-sonnet-4-5": SupportedModel.CLAUDE_SONNET_4_5,
     "claude-sonnet-4-6": SupportedModel.CLAUDE_SONNET_4_6,

--- a/tests/test_pricing.py
+++ b/tests/test_pricing.py
@@ -266,6 +266,26 @@ class TestModelRegistry(unittest.TestCase):
         self.assertEqual(cfg.output_price_usd, Decimal("0.00005"))
         self.assertTrue(cfg.responses_api_for_tools)
 
+    def test_gpt_image_2_5_flare_resolves(self):
+        cfg = get_model_config("gpt-image-2.5-flare")
+        self.assertEqual(cfg.provider, "openai")
+        self.assertEqual(cfg.api_name, "gpt-image-2.5-flare")
+        self.assertTrue(cfg.image_generation)
+        self.assertEqual(cfg.per_image_price_usd, Decimal("0.05"))
+
+    def test_gpt_image_2_5_bare_alias_resolves_to_flare(self):
+        self.assertEqual(
+            get_model_config("gpt-image-2.5"),
+            get_model_config("gpt-image-2.5-flare"),
+        )
+
+    def test_gpt_image_2_5_sunburst_resolves(self):
+        cfg = get_model_config("gpt-image-2.5-sunburst")
+        self.assertEqual(cfg.provider, "openai")
+        self.assertEqual(cfg.api_name, "gpt-image-2.5-sunburst")
+        self.assertTrue(cfg.image_generation)
+        self.assertEqual(cfg.per_image_price_usd, Decimal("0.05"))
+
     # ── Google ──────────────────────────────────────────────────────────────
 
     def test_gemini_2_5_flash_resolves(self):


### PR DESCRIPTION
## Summary

OpenAI shipped **GPT-Image-2.5** on 2026-09-08 (two days before this run) as
two GA API models:

- **`gpt-image-2.5-flare`** — "our fastest model for high-quality, everyday
  image generation": 50% lower latency than `gpt-image-2`, better
  reference-photo fidelity and precise edits. Positioned as the general-purpose
  successor to `gpt-image-2`. Registered with a bare `gpt-image-2.5` alias
  since it's the default/general-purpose variant.
- **`gpt-image-2.5-sunburst`** — "our most capable model for image generation
  and editing": precision editing for premium/production visual workflows.

Both route through the same `/images/generations` + `/images/edits` endpoints
as `gpt-image-2` (not chat/Responses/Batch), and per OpenAI's own model pages,
"token rates align with GPT Image 2" ($5/$1.25(cached) per MTok text,
$8/$2(cached) per MTok image input, $30 per MTok image output — text output
unbilled) — so both reuse the same flat `$0.05`/image approximation
`gpt-image-2` already uses.

## Pricing / parameter citations

- Pricing: OpenAI's own model reference pages —
  [gpt-image-2.5-flare](https://developers.openai.com/api/docs/models/gpt-image-2.5-flare),
  [gpt-image-2.5-sunburst](https://developers.openai.com/api/docs/models/gpt-image-2.5-sunburst).
- Parameters: same page — only `/v1/images/generations` and `/v1/images/edits`
  are supported endpoints for both variants (confirmed explicitly for
  Sunburst: "Cannot be used via Chat Completions, Responses, or Batch
  endpoints"), matching `gpt-image-2`'s existing request shaping
  (`image_response_format=None`, `image_supports_reference=True`,
  `image_edit_endpoint="/images/edits"`), so no new flags were needed.

## Found during

Routine check for new releases from providers already integrated in the
gateway. Also checked the two other open PRs touching `model_registry.py`
from previous runs of this task — #160 ("Add Tencent Hy4 Preview") and #156
("Add Z.ai GLM-5.3 and GLM-5.3-Flash") — both are unrelated (different
provider sections, no line overlap) and still open drafts, so no changes were
bundled into them.

Also checked Claude Mythos 5.1 and Gemini 3.8 Flash Cyber, both released
around the same time — neither was added: both are vetted-access-only
cybersecurity/biology models (Anthropic's Project Glasswing, Google's
Fairwind Program) with no public self-serve API, so there's nothing a
standard provider API key here could route to.

## Test plan

- [x] `uv run pytest tests/test_pricing.py` — 147 passed (added
      `test_gpt_image_2_5_flare_resolves`,
      `test_gpt_image_2_5_bare_alias_resolves_to_flare`,
      `test_gpt_image_2_5_sunburst_resolves`)
- [x] `make lint` (ruff format + check, mypy) — clean

## Companion PR

opengradient/chat-api#299 — adds the corresponding catalog entries so clients
can select the model.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DoBWfeNKzcQ2ZscrGeUQsA