### PR TITLE
Fix the large-body 402 reset, serve with gunicorn, classify provider failures

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -10,6 +10,8 @@ The repo must provide a stable AWS Nitro PCR when the code doesn't change in ord
 ├── tee_gateway/             # Main application package (Flask/connexion)
 │   ├── __main__.py          # App factory, x402 middleware setup, key injection; dev server when run directly
 │   ├── wsgi.py              # `application` for gunicorn (what the enclave runs)
+│   ├── body_preread.py      # Reads/refuses a paid POST body before x402 can answer 402
+│   ├── errors.py            # One error payload + outer status for provider vs gateway failures
 │   ├── gunicorn_conf.py     # Production server settings: one gthread worker, fatal worker exit
 │   ├── llm_backend.py       # LLM provider routing via LangChain, HTTP client management
 │   ├── image_generation.py  # Endpoint-based image gen (/images/generations): request shaping, URL→inline-bytes, signed responses
@@ -232,26 +234,37 @@ terminal in-band SSE `data:` frame, since the status is already 200):
   failure inside the enclave. `provider_status` is the provider's own HTTP
   status when it returned one; `retryable` says whether resending the same
   request has a real chance (provider 5xx/429/overload, resets, timeouts).
-- The outer status follows the same classification: provider failures are
-  **502** (or **504** when the provider timed out), gateway failures **500**.
-  Before this, every failure was a 500, so a browser could not tell an
-  overloaded provider from an enclave bug — and could not distinguish either
-  from the bare 502 nitriding emits when it cannot reach this app at all.
+- The outer status follows the same classification: a provider that could
+  not be reached or answered 5xx is **502** (**504** for a timeout or 408,
+  **503** for 429), a gateway failure **500**. A provider 4xx about the
+  request itself (context too long, bad parameter, unknown model, oversize
+  image) is **passed through unchanged**: the relay and the browser retry
+  502/503 once, and resending an invalid request cannot help. The exception
+  is 401/402/403/407 from a provider, which are about the gateway's own key
+  or account and become 502 (a 401 would read as the client's credentials
+  failing; a 402 would be taken by the relay's x402 client for a payment
+  challenge from this gateway). Before this, every failure was a 500, so a
+  browser could not tell an overloaded provider from an enclave bug — and
+  could not distinguish either from the bare 502 nitriding emits when it
+  cannot reach this app at all.
 - Never put prompt or completion text in an error: provider messages describe
   their refusal, not the user's content, and error bodies are forwarded to the
   relay as plaintext.
 
 ### Request bodies are read before any response
 
-`__main__._read_body_before_responding` wraps the WSGI stack *outside* the
-x402 payment middleware and buffers the body of a POST to a paid route (up to
-the OHTTP cap) before dispatch. Without it, a 402 challenge on a
-multi-megabyte body was written while nitriding was still streaming the body
-in; Go's HTTP server closes a connection with more than 256 KiB of unread
-body, the reset propagated through gvproxy, and the relay saw either an empty
-`ReadError` or a bare 502 instead of the challenge. Keep this the outermost
-layer: anything that can answer before the body is consumed (payment errors,
-pricing 503s) must run inside it.
+`tee_gateway/body_preread.py` wraps the WSGI stack *outside* the x402
+payment middleware and buffers the body of a POST to a paid route before
+dispatch. Without it, a 402 challenge on a multi-megabyte body was written
+while nitriding was still streaming the body in; Go's HTTP server closes a
+connection with more than 256 KiB of unread body, the reset propagated
+through gvproxy, and the relay saw either an empty `ReadError` or a bare 502
+instead of the challenge. A body over `MAX_PAID_REQUEST_BYTES` (20 MiB, the
+same cap the OHTTP handler enforces) is refused with 413 there, before
+payment, rather than passed through unread. Keep this the outermost layer:
+anything that can answer before the body is consumed (payment errors,
+pricing 503s) must run inside it. The module has no import-time side
+effects, so it is unit-tested directly (`test_body_preread.py`).
 
 ### Production server
 
@@ -267,9 +280,11 @@ tunables:
   registration, the injected provider keys and the x402 session store are all
   state of the one worker process. More workers would mean several signing
   keys behind one registry entry.
-- **A worker exit halts gunicorn** (`child_exit`). A respawned worker would
-  have a new signing key and no provider keys and keep answering requests
-  wrongly. Dying is what the bare process did; keep it that way.
+- **An unsolicited worker exit halts gunicorn** (`child_exit`, exit status
+  1; a normal SIGTERM shutdown still exits 0). A respawned worker would have
+  a new signing key and no provider keys and keep answering requests wrongly.
+  Dying is what the bare process did; keep it that way. `scripts/start.sh`
+  `exec`s gunicorn so that status is the container's.
 - **`keepalive = 3600`.** nitriding's Go proxy pools idle loopback connections
   with no idle timeout and does not retry a POST it has written; the server
   must not be the side that closes an idle connection first (that race is a

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -238,6 +238,18 @@ terminal in-band SSE `data:` frame, since the status is already 200):
   their refusal, not the user's content, and error bodies are forwarded to the
   relay as plaintext.
 
+### Request bodies are read before any response
+
+`__main__._read_body_before_responding` wraps the WSGI stack *outside* the
+x402 payment middleware and buffers the body of a POST to a paid route (up to
+the OHTTP cap) before dispatch. Without it, a 402 challenge on a
+multi-megabyte body was written while nitriding was still streaming the body
+in; Go's HTTP server closes a connection with more than 256 KiB of unread
+body, the reset propagated through gvproxy, and the relay saw either an empty
+`ReadError` or a bare 502 instead of the challenge. Keep this the outermost
+layer: anything that can answer before the body is consumed (payment errors,
+pricing 503s) must run inside it.
+
 ### Load reporting
 
 `/health` carries a `load` block — `in_flight_requests`,

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -213,6 +213,42 @@ Points to keep in mind:
   blocked (451) requests produce no `opengradient` block and are never
   settled.
 
+### Error responses
+
+Every inference endpoint answers failures with one JSON shape, built by
+`tee_gateway/errors.py` (non-streaming: the response body; streaming: the
+terminal in-band SSE `data:` frame, since the status is already 200):
+
+```json
+{"error": "Error code: 529 - {...overloaded_error...}", "exception_type": "APIStatusError",
+ "source": "provider", "provider_status": 529, "retryable": true}
+```
+
+- `source` is `provider` when a model provider answered with an error or could
+  not be reached (any exception from a provider SDK or httpx), `gateway` for a
+  failure inside the enclave. `provider_status` is the provider's own HTTP
+  status when it returned one; `retryable` says whether resending the same
+  request has a real chance (provider 5xx/429/overload, resets, timeouts).
+- The outer status follows the same classification: provider failures are
+  **502** (or **504** when the provider timed out), gateway failures **500**.
+  Before this, every failure was a 500, so a browser could not tell an
+  overloaded provider from an enclave bug — and could not distinguish either
+  from the bare 502 nitriding emits when it cannot reach this app at all.
+- Never put prompt or completion text in an error: provider messages describe
+  their refusal, not the user's content, and error bodies are forwarded to the
+  relay as plaintext.
+
+### Load reporting
+
+`/health` carries a `load` block — `in_flight_requests`,
+`peak_in_flight_requests`, `requests_served`, `active_threads` — counted in
+`__main__.py` by a `before_request`/`teardown_request` pair (health and
+heartbeat polls excluded). The app runs on Werkzeug's threaded dev server
+(`application.run`): one thread per connection, no concurrency cap, and
+`Connection: close` on every response, so under load the symptom is thread
+growth and nitriding 502s rather than any error of its own. Check `load`
+first when the relay reports `tee_gateway_error` 502s.
+
 ## Verification Examples
 
 - `examples/verify_attestation.py` — Validates AWS Nitro attestation documents against the root CA

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,7 +8,9 @@ The repo must provide a stable AWS Nitro PCR when the code doesn't change in ord
 
 ```
 ├── tee_gateway/             # Main application package (Flask/connexion)
-│   ├── __main__.py          # Entry point: app factory, x402 middleware setup, key injection
+│   ├── __main__.py          # App factory, x402 middleware setup, key injection; dev server when run directly
+│   ├── wsgi.py              # `application` for gunicorn (what the enclave runs)
+│   ├── gunicorn_conf.py     # Production server settings: one gthread worker, fatal worker exit
 │   ├── llm_backend.py       # LLM provider routing via LangChain, HTTP client management
 │   ├── image_generation.py  # Endpoint-based image gen (/images/generations): request shaping, URL→inline-bytes, signed responses
 │   ├── tee_manager.py       # TEE key generation, nitriding registration, response signing
@@ -41,7 +43,8 @@ uv lock                      # Regenerate lockfile after editing pyproject.toml
 # Only regenerate the lockfile when intentionally changing dependencies.
 
 # Run server locally for development (without TEE)
-make test-local              # Runs: uv run python -m tee_gateway
+make test-local              # Runs: uv run python -m tee_gateway (Werkzeug dev server)
+make serve                   # Runs the production command the enclave uses (gunicorn)
 
 # Linting and type checking
 make lint                    # Run ruff format + ruff check + mypy
@@ -255,11 +258,35 @@ pricing 503s) must run inside it.
 `/health` carries a `load` block — `in_flight_requests`,
 `peak_in_flight_requests`, `requests_served`, `active_threads` — counted in
 `__main__.py` by a `before_request`/`teardown_request` pair (health and
-heartbeat polls excluded). The app runs on Werkzeug's threaded dev server
-(`application.run`): one thread per connection, no concurrency cap, and
-`Connection: close` on every response, so under load the symptom is thread
-growth and nitriding 502s rather than any error of its own. Check `load`
-first when the relay reports `tee_gateway_error` 502s.
+heartbeat polls excluded). Check `load` first when the relay reports
+`tee_gateway_error` 502s: `in_flight_requests` at the `GUNICORN_THREADS` cap
+(default 64) means requests are queueing in the listen backlog.
+
+### Production server
+
+The enclave serves the app with **gunicorn**, one `gthread` worker
+(`scripts/start.sh` → `tee_gateway/gunicorn_conf.py`, app object in
+`tee_gateway/wsgi.py`). `python -m tee_gateway` still runs Werkzeug's
+development server for local work only; it used to be what the enclave ran,
+with one unbounded thread per connection, a 128-entry backlog and
+`Connection: close` on every response. The config's constraints are not
+tunables:
+
+- **`workers = 1`, no preload.** The TEE signing key, the nitriding
+  registration, the injected provider keys and the x402 session store are all
+  state of the one worker process. More workers would mean several signing
+  keys behind one registry entry.
+- **A worker exit halts gunicorn** (`child_exit`). A respawned worker would
+  have a new signing key and no provider keys and keep answering requests
+  wrongly. Dying is what the bare process did; keep it that way.
+- **`keepalive = 3600`.** nitriding's Go proxy pools idle loopback connections
+  with no idle timeout and does not retry a POST it has written; the server
+  must not be the side that closes an idle connection first (that race is a
+  bare 502 to the relay).
+- **`timeout = 0`.** The heartbeat watchdog is off because, with worker exit
+  fatal, a false positive under load would take the enclave down.
+- `GUNICORN_THREADS` caps concurrent requests (each chat stream holds a
+  thread for its duration); `API_SERVER_HOST`/`API_SERVER_PORT` bind as before.
 
 ## Verification Examples
 
@@ -268,6 +295,6 @@ first when the relay reports `tee_gateway_error` 502s.
 
 ## Deployment
 
-Multi-stage Docker build: nitriding compiled from source (`brave/nitriding-daemon`), then copied into `python:3.12.10-slim-bullseye`. Dependencies are installed via `uv sync --frozen` from the lockfile for reproducible builds. Enclave launched via `scripts/run-enclave.sh` with gvproxy as the vsock network bridge, allocating 2 CPUs and 8GB memory.
+Multi-stage Docker build: nitriding compiled from source (`brave/nitriding-daemon`), then copied into `python:3.12.10-slim-bullseye`. Dependencies are installed via `uv sync --frozen` from the lockfile for reproducible builds. `scripts/start.sh` starts nitriding and then gunicorn (see "Production server"). Enclave launched via `scripts/run-enclave.sh` with gvproxy as the vsock network bridge, allocating 2 CPUs and 8GB memory.
 
 Port 8000 is forwarded to `127.0.0.1` only on the EC2 host (loopback-only for key injection). Port 443 is forwarded publicly via gvproxy.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -253,15 +253,6 @@ body, the reset propagated through gvproxy, and the relay saw either an empty
 layer: anything that can answer before the body is consumed (payment errors,
 pricing 503s) must run inside it.
 
-### Load reporting
-
-`/health` carries a `load` block — `in_flight_requests`,
-`peak_in_flight_requests`, `requests_served`, `active_threads` — counted in
-`__main__.py` by a `before_request`/`teardown_request` pair (health and
-heartbeat polls excluded). Check `load` first when the relay reports
-`tee_gateway_error` 502s: `in_flight_requests` at the `GUNICORN_THREADS` cap
-(default 64) means requests are queueing in the listen backlog.
-
 ### Production server
 
 The enclave serves the app with **gunicorn**, one `gthread` worker

--- a/Makefile
+++ b/Makefile
@@ -79,6 +79,12 @@ get-tls-cert:
 # Local development (no TEE, no payment middleware enforced by x402 clients)
 # ---------------------------------------------------------------------------
 
+.PHONY: serve
+serve:
+	# Run the exact server command the enclave uses (gunicorn, one gthread
+	# worker; see tee_gateway/gunicorn_conf.py). Needs the same env as test-local.
+	uv run gunicorn -c python:tee_gateway.gunicorn_conf tee_gateway.wsgi:application
+
 .PHONY: test-local
 test-local:
 	# Run server locally without TEE (for development).
@@ -108,7 +114,8 @@ help:
 	@echo "  make verify-tee-id  - Verify tee_id matches the public key"
 	@echo "  make get-tls-cert   - Print the nitriding TLS certificate"
 	@echo ""
-	@echo "  make test-local     - Run server locally without TEE (development)"
+	@echo "  make test-local     - Run server locally without TEE (development, Werkzeug)"
+	@echo "  make serve          - Run the production server command (gunicorn)"
 	@echo "  make lint           - Run ruff check, ruff format --check, and mypy"
 	@echo "  make mypy           - Run mypy type checker on tee_gateway"
 	@echo ""

--- a/README.md
+++ b/README.md
@@ -58,8 +58,9 @@ export OPENROUTER_API_KEY=...  # OpenRouter
 export ZAI_API_KEY=...   # Z.ai Model API
 
 # Run server (starts the Flask/connexion app on port 8000)
-make test-local
+make test-local          # Werkzeug dev server (development only)
 # or: python3 -m tee_gateway
+make serve               # gunicorn, the command the enclave runs (tee_gateway/gunicorn_conf.py)
 ```
 
 ### Test Endpoints

--- a/scripts/start.sh
+++ b/scripts/start.sh
@@ -7,10 +7,13 @@ echo "[sh] Started nitriding."
 
 sleep 1
 
-# Start the Flask/connexion OpenAI-compatible API on port 8000.
+# Start the Flask/connexion OpenAI-compatible API on port 8000 under gunicorn
+# (one gthread worker; settings and rationale in tee_gateway/gunicorn_conf.py).
 # TEE key management (key generation, nitriding registration, response signing)
-# and nitriding readiness signaling all happen inside this process.
+# and nitriding readiness signaling all happen inside the worker process. A
+# worker exit halts gunicorn — see child_exit in the config — so this script
+# ends exactly when the bare `python3 -m tee_gateway` used to.
 echo "[sh] Starting OpenAI-compatible API server on port 8000..."
 cd /app
-python3 -m tee_gateway
+gunicorn -c python:tee_gateway.gunicorn_conf tee_gateway.wsgi:application
 echo "[sh] API server exited."

--- a/scripts/start.sh
+++ b/scripts/start.sh
@@ -10,10 +10,10 @@ sleep 1
 # Start the Flask/connexion OpenAI-compatible API on port 8000 under gunicorn
 # (one gthread worker; settings and rationale in tee_gateway/gunicorn_conf.py).
 # TEE key management (key generation, nitriding registration, response signing)
-# and nitriding readiness signaling all happen inside the worker process. A
-# worker exit halts gunicorn — see child_exit in the config — so this script
-# ends exactly when the bare `python3 -m tee_gateway` used to.
+# and nitriding readiness signaling all happen inside the worker process.
+# `exec` makes gunicorn this script's process: signals reach it directly and
+# its exit status (a halted worker exits 1, see child_exit) is the script's,
+# instead of being swallowed by a trailing shell echo.
 echo "[sh] Starting OpenAI-compatible API server on port 8000..."
 cd /app
-gunicorn -c python:tee_gateway.gunicorn_conf tee_gateway.wsgi:application
-echo "[sh] API server exited."
+exec gunicorn -c python:tee_gateway.gunicorn_conf tee_gateway.wsgi:application

--- a/tee_gateway/__main__.py
+++ b/tee_gateway/__main__.py
@@ -3,6 +3,7 @@ OpenAI-compatible API server with TEE integration and x402 payment middleware.
 Runs inside a Nitro Enclave, proxied by nitriding on port 443.
 """
 
+import io
 import logging
 import sys
 import os
@@ -26,6 +27,7 @@ from tee_gateway.moderation import moderation_available
 from tee_gateway.web_search import web_search_available
 from tee_gateway.heartbeat import create_heartbeat_service
 from tee_gateway.controllers.ohttp_controller import (
+    _MAX_ENCAPSULATED_REQUEST_BYTES,
     create_anonymous_chat_completion,
     get_hpke_config,
 )
@@ -285,6 +287,55 @@ def _session_cost_calculator(ctx: dict) -> int:
 
 
 # ---------------------------------------------------------------------------
+# Read the request body before anything can answer
+#
+# The x402 middleware answers 402 Payment Required from the request *headers*,
+# before a byte of the body has been read. That is fine for a 2 KB chat body
+# and a disaster for a multi-megabyte one (an image attachment, a long
+# transcript): nitriding's Go reverse proxy is still streaming the body from
+# the relay when the 402 comes back. Go's HTTP server will not drain more than
+# 256 KiB of unread body after a response, so it sends its FIN, waits 500 ms
+# and closes — a TCP reset while the relay is still uploading, which gvproxy
+# (the host-side vsock forwarder) relays as an abort. The relay sees a
+# connection reset with no response at all (httpx ``ReadError`` with an empty
+# message), or nitriding sees the same reset from Werkzeug's side and answers
+# a bare 502. Either way a request that only needed a payment challenge fails,
+# and it fails exactly on big bodies — which is what "flaky 502s on image
+# chats" looked like from the app.
+#
+# Reading the body up front, before the payment middleware runs, means every
+# response — the 402 included — is written after the upload has been consumed
+# end to end, so the connection is left clean for the paid retry. The OHTTP
+# controller already buffers the whole body (``get_data``), so this changes
+# where the bytes are read, not how many are held. Bodies above the OHTTP cap
+# are left alone: the controller rejects them with 413 without reading them.
+# ---------------------------------------------------------------------------
+MAX_PREREAD_REQUEST_BYTES = _MAX_ENCAPSULATED_REQUEST_BYTES
+
+
+def _read_body_before_responding(wsgi_app, paths):
+    """WSGI wrapper: buffer the body of a POST to ``paths`` before dispatch."""
+    paths = frozenset(paths)
+
+    def wrapper(environ, start_response):
+        if (
+            environ.get("REQUEST_METHOD") == "POST"
+            and environ.get("PATH_INFO") in paths
+        ):
+            try:
+                length = int(environ.get("CONTENT_LENGTH") or 0)
+            except ValueError:
+                length = 0
+            if 0 < length <= MAX_PREREAD_REQUEST_BYTES:
+                body = environ["wsgi.input"].read(length)
+                environ["wsgi.input"] = io.BytesIO(body)
+                environ["CONTENT_LENGTH"] = str(len(body))
+        return wsgi_app(environ, start_response)
+
+    return wrapper
+
+
+# ---------------------------------------------------------------------------
 # One-time runtime configuration injection
 # ---------------------------------------------------------------------------
 _keys_initialized: bool = False
@@ -413,6 +464,12 @@ def _init_payment_middleware(facilitator_url: str) -> None:
         cost_per_request=100000000000000,  # static precheck/fallback estimate
         session_idle_timeout=100,
         session_cost_calculator=_session_cost_calculator,
+    )
+    # Outermost layer, so the body is consumed before the payment middleware
+    # can answer 402 (see "Read the request body before anything can answer").
+    application.wsgi_app = _read_body_before_responding(
+        application.wsgi_app,
+        paths=[route.split(" ", 1)[1] for route in routes],
     )
     logger.info(
         "x402 payment middleware initialized with facilitator: %s", facilitator_url

--- a/tee_gateway/__main__.py
+++ b/tee_gateway/__main__.py
@@ -3,7 +3,6 @@ OpenAI-compatible API server with TEE integration and x402 payment middleware.
 Runs inside a Nitro Enclave, proxied by nitriding on port 443.
 """
 
-import io
 import logging
 import sys
 import os
@@ -27,10 +26,10 @@ from tee_gateway.moderation import moderation_available
 from tee_gateway.web_search import web_search_available
 from tee_gateway.heartbeat import create_heartbeat_service
 from tee_gateway.controllers.ohttp_controller import (
-    _MAX_ENCAPSULATED_REQUEST_BYTES,
     create_anonymous_chat_completion,
     get_hpke_config,
 )
+from tee_gateway.body_preread import read_body_before_responding
 from tee_gateway.controllers.web_search_controller import create_web_search
 
 from x402.http import FacilitatorConfig, HTTPFacilitatorClientSync, PaymentOption
@@ -261,55 +260,6 @@ def _session_cost_calculator(ctx: dict) -> int:
 
 
 # ---------------------------------------------------------------------------
-# Read the request body before anything can answer
-#
-# The x402 middleware answers 402 Payment Required from the request *headers*,
-# before a byte of the body has been read. That is fine for a 2 KB chat body
-# and a disaster for a multi-megabyte one (an image attachment, a long
-# transcript): nitriding's Go reverse proxy is still streaming the body from
-# the relay when the 402 comes back. Go's HTTP server will not drain more than
-# 256 KiB of unread body after a response, so it sends its FIN, waits 500 ms
-# and closes — a TCP reset while the relay is still uploading, which gvproxy
-# (the host-side vsock forwarder) relays as an abort. The relay sees a
-# connection reset with no response at all (httpx ``ReadError`` with an empty
-# message), or nitriding sees the same reset from Werkzeug's side and answers
-# a bare 502. Either way a request that only needed a payment challenge fails,
-# and it fails exactly on big bodies — which is what "flaky 502s on image
-# chats" looked like from the app.
-#
-# Reading the body up front, before the payment middleware runs, means every
-# response — the 402 included — is written after the upload has been consumed
-# end to end, so the connection is left clean for the paid retry. The OHTTP
-# controller already buffers the whole body (``get_data``), so this changes
-# where the bytes are read, not how many are held. Bodies above the OHTTP cap
-# are left alone: the controller rejects them with 413 without reading them.
-# ---------------------------------------------------------------------------
-MAX_PREREAD_REQUEST_BYTES = _MAX_ENCAPSULATED_REQUEST_BYTES
-
-
-def _read_body_before_responding(wsgi_app, paths):
-    """WSGI wrapper: buffer the body of a POST to ``paths`` before dispatch."""
-    paths = frozenset(paths)
-
-    def wrapper(environ, start_response):
-        if (
-            environ.get("REQUEST_METHOD") == "POST"
-            and environ.get("PATH_INFO") in paths
-        ):
-            try:
-                length = int(environ.get("CONTENT_LENGTH") or 0)
-            except ValueError:
-                length = 0
-            if 0 < length <= MAX_PREREAD_REQUEST_BYTES:
-                body = environ["wsgi.input"].read(length)
-                environ["wsgi.input"] = io.BytesIO(body)
-                environ["CONTENT_LENGTH"] = str(len(body))
-        return wsgi_app(environ, start_response)
-
-    return wrapper
-
-
-# ---------------------------------------------------------------------------
 # One-time runtime configuration injection
 # ---------------------------------------------------------------------------
 _keys_initialized: bool = False
@@ -439,9 +389,9 @@ def _init_payment_middleware(facilitator_url: str) -> None:
         session_idle_timeout=100,
         session_cost_calculator=_session_cost_calculator,
     )
-    # Outermost layer, so the body is consumed before the payment middleware
-    # can answer 402 (see "Read the request body before anything can answer").
-    application.wsgi_app = _read_body_before_responding(
+    # Outermost layer, so the body is consumed (or refused as too large)
+    # before the payment middleware can answer 402; see body_preread.py.
+    application.wsgi_app = read_body_before_responding(
         application.wsgi_app,
         paths=[route.split(" ", 1)[1] for route in routes],
     )

--- a/tee_gateway/__main__.py
+++ b/tee_gateway/__main__.py
@@ -129,6 +129,32 @@ set_price_feed(_price_feed)
 
 _started_at = time.time()
 
+# ---------------------------------------------------------------------------
+# Load accounting
+#
+# The enclave serves requests from Werkzeug's threaded dev server: one thread
+# per connection, no concurrency cap, on the 2 vCPUs the enclave is given.
+# When it is overloaded nothing says so — nitriding's reverse proxy just
+# answers 502 once the app stops accepting. These counters, reported on
+# /health, make load observable: in-flight inference requests (incremented
+# for the duration of every request), the high-water mark since start, and
+# the process thread count.
+# ---------------------------------------------------------------------------
+_load_lock = threading.Lock()
+_in_flight_requests = 0
+_peak_in_flight_requests = 0
+_requests_served = 0
+
+
+def _load_snapshot() -> dict:
+    with _load_lock:
+        return {
+            "in_flight_requests": _in_flight_requests,
+            "peak_in_flight_requests": _peak_in_flight_requests,
+            "requests_served": _requests_served,
+            "active_threads": threading.active_count(),
+        }
+
 
 def _gateway_version() -> str:
     try:
@@ -560,6 +586,8 @@ def health():
         "moderation_enabled": moderation_available(),
         "facilitator_url": _active_facilitator_url,
         "price_feed": _price_feed.get_status(),
+        # Concurrency the app is carrying right now (see "Load accounting").
+        "load": _load_snapshot(),
     }, 200
 
 
@@ -644,6 +672,30 @@ application = create_app()
 #   1. Price feed has a valid OPG/USD price (CoinGecko fetch succeeded).
 #   2. The requested model is in the registry (has a known per-token price).
 # ---------------------------------------------------------------------------
+
+
+@application.before_request
+def _count_request_start():
+    global _in_flight_requests, _peak_in_flight_requests, _requests_served
+    if request.path in ("/health", "/heartbeat/status"):
+        return
+    with _load_lock:
+        _in_flight_requests += 1
+        _requests_served += 1
+        _peak_in_flight_requests = max(_peak_in_flight_requests, _in_flight_requests)
+    request.environ["tee_gateway.counted"] = True
+
+
+@application.teardown_request
+def _count_request_end(_exc):
+    # teardown_request runs once the response has been fully sent — after
+    # the last SSE chunk for streams — so in-flight counts whole requests,
+    # not just the time until headers were written.
+    global _in_flight_requests
+    if not request.environ.pop("tee_gateway.counted", False):
+        return
+    with _load_lock:
+        _in_flight_requests = max(0, _in_flight_requests - 1)
 
 
 @application.before_request

--- a/tee_gateway/__main__.py
+++ b/tee_gateway/__main__.py
@@ -131,32 +131,6 @@ set_price_feed(_price_feed)
 
 _started_at = time.time()
 
-# ---------------------------------------------------------------------------
-# Load accounting
-#
-# The enclave serves requests from Werkzeug's threaded dev server: one thread
-# per connection, no concurrency cap, on the 2 vCPUs the enclave is given.
-# When it is overloaded nothing says so — nitriding's reverse proxy just
-# answers 502 once the app stops accepting. These counters, reported on
-# /health, make load observable: in-flight inference requests (incremented
-# for the duration of every request), the high-water mark since start, and
-# the process thread count.
-# ---------------------------------------------------------------------------
-_load_lock = threading.Lock()
-_in_flight_requests = 0
-_peak_in_flight_requests = 0
-_requests_served = 0
-
-
-def _load_snapshot() -> dict:
-    with _load_lock:
-        return {
-            "in_flight_requests": _in_flight_requests,
-            "peak_in_flight_requests": _peak_in_flight_requests,
-            "requests_served": _requests_served,
-            "active_threads": threading.active_count(),
-        }
-
 
 def _gateway_version() -> str:
     try:
@@ -643,8 +617,6 @@ def health():
         "moderation_enabled": moderation_available(),
         "facilitator_url": _active_facilitator_url,
         "price_feed": _price_feed.get_status(),
-        # Concurrency the app is carrying right now (see "Load accounting").
-        "load": _load_snapshot(),
     }, 200
 
 
@@ -729,30 +701,6 @@ application = create_app()
 #   1. Price feed has a valid OPG/USD price (CoinGecko fetch succeeded).
 #   2. The requested model is in the registry (has a known per-token price).
 # ---------------------------------------------------------------------------
-
-
-@application.before_request
-def _count_request_start():
-    global _in_flight_requests, _peak_in_flight_requests, _requests_served
-    if request.path in ("/health", "/heartbeat/status"):
-        return
-    with _load_lock:
-        _in_flight_requests += 1
-        _requests_served += 1
-        _peak_in_flight_requests = max(_peak_in_flight_requests, _in_flight_requests)
-    request.environ["tee_gateway.counted"] = True
-
-
-@application.teardown_request
-def _count_request_end(_exc):
-    # teardown_request runs once the response has been fully sent — after
-    # the last SSE chunk for streams — so in-flight counts whole requests,
-    # not just the time until headers were written.
-    global _in_flight_requests
-    if not request.environ.pop("tee_gateway.counted", False):
-        return
-    with _load_lock:
-        _in_flight_requests = max(0, _in_flight_requests - 1)
 
 
 @application.before_request

--- a/tee_gateway/body_preread.py
+++ b/tee_gateway/body_preread.py
@@ -1,0 +1,91 @@
+"""Read a paid POST's body before anything downstream can answer.
+
+The x402 payment middleware decides from the request *headers* whether to
+answer ``402 Payment Required``, before a byte of the body has been read. On a
+multi-megabyte body (an image attachment) that 402 leaves the enclave while
+nitriding's Go reverse proxy is still receiving the upload from the relay.
+Go's HTTP server will not drain more than 256 KiB of unread body after a
+response: it sends its FIN, waits 500 ms and closes, which is a TCP reset
+while the relay is still uploading. gvproxy (the host-side vsock forwarder)
+relays the abort, so the relay sees a connection reset and no response at all
+(httpx ``ReadError`` with an empty message), or nitriding sees the reset first
+and answers a bare 502. A request that only needed a payment challenge fails,
+and it fails exactly on big bodies, which is what "flaky 502s on image chats"
+looked like from the app.
+
+:func:`read_body_before_responding` wraps the WSGI stack *outside* the
+payment middleware and buffers the body of a POST to a paid route before
+dispatch, so every response, the 402 included, is written after the upload has
+been consumed end to end and the connection is left clean for the paid retry.
+The handlers already buffer the whole body (``get_data``), so this changes
+where the bytes are read, not how many are held.
+
+A body larger than :data:`MAX_PAID_REQUEST_BYTES` is refused with **413**
+right here, before payment. Nothing in the enclave accepts such a body (the
+OHTTP handler re-checks the same cap after reading), so buffering it would
+only cost memory; and answering 402 for it would recreate the reset above. The
+413 is written without reading the body, so an oversize upload may still see
+a reset instead of the status; that is the one case where this is acceptable.
+"""
+
+from __future__ import annotations
+
+import io
+import json
+from collections.abc import Callable, Iterable
+from typing import Any
+
+# The largest request body any paid route accepts. The OHTTP handler enforces
+# the same number on the decrypted side; keep them one constant.
+MAX_PAID_REQUEST_BYTES = 20 * 1024 * 1024
+
+WSGIApp = Callable[[dict[str, Any], Callable[..., Any]], Iterable[bytes]]
+
+
+def _too_large(start_response: Callable[..., Any]) -> Iterable[bytes]:
+    body = json.dumps({"error": "request body too large"}).encode()
+    start_response(
+        "413 Request Entity Too Large",
+        [("Content-Type", "application/json"), ("Content-Length", str(len(body)))],
+    )
+    return [body]
+
+
+def read_body_before_responding(wsgi_app: WSGIApp, paths: Iterable[str]) -> WSGIApp:
+    """WSGI wrapper: buffer the body of a POST to ``paths`` before dispatch."""
+    paid_paths = frozenset(paths)
+
+    def wrapper(
+        environ: dict[str, Any], start_response: Callable[..., Any]
+    ) -> Iterable[bytes]:
+        if (
+            environ.get("REQUEST_METHOD") != "POST"
+            or environ.get("PATH_INFO") not in paid_paths
+        ):
+            return wsgi_app(environ, start_response)
+
+        try:
+            declared = int(environ.get("CONTENT_LENGTH") or 0)
+        except ValueError:
+            declared = 0
+        chunked = "chunked" in environ.get("HTTP_TRANSFER_ENCODING", "").lower()
+
+        if declared > MAX_PAID_REQUEST_BYTES:
+            return _too_large(start_response)
+        if declared > 0:
+            body = environ["wsgi.input"].read(declared)
+        elif chunked:
+            # No declared length: read up to the cap plus one byte so an
+            # oversize chunked upload is refused instead of buffered.
+            body = environ["wsgi.input"].read(MAX_PAID_REQUEST_BYTES + 1)
+            if len(body) > MAX_PAID_REQUEST_BYTES:
+                return _too_large(start_response)
+        else:
+            return wsgi_app(environ, start_response)
+
+        environ["wsgi.input"] = io.BytesIO(body)
+        environ["CONTENT_LENGTH"] = str(len(body))
+        environ.pop("HTTP_TRANSFER_ENCODING", None)
+        return wsgi_app(environ, start_response)
+
+    return wrapper

--- a/tee_gateway/controllers/chat_controller.py
+++ b/tee_gateway/controllers/chat_controller.py
@@ -40,6 +40,7 @@ from tee_gateway.image_generation import (
     create_image_generation_streaming_response,
     validate_aspect_ratio,
 )
+from tee_gateway.errors import describe_exception, error_response
 from tee_gateway.model_registry import get_model_config
 from tee_gateway.moderation import (
     ModerationOutcome,
@@ -446,10 +447,11 @@ def _create_non_streaming_response(
 
     except Exception as e:
         logger.error(f"Chat completion error: {str(e)}", exc_info=True)
-        return {
-            "error": str(e) or "Request processing failed",
-            "exception_type": type(e).__name__,
-        }, 500
+        # Provider failures (their 5xx/429, a reset, a timeout) answer 502/504
+        # with the provider's own status and message so the relay and browser
+        # can tell "the model provider is struggling" from "the enclave has a
+        # bug" (500). See tee_gateway/errors.py for the payload.
+        return error_response(e, fallback="Request processing failed")
 
 
 def _create_streaming_response(
@@ -891,10 +893,9 @@ def _create_streaming_response(
                 # event IS the terminal marker for the error path — we do NOT
                 # emit a trailing `[DONE]`, which conventionally signals a
                 # clean completion and would mis-signal an errored stream.
-                error_payload = {
-                    "error": str(e) or "Stream processing failed",
-                    "exception_type": type(e).__name__,
-                }
+                error_payload = describe_exception(
+                    e, fallback="Stream processing failed"
+                )
                 yield f"data: {json.dumps(error_payload)}\n\n"
 
         return Response(
@@ -909,10 +910,7 @@ def _create_streaming_response(
 
     except Exception as e:
         logger.error(f"Stream setup error: {str(e)}", exc_info=True)
-        return {
-            "error": str(e) or "Stream setup failed",
-            "exception_type": type(e).__name__,
-        }, 500
+        return error_response(e, fallback="Stream setup failed")
 
 
 # ---------------------------------------------------------------------------

--- a/tee_gateway/controllers/completions_controller.py
+++ b/tee_gateway/controllers/completions_controller.py
@@ -10,6 +10,7 @@ from langchain_core.messages import HumanMessage
 
 from tee_gateway.models.create_completion_request import CreateCompletionRequest
 
+from tee_gateway.errors import error_response
 from tee_gateway.tee_manager import get_tee_keys, compute_tee_msg_hash
 from tee_gateway.llm_backend import (
     get_chat_model_cached,
@@ -108,7 +109,6 @@ def create_completion(body):
 
     except Exception as e:
         logger.error(f"Completion error: {str(e)}", exc_info=True)
-        return {
-            "error": str(e) or "Request processing failed",
-            "exception_type": type(e).__name__,
-        }, 500
+        # Provider failures answer 502/504 with the provider's status; only
+        # the gateway's own failures are 500 (see tee_gateway/errors.py).
+        return error_response(e, fallback="Request processing failed")

--- a/tee_gateway/controllers/ohttp_controller.py
+++ b/tee_gateway/controllers/ohttp_controller.py
@@ -81,6 +81,7 @@ from flask import Response, current_app, request as flask_request
 from tee_gateway import ohttp
 from tee_gateway.tee_manager import get_tee_keys
 from tee_gateway.pricing import SessionCost
+from tee_gateway.body_preread import MAX_PAID_REQUEST_BYTES
 
 logger = logging.getLogger(__name__)
 
@@ -94,7 +95,7 @@ _SSE_CONTENT_TYPE = "text/event-stream"
 # 14 MiB raw image — or several attached reference images — after base64/JSON
 # overhead while still bounding enclave memory use for malicious or
 # accidentally huge payloads.
-_MAX_ENCAPSULATED_REQUEST_BYTES = 20 * 1024 * 1024
+_MAX_ENCAPSULATED_REQUEST_BYTES = MAX_PAID_REQUEST_BYTES
 
 # Fields that can re-identify a client and have no role in inference. We drop
 # them before forwarding to the inner handler — keeping them inside the

--- a/tee_gateway/errors.py
+++ b/tee_gateway/errors.py
@@ -138,19 +138,38 @@ def describe_exception(
     return payload
 
 
+# Provider 4xx that are about *this gateway's* standing with the provider
+# (its key, its plan, its quota), not about the request. They must not reach
+# the client as-is: a 401/403 would read as the client's own credentials
+# failing, and a 402 would be taken by the relay's x402 client for a payment
+# challenge from this gateway.
+_GATEWAY_ACCOUNT_STATUSES = frozenset({401, 402, 403, 407})
+
+
 def http_status_for(exc: BaseException) -> int:
     """Outer HTTP status for a failed (non-streaming) inference request.
 
-    * a provider answered with an error, or could not be reached → ``502``
-      (this gateway got a bad answer from the server behind it);
-    * a provider did not answer in time → ``504``;
-    * anything raised by the gateway's own code → ``500``.
+    * anything raised by the gateway's own code → ``500``;
+    * a provider could not be reached → ``502``, or ``504`` for a timeout;
+    * a provider answered 5xx → ``502``; ``429`` → ``503``; ``408`` → ``504``;
+    * a provider refused the gateway's credentials or account → ``502``;
+    * any other provider 4xx is about the request itself (too long, bad
+      parameter, unknown model, oversize image) and is passed through
+      unchanged, so the relay and browser do not retry it as a gateway
+      failure — resending an invalid request cannot make it valid.
     """
     if not _is_provider_exception(exc):
         return 500
-    if _provider_status(exc) is None and _is_timeout(exc):
+    status = _provider_status(exc)
+    if status is None:
+        return 504 if _is_timeout(exc) else 502
+    if status == 429:
+        return 503
+    if status == 408:
         return 504
-    return 502
+    if status >= 500 or status in _GATEWAY_ACCOUNT_STATUSES:
+        return 502
+    return status if status >= 400 else 502
 
 
 def error_response(

--- a/tee_gateway/errors.py
+++ b/tee_gateway/errors.py
@@ -1,0 +1,160 @@
+"""Self-describing error payloads for the gateway's inference endpoints.
+
+Every failure that reaches a client used to be ``{"error": str(e),
+"exception_type": ...}`` with HTTP 500 — whether the enclave had a bug, the
+provider was overloaded, or the provider's TCP connection reset. From the
+relay's and browser's side those are different incidents: a provider 529 is
+retryable and not ours, a ``ValueError`` in our request shaping is a bug and
+retrying it is pointless. This module classifies an exception once, so the
+non-streaming error response, the stream-setup error response and the
+in-band SSE error frame all report the same thing:
+
+``error``
+    Human-readable detail — the provider's message when there is one.
+``exception_type``
+    The exception class name (content-free bucket key; unchanged).
+``source``
+    ``"provider"`` when a model provider answered with an error or could not
+    be reached; ``"gateway"`` for anything that failed inside the enclave.
+``provider_status``
+    The HTTP status the provider returned, when it returned one.
+``retryable``
+    Whether resending the same request has a real chance of succeeding
+    (provider 5xx/429/overload, connection resets, timeouts).
+
+:func:`http_status_for` maps the same classification onto the outer status:
+provider failures are ``502``/``504`` (we are the gateway that got a bad or no
+answer from upstream), gateway failures stay ``500``.
+
+Nothing here quotes the request: provider messages describe *their* refusal
+(model name, parameter names, rate limits), not the prompt.
+"""
+
+from __future__ import annotations
+
+import re
+from typing import Any, Optional
+
+import httpx
+
+# Truncation guard for provider messages that echo a whole request body.
+_MESSAGE_CHARS = 600
+_WHITESPACE_RE = re.compile(r"\s+")
+
+SOURCE_PROVIDER = "provider"
+SOURCE_GATEWAY = "gateway"
+
+# Provider statuses after which a resend of the identical request can succeed.
+_RETRYABLE_PROVIDER_STATUSES = frozenset({408, 409, 425, 429, 500, 502, 503, 504, 529})
+
+
+def _provider_status(exc: BaseException) -> Optional[int]:
+    """The HTTP status a provider SDK exception carries, or ``None``.
+
+    Duck-typed on purpose: openai/anthropic/xai expose ``status_code``,
+    google-genai ``status`` (an int on APIError) or ``code``, and a raw httpx
+    failure has ``response.status_code``. Importing every SDK's exception
+    class here would couple this module to each provider package.
+    """
+    for attr in ("status_code", "status", "code"):
+        value = getattr(exc, attr, None)
+        if isinstance(value, bool):
+            continue
+        if isinstance(value, int) and 100 <= value <= 599:
+            return value
+    response = getattr(exc, "response", None)
+    status = getattr(response, "status_code", None)
+    if isinstance(status, int) and 100 <= status <= 599:
+        return status
+    return None
+
+
+def _is_provider_exception(exc: BaseException) -> bool:
+    """Whether ``exc`` came out of a provider client rather than our code.
+
+    Matched by module: every provider SDK we route through lives under one
+    of these roots, and LangChain re-raises the SDK's own exception types.
+    httpx errors are treated as provider failures because the only outbound
+    httpx traffic from an inference request is to a provider.
+    """
+    if isinstance(exc, httpx.HTTPError):
+        return True
+    module = type(exc).__module__ or ""
+    return module.split(".", 1)[0] in {
+        "openai",
+        "anthropic",
+        "google",
+        "xai_sdk",
+        "langchain_google_genai",
+        "grpc",
+        "aiohttp",
+    }
+
+
+def _is_timeout(exc: BaseException) -> bool:
+    if isinstance(exc, (httpx.TimeoutException, TimeoutError)):
+        return True
+    return "timeout" in type(exc).__name__.lower()
+
+
+def _is_connection_failure(exc: BaseException) -> bool:
+    if isinstance(exc, (httpx.TransportError, ConnectionError)):
+        return True
+    return "connection" in type(exc).__name__.lower()
+
+
+def _message(exc: BaseException, fallback: str) -> str:
+    text = _WHITESPACE_RE.sub(" ", str(exc)).strip()
+    if not text:
+        return fallback
+    if len(text) > _MESSAGE_CHARS:
+        text = text[:_MESSAGE_CHARS] + "…"
+    return text
+
+
+def describe_exception(
+    exc: BaseException, *, fallback: str = "Request processing failed"
+) -> dict[str, Any]:
+    """Build the error payload for ``exc`` (see module docstring)."""
+    provider_status = _provider_status(exc) if _is_provider_exception(exc) else None
+    from_provider = _is_provider_exception(exc)
+
+    payload: dict[str, Any] = {
+        "error": _message(exc, fallback),
+        "exception_type": type(exc).__name__,
+        "source": SOURCE_PROVIDER if from_provider else SOURCE_GATEWAY,
+    }
+    if provider_status is not None:
+        payload["provider_status"] = provider_status
+
+    if from_provider:
+        payload["retryable"] = (
+            provider_status in _RETRYABLE_PROVIDER_STATUSES
+            if provider_status is not None
+            else _is_timeout(exc) or _is_connection_failure(exc)
+        )
+    else:
+        payload["retryable"] = False
+    return payload
+
+
+def http_status_for(exc: BaseException) -> int:
+    """Outer HTTP status for a failed (non-streaming) inference request.
+
+    * a provider answered with an error, or could not be reached → ``502``
+      (this gateway got a bad answer from the server behind it);
+    * a provider did not answer in time → ``504``;
+    * anything raised by the gateway's own code → ``500``.
+    """
+    if not _is_provider_exception(exc):
+        return 500
+    if _provider_status(exc) is None and _is_timeout(exc):
+        return 504
+    return 502
+
+
+def error_response(
+    exc: BaseException, *, fallback: str = "Request processing failed"
+) -> tuple[dict[str, Any], int]:
+    """``(payload, status)`` for a Flask handler's error return."""
+    return describe_exception(exc, fallback=fallback), http_status_for(exc)

--- a/tee_gateway/gunicorn_conf.py
+++ b/tee_gateway/gunicorn_conf.py
@@ -1,0 +1,89 @@
+"""gunicorn settings for serving the gateway inside the enclave.
+
+Until this file existed the enclave ran ``application.run()`` — Werkzeug's
+development server: one unbounded thread per connection, a 128-entry listen
+backlog, ``Connection: close`` on every response, no request logging worth the
+name, and a banner in its own docs saying not to use it in production. Load
+showed up only as thread growth and, past the backlog, as bare 502s from
+nitriding's reverse proxy.
+
+Everything here follows from one constraint: **the gateway is one process**.
+The TEE signing key is generated at import and its hash registered with
+nitriding once; provider API keys are injected once over ``POST /v1/keys``
+into that process; the x402 session store is an in-memory dict. None of that
+survives a fork or a restart, so:
+
+* ``workers = 1`` with the ``gthread`` worker — concurrency comes from
+  threads in the one process, as before, but bounded and with a real backlog.
+* No ``preload_app``: the app (and the key material) is created in the worker,
+  exactly as when it ran directly.
+* A worker exit is fatal (``child_exit`` below). gunicorn would otherwise
+  fork a fresh worker that generates a *new* signing key — while the registry
+  and nitriding still hold the old one — and has no provider keys, and would
+  answer every request wrongly until someone noticed. Dying loudly, as the
+  bare process did, is the safer behaviour; the host's supervision decides
+  what happens next.
+
+Connections to this server come only from nitriding's Go reverse proxy on
+loopback. Go's transport pools idle connections indefinitely (nitriding sets
+no IdleConnTimeout) and does not retry a POST it has already written, so the
+server must never be the side that closes an idle connection first; hence a
+keep-alive far longer than any realistic idle gap.
+"""
+
+from __future__ import annotations
+
+import os
+
+bind = (
+    f"{os.getenv('API_SERVER_HOST', '0.0.0.0')}:{os.getenv('API_SERVER_PORT', '8000')}"
+)
+
+# One process; see the module docstring for why this must stay 1.
+workers = 1
+worker_class = "gthread"
+# Concurrent requests the process serves. Each in-flight chat stream holds a
+# thread for its whole duration (blocking provider I/O), so this is the cap on
+# simultaneous conversations per enclave. Requests beyond it wait in the
+# backlog instead of spawning threads without limit.
+threads = int(os.getenv("GUNICORN_THREADS", "64"))
+worker_connections = 1000
+backlog = 2048
+
+# Never let this server close an idle keep-alive connection before the Go
+# proxy does (see module docstring); an hour is "never" for loopback traffic.
+keepalive = 3600
+
+# The gthread worker heartbeats from its main loop, so a long-running request
+# cannot trip this — but a GIL-starved main loop under heavy load could, and
+# with child_exit fatal that would take the enclave down. Werkzeug had no such
+# watchdog; keep none.
+timeout = 0
+# On SIGTERM, let in-flight streams finish (chat-api waits up to 210 s).
+graceful_timeout = 240
+
+# No recycling: a worker restart is a key rotation (see module docstring).
+max_requests = 0
+
+# stdout/stderr are the enclave console, like the app's own logger.
+accesslog = "-"
+errorlog = "-"
+loglevel = "info"
+access_log_format = '%(h)s "%(r)s" %(s)s %(b)s %(M)sms'
+
+
+def child_exit(server, worker):  # noqa: ANN001 - gunicorn hook signature
+    """Stop the whole server when the single worker exits.
+
+    Runs in the arbiter. A replacement worker would carry a new TEE signing
+    key and no provider keys (both are process state), so serving on is worse
+    than stopping: attestation and signature verification would fail for
+    every client until the enclave is restarted anyway.
+    """
+    server.log.critical(
+        "gateway worker %s exited; TEE key material, injected provider keys and "
+        "x402 sessions lived in that process — halting instead of serving with "
+        "regenerated keys",
+        worker.pid,
+    )
+    server.halt(reason="gateway worker exited", exit_status=1)

--- a/tee_gateway/gunicorn_conf.py
+++ b/tee_gateway/gunicorn_conf.py
@@ -79,7 +79,14 @@ def child_exit(server, worker):  # noqa: ANN001 - gunicorn hook signature
     key and no provider keys (both are process state), so serving on is worse
     than stopping: attestation and signature verification would fail for
     every client until the enclave is restarted anyway.
+
+    During a shutdown the arbiter has already closed its listeners before it
+    signals the worker, so a worker exit then is the expected one: let the
+    normal stop finish with status 0 instead of a false CRITICAL and a
+    re-entered stop.
     """
+    if not server.LISTENERS:
+        return
     server.log.critical(
         "gateway worker %s exited; TEE key material, injected provider keys and "
         "x402 sessions lived in that process — halting instead of serving with "

--- a/tee_gateway/image_generation.py
+++ b/tee_gateway/image_generation.py
@@ -35,6 +35,7 @@ import httpx
 from flask import Response
 
 from tee_gateway import llm_backend
+from tee_gateway.errors import describe_exception
 from tee_gateway.moderation import ModerationOutcome
 from tee_gateway.models.create_chat_completion_request import (
     CreateChatCompletionRequest,
@@ -647,13 +648,10 @@ def create_image_generation_streaming_response(
             yield "data: [DONE]\n\n"
         except Exception as e:
             logger.error(f"Image generation streaming error: {str(e)}", exc_info=True)
-            # Surface the real exception detail to the client (matching the chat
-            # streaming path) so browser-side logs show the actual cause instead
-            # of an opaque generic string.
-            error_payload = {
-                "error": str(e) or "Stream processing failed",
-                "exception_type": type(e).__name__,
-            }
+            # Same in-band error frame as the chat streaming path: the status
+            # is already 200, so this classified payload is the only channel
+            # left to say whether the provider or the enclave failed.
+            error_payload = describe_exception(e, fallback="Stream processing failed")
             yield f"data: {json.dumps(error_payload)}\n\n"
 
     return Response(

--- a/tee_gateway/test/test_body_preread.py
+++ b/tee_gateway/test/test_body_preread.py
@@ -1,0 +1,84 @@
+"""The body of a paid POST is consumed before the wrapped app can respond."""
+
+import io
+import unittest
+
+from tee_gateway.__main__ import MAX_PREREAD_REQUEST_BYTES, _read_body_before_responding
+
+
+class _CountingStream(io.BytesIO):
+    """Records how much of the body had been read when the inner app ran."""
+
+    def __init__(self, data: bytes):
+        super().__init__(data)
+        self.read_calls = 0
+
+    def read(self, n=-1):
+        self.read_calls += 1
+        return super().read(n)
+
+
+def _environ(body: bytes, path="/v1/ohttp", method="POST", length=None):
+    stream = _CountingStream(body)
+    return {
+        "REQUEST_METHOD": method,
+        "PATH_INFO": path,
+        "CONTENT_LENGTH": str(len(body) if length is None else length),
+        "wsgi.input": stream,
+    }, stream
+
+
+class TestReadBodyBeforeResponding(unittest.TestCase):
+    def _run(self, environ):
+        seen = {}
+
+        def inner(env, start_response):
+            # An x402-style early answer: respond off the headers, never touch
+            # the body. Record what the body stream looks like at this point.
+            seen["input"] = env["wsgi.input"]
+            seen["remaining_in_original"] = (
+                len(self.stream.getvalue()) - self.stream.tell()
+            )
+            start_response("402 Payment Required", [])
+            return [b"{}"]
+
+        app = _read_body_before_responding(
+            inner, paths=["/v1/ohttp", "/v1/chat/completions"]
+        )
+        list(app(environ, lambda *a: None))
+        return seen
+
+    def test_paid_post_body_is_fully_read_before_dispatch(self):
+        body = b"x" * (3 * 1024 * 1024)
+        environ, self.stream = _environ(body)
+        seen = self._run(environ)
+        self.assertEqual(0, seen["remaining_in_original"])
+        self.assertIsInstance(seen["input"], io.BytesIO)
+        self.assertEqual(body, seen["input"].read())
+        self.assertEqual(str(len(body)), environ["CONTENT_LENGTH"])
+
+    def test_other_paths_and_methods_are_untouched(self):
+        for path, method in (
+            ("/health", "GET"),
+            ("/v1/keys", "POST"),
+            ("/v1/ohttp", "GET"),
+        ):
+            environ, self.stream = _environ(b"body", path=path, method=method)
+            seen = self._run(environ)
+            self.assertIs(seen["input"], self.stream, (path, method))
+            self.assertEqual(0, self.stream.read_calls)
+
+    def test_oversize_and_bodyless_requests_are_not_buffered(self):
+        environ, self.stream = _environ(b"", length=MAX_PREREAD_REQUEST_BYTES + 1)
+        seen = self._run(environ)
+        self.assertIs(seen["input"], self.stream)
+        environ, self.stream = _environ(b"", length=0)
+        seen = self._run(environ)
+        self.assertIs(seen["input"], self.stream)
+        environ, self.stream = _environ(b"abc", length="not-a-number")
+        seen = self._run(environ)
+        self.assertIs(seen["input"], self.stream)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tee_gateway/test/test_body_preread.py
+++ b/tee_gateway/test/test_body_preread.py
@@ -1,9 +1,12 @@
-"""The body of a paid POST is consumed before the wrapped app can respond."""
+"""The body of a paid POST is consumed, or refused, before the wrapped app can respond."""
 
 import io
+import json
 import unittest
 
-from tee_gateway.__main__ import MAX_PREREAD_REQUEST_BYTES, _read_body_before_responding
+from tee_gateway.body_preread import MAX_PAID_REQUEST_BYTES, read_body_before_responding
+
+PAID = ["/v1/ohttp", "/v1/chat/completions", "/v1/completions", "/v1/web_search"]
 
 
 class _CountingStream(io.BytesIO):
@@ -18,19 +21,22 @@ class _CountingStream(io.BytesIO):
         return super().read(n)
 
 
-def _environ(body: bytes, path="/v1/ohttp", method="POST", length=None):
+def _environ(body: bytes, path="/v1/ohttp", method="POST", length=None, **extra):
     stream = _CountingStream(body)
-    return {
+    environ = {
         "REQUEST_METHOD": method,
         "PATH_INFO": path,
         "CONTENT_LENGTH": str(len(body) if length is None else length),
         "wsgi.input": stream,
-    }, stream
+        **extra,
+    }
+    return environ, stream
 
 
 class TestReadBodyBeforeResponding(unittest.TestCase):
     def _run(self, environ):
         seen = {}
+        status = []
 
         def inner(env, start_response):
             # An x402-style early answer: respond off the headers, never touch
@@ -42,10 +48,10 @@ class TestReadBodyBeforeResponding(unittest.TestCase):
             start_response("402 Payment Required", [])
             return [b"{}"]
 
-        app = _read_body_before_responding(
-            inner, paths=["/v1/ohttp", "/v1/chat/completions"]
-        )
-        list(app(environ, lambda *a: None))
+        app = read_body_before_responding(inner, paths=PAID)
+        body = b"".join(app(environ, lambda st, headers: status.append((st, headers))))
+        seen["status"], seen["headers"] = status[0]
+        seen["body"] = body
         return seen
 
     def test_paid_post_body_is_fully_read_before_dispatch(self):
@@ -56,6 +62,13 @@ class TestReadBodyBeforeResponding(unittest.TestCase):
         self.assertIsInstance(seen["input"], io.BytesIO)
         self.assertEqual(body, seen["input"].read())
         self.assertEqual(str(len(body)), environ["CONTENT_LENGTH"])
+        self.assertEqual("402 Payment Required", seen["status"])
+
+    def test_every_paid_route_is_covered(self):
+        for path in PAID:
+            environ, self.stream = _environ(b"body", path=path)
+            seen = self._run(environ)
+            self.assertEqual(0, seen["remaining_in_original"], path)
 
     def test_other_paths_and_methods_are_untouched(self):
         for path, method in (
@@ -68,16 +81,50 @@ class TestReadBodyBeforeResponding(unittest.TestCase):
             self.assertIs(seen["input"], self.stream, (path, method))
             self.assertEqual(0, self.stream.read_calls)
 
-    def test_oversize_and_bodyless_requests_are_not_buffered(self):
-        environ, self.stream = _environ(b"", length=MAX_PREREAD_REQUEST_BYTES + 1)
+    def test_oversize_body_is_refused_before_payment_without_being_read(self):
+        for path in PAID:
+            environ, self.stream = _environ(
+                b"", length=MAX_PAID_REQUEST_BYTES + 1, path=path
+            )
+            status = []
+            app = read_body_before_responding(self._never_called, paths=PAID)
+            body = b"".join(app(environ, lambda st, headers: status.append(st)))
+            self.assertEqual(["413 Request Entity Too Large"], status, path)
+            self.assertEqual({"error": "request body too large"}, json.loads(body))
+            self.assertEqual(0, self.stream.read_calls)
+
+    def test_chunked_body_is_buffered_and_given_a_length(self):
+        body = b"y" * 1000
+        environ, self.stream = _environ(
+            body, length=0, HTTP_TRANSFER_ENCODING="chunked"
+        )
         seen = self._run(environ)
-        self.assertIs(seen["input"], self.stream)
+        self.assertEqual(0, seen["remaining_in_original"])
+        self.assertEqual("1000", environ["CONTENT_LENGTH"])
+        self.assertNotIn("HTTP_TRANSFER_ENCODING", environ)
+
+    def test_oversize_chunked_body_is_refused(self):
+        environ, self.stream = _environ(
+            b"z" * (MAX_PAID_REQUEST_BYTES + 10),
+            length=0,
+            HTTP_TRANSFER_ENCODING="chunked",
+        )
+        status = []
+        app = read_body_before_responding(self._never_called, paths=PAID)
+        list(app(environ, lambda st, headers: status.append(st)))
+        self.assertEqual(["413 Request Entity Too Large"], status)
+
+    def test_bodyless_and_malformed_length_requests_pass_through(self):
         environ, self.stream = _environ(b"", length=0)
         seen = self._run(environ)
         self.assertIs(seen["input"], self.stream)
         environ, self.stream = _environ(b"abc", length="not-a-number")
         seen = self._run(environ)
         self.assertIs(seen["input"], self.stream)
+
+    @staticmethod
+    def _never_called(environ, start_response):
+        raise AssertionError("inner app must not run for a refused body")
 
 
 if __name__ == "__main__":

--- a/tee_gateway/test/test_errors.py
+++ b/tee_gateway/test/test_errors.py
@@ -1,0 +1,91 @@
+"""Provider failures must be told apart from gateway bugs, with the status."""
+
+import unittest
+
+import anthropic
+import httpx
+import openai
+
+from tee_gateway.errors import describe_exception, error_response, http_status_for
+
+
+def _response(status: int) -> httpx.Response:
+    return httpx.Response(status, request=httpx.Request("POST", "https://provider"))
+
+
+class TestDescribeException(unittest.TestCase):
+    def test_provider_overload_is_a_retryable_502(self):
+        exc = anthropic.APIStatusError(
+            "Error code: 529 - {'type': 'error', 'error': {'type': 'overloaded_error', 'message': 'Overloaded'}}",
+            response=_response(529),
+            body={"type": "error", "error": {"type": "overloaded_error"}},
+        )
+        payload, status = error_response(exc)
+        self.assertEqual(502, status)
+        self.assertEqual("provider", payload["source"])
+        self.assertEqual(529, payload["provider_status"])
+        self.assertTrue(payload["retryable"])
+        self.assertEqual("APIStatusError", payload["exception_type"])
+        self.assertIn("overloaded_error", payload["error"])
+
+    def test_provider_400_is_a_502_but_not_retryable(self):
+        exc = openai.BadRequestError(
+            "Unsupported parameter: 'temperature'",
+            response=_response(400),
+            body={"error": {"message": "Unsupported parameter: 'temperature'"}},
+        )
+        payload, status = error_response(exc)
+        self.assertEqual(502, status)
+        self.assertEqual(400, payload["provider_status"])
+        self.assertFalse(payload["retryable"])
+        self.assertEqual("Unsupported parameter: 'temperature'", payload["error"])
+
+    def test_provider_rate_limit_is_retryable(self):
+        exc = openai.RateLimitError(
+            "Rate limit reached", response=_response(429), body=None
+        )
+        payload = describe_exception(exc)
+        self.assertEqual(429, payload["provider_status"])
+        self.assertTrue(payload["retryable"])
+
+    def test_provider_connection_reset_is_a_retryable_502(self):
+        exc = httpx.ReadError("[Errno 104] Connection reset by peer")
+        payload, status = error_response(exc)
+        self.assertEqual(502, status)
+        self.assertEqual("provider", payload["source"])
+        self.assertNotIn("provider_status", payload)
+        self.assertTrue(payload["retryable"])
+
+    def test_provider_timeout_is_a_504(self):
+        self.assertEqual(504, http_status_for(httpx.ReadTimeout("timed out")))
+        sdk_timeout = openai.APITimeoutError(
+            request=httpx.Request("POST", "https://provider")
+        )
+        self.assertEqual(504, http_status_for(sdk_timeout))
+        self.assertTrue(describe_exception(sdk_timeout)["retryable"])
+
+    def test_gateway_bug_stays_a_500(self):
+        payload, status = error_response(ValueError("Unsupported provider: nope"))
+        self.assertEqual(500, status)
+        self.assertEqual(
+            {
+                "error": "Unsupported provider: nope",
+                "exception_type": "ValueError",
+                "source": "gateway",
+                "retryable": False,
+            },
+            payload,
+        )
+
+    def test_empty_message_uses_the_fallback(self):
+        payload = describe_exception(RuntimeError(), fallback="Stream setup failed")
+        self.assertEqual("Stream setup failed", payload["error"])
+
+    def test_long_messages_are_truncated(self):
+        payload = describe_exception(RuntimeError("x" * 5000))
+        self.assertLess(len(payload["error"]), 700)
+        self.assertTrue(payload["error"].endswith("…"))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tee_gateway/test/test_errors.py
+++ b/tee_gateway/test/test_errors.py
@@ -28,17 +28,46 @@ class TestDescribeException(unittest.TestCase):
         self.assertEqual("APIStatusError", payload["exception_type"])
         self.assertIn("overloaded_error", payload["error"])
 
-    def test_provider_400_is_a_502_but_not_retryable(self):
+    def test_provider_400_passes_through_and_is_not_retryable(self):
         exc = openai.BadRequestError(
             "Unsupported parameter: 'temperature'",
             response=_response(400),
             body={"error": {"message": "Unsupported parameter: 'temperature'"}},
         )
         payload, status = error_response(exc)
-        self.assertEqual(502, status)
+        self.assertEqual(400, status)
+        self.assertEqual("provider", payload["source"])
         self.assertEqual(400, payload["provider_status"])
         self.assertFalse(payload["retryable"])
         self.assertEqual("Unsupported parameter: 'temperature'", payload["error"])
+
+    def test_request_class_provider_4xx_keep_their_status(self):
+        for provider_status in (404, 413, 415, 422):
+            exc = openai.APIStatusError(
+                "nope", response=_response(provider_status), body=None
+            )
+            self.assertEqual(provider_status, http_status_for(exc), provider_status)
+
+    def test_provider_account_errors_become_502_not_the_clients_problem(self):
+        # 401/403: the gateway's key, not the client's credentials. 402: must
+        # never reach the relay, whose x402 client would read it as a payment
+        # challenge from this gateway.
+        for provider_status in (401, 402, 403, 407):
+            exc = openai.APIStatusError(
+                "denied", response=_response(provider_status), body=None
+            )
+            payload, status = error_response(exc)
+            self.assertEqual(502, status, provider_status)
+            self.assertEqual(provider_status, payload["provider_status"])
+            self.assertFalse(payload["retryable"])
+
+    def test_provider_rate_limit_is_a_503_and_408_a_504(self):
+        exc = openai.RateLimitError(
+            "Rate limit reached", response=_response(429), body=None
+        )
+        self.assertEqual(503, http_status_for(exc))
+        exc = openai.APIStatusError("slow", response=_response(408), body=None)
+        self.assertEqual(504, http_status_for(exc))
 
     def test_provider_rate_limit_is_retryable(self):
         exc = openai.RateLimitError(

--- a/tee_gateway/test/test_gunicorn_conf.py
+++ b/tee_gateway/test/test_gunicorn_conf.py
@@ -1,0 +1,39 @@
+"""The single worker's death halts gunicorn; a normal shutdown does not trip it."""
+
+import logging
+import unittest
+from unittest import mock
+
+from tee_gateway import gunicorn_conf
+
+
+class _Server:
+    def __init__(self, listeners):
+        self.LISTENERS = listeners
+        self.log = logging.getLogger("test.gunicorn")
+        self.halt = mock.Mock()
+
+
+class TestChildExit(unittest.TestCase):
+    def test_unsolicited_worker_exit_halts_with_status_1(self):
+        server = _Server(listeners=["a socket"])
+        gunicorn_conf.child_exit(server, mock.Mock(pid=4242))
+        server.halt.assert_called_once_with(
+            reason="gateway worker exited", exit_status=1
+        )
+
+    def test_worker_exit_during_shutdown_is_left_to_the_arbiter(self):
+        # Arbiter.stop() empties LISTENERS before signalling the worker.
+        server = _Server(listeners=[])
+        gunicorn_conf.child_exit(server, mock.Mock(pid=4242))
+        server.halt.assert_not_called()
+
+    def test_one_gthread_worker(self):
+        self.assertEqual(1, gunicorn_conf.workers)
+        self.assertEqual("gthread", gunicorn_conf.worker_class)
+        self.assertEqual(0, gunicorn_conf.max_requests)
+        self.assertFalse(getattr(gunicorn_conf, "preload_app", False))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tee_gateway/wsgi.py
+++ b/tee_gateway/wsgi.py
@@ -1,0 +1,14 @@
+"""WSGI entry point for a production server.
+
+``tee_gateway/__main__.py`` builds the Flask app at import time (``application``)
+and, when run as a script, serves it on Werkzeug's development server. Inside
+the enclave the app is served by gunicorn instead (see ``gunicorn_conf.py`` and
+``scripts/start.sh``); gunicorn imports the app from here so it never has to
+import a module named ``__main__``:
+
+    gunicorn -c python:tee_gateway.gunicorn_conf tee_gateway.wsgi:application
+"""
+
+from tee_gateway.__main__ import application
+
+__all__ = ["application"]


### PR DESCRIPTION
## Root cause of the flaky 502s (fixed here)

chat-api's logs show OHTTP requests of 3–11 MB (image attachments) failing with `httpx.ReadError` (empty message = `ECONNRESET`) while waiting for response headers from the TEE:

```
"message": "TEE OHTTP stream failed", "error_type": "ReadError", "error": "",
"request_bytes": 10865755, "tee_base_url": "https://3.147.79.53"
"request_bytes": 3312266,  "tee_base_url": "https://13.59.207.188"
```

The x402 middleware answers `402 Payment Required` from the request **headers**, before a byte of the body is read. On a multi-megabyte body nitriding's Go reverse proxy is still streaming the upload in when that 402 is written. Go's `net/http` server will not drain more than 256 KiB of unread body after a response; it sends FIN, waits 500 ms, then closes, which is a reset while the relay is still uploading. gvproxy relays that as an abort, so chat-api sees a reset and no 402 at all. When the reset reaches nitriding first (Werkzeug closing with unread data), nitriding emits the bare, body-less 502 instead. Small bodies never hit this, and a challenge is only needed when the x402 session has idled out (100 s) or been exhausted, which is why it looked random.

**Reproduced locally**: Werkzeug 3.1.8 answering an early 402, a Go `httputil.ReverseProxy` configured like nitriding, and a TCP relay standing in for gvproxy. A 10 MB upload failed 13/20 times; with the body read before responding, 20/20 succeeded. Plain loopback never fails (the whole body lands before the 402), matching why it was invisible in dev.

A live reproduction against a real TEE (fresh SDK client per request so every request is challenged, body-size sweep, unbillable inner request) is going into the OpenGradient-SDK repo as `integrationtest/llm/test_large_body_402.py`.

**Fix**: `tee_gateway/body_preread.py` wraps the WSGI stack *outside* the payment middleware and buffers the body of a POST to any paid route before dispatch, so every response, the 402 included, is written after the upload has been consumed end to end. A body over the 20 MiB cap (shared with the OHTTP handler) is refused with **413 before payment** rather than passed through unread; chunked bodies are buffered up to the same cap. The OHTTP controller already buffered the whole body, so only where the bytes are read changes. The module has no import-time side effects and is unit-tested directly.

The same fix belongs in the og-x402 fork's Flask middleware (it already has `_read_body_bytes`, just called after the 402 decisions); this wrapper fixes production without a dependency bump and comes out once the fork is released with the read hoisted.

## Production server: gunicorn instead of Werkzeug's dev server

The enclave ran `application.run()`: Werkzeug's development server, one unbounded thread per connection, a 128-entry listen backlog, `Connection: close` on every response. `scripts/start.sh` now `exec`s `gunicorn -c python:tee_gateway.gunicorn_conf tee_gateway.wsgi:application`, so gunicorn's signals and exit status are the container's. The settings follow from the gateway being **one process** (TEE signing key + nitriding registration, injected provider keys and the x402 session store are all worker state, so multiple workers are not an option; threads in the one worker share memory exactly as Werkzeug's did):

- one `gthread` worker, `GUNICORN_THREADS` (default 64) concurrent requests, 2048 backlog, no preload;
- **an unsolicited worker exit halts gunicorn with status 1** (`child_exit`): a respawned worker would have a new signing key and no provider keys and keep answering wrongly; dying, as the bare process did, is safer. A normal SIGTERM stop is left alone and exits 0;
- `keepalive = 3600` so this server never closes an idle loopback connection before nitriding's Go proxy does (Go pools idle connections with no timeout and does not retry a written POST);
- heartbeat `timeout = 0` (a false positive would now take the enclave down);
- access log with per-request duration and error log to the console.

Verified locally: `/health`, `/v1/ohttp/config` and a chat error response served; a second request reused the connection; SIGKILL on the worker halted the master with a CRITICAL line and exit status 1; SIGTERM to the master stopped it with exit status 0 and no CRITICAL. `make test-local` keeps the dev server for local work, `make serve` runs the production command. gunicorn was already a locked dependency, so `uv.lock` is unchanged.

To verify on first enclave boot: gunicorn writes one small heartbeat temp file per worker at startup and needs a writable temp directory inside the EIF. If that fails it exits immediately with a clear error; the fix is `worker_tmp_dir` in the config.

## Also in this PR

- **`tee_gateway/errors.py`** classifies an exception once: `source` (`provider` for any provider-SDK or httpx failure, `gateway` otherwise), `provider_status` when the provider returned one, and `retryable`. The outer status follows: provider unreachable or 5xx **502**, timeout or 408 **504**, 429 **503**, gateway failures **500**. A provider 4xx about the request itself (context too long, bad parameter, unknown model, oversize image) **passes through unchanged**, because chat-api and chat-app retry an outer 502/503 once and resending an invalid request cannot help. Provider 401/402/403/407 are about the gateway's own key or account and become 502 (a 401 would read as the client's credentials; a 402 would be taken by the relay's x402 client for a payment challenge). The chat controller (non-stream, stream setup, in-band SSE error frame), the completions controller and the image-generation streaming frame all use it. `error` and `exception_type` are unchanged, so existing clients keep parsing.
- CLAUDE.md: "Error responses", "Request bodies are read before any response", "Production server".

An earlier commit added in-flight/peak/served counters to `/health`; they are dropped again. They were written while overload was still a hypothesis, the root cause turned out to be the reset above, and the gunicorn access log answers the same question without a lock and mutable globals in the request path.

Companion PRs: [OpenGradient/chat-api#304](https://github.com/OpenGradient/chat-api/pull/304) (relay names the failing hop and logs model/provider, uvicorn keep-alive) and [OpenGradient/chat-app#1108](https://github.com/OpenGradient/chat-app/pull/1108) (app surfaces the hop and retries an outer 502/503 once).

No dependency changes; `uv.lock` untouched. The PCR changes as with any code change.

## Test plan

- `uv run --group test pytest tee_gateway/test/ tests/test_pricing.py tests/test_opengradient_field.py --import-mode=importlib`: 447 passed (new `test_errors.py`, `test_body_preread.py`, `test_gunicorn_conf.py`).
- `make lint` clean (ruff format, ruff check, mypy).
- `make serve` locally, SIGTERM and worker-SIGKILL behaviour (see above).
- The SDK repo's live large-body test before and after deploying: on the current deployment bodies over 256 KiB fail before any response; with this PR every size gets a gateway HTTP status.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0148ZVpCntQ1gbReZVFibrCA